### PR TITLE
ISPN-10053 Mount secret volume for authentication

### DIFF
--- a/deploy/cr/cr_authentication.yaml
+++ b/deploy/cr/cr_authentication.yaml
@@ -1,0 +1,11 @@
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: example-infinispan
+config:
+  sourceType: ConfigMap
+  sourceRef:  infinispan-app-configuration
+  name: cloud-ephemeral.xml
+  secret: cluster-secrets
+spec:
+  size: 3

--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -43,6 +43,9 @@ type InfinispanConfig struct {
 
 	// If the source is external, the reference to the resource
 	SourceRef string `json:"sourceRef,omitempty"`
+
+	// Name of the secrets volume if any
+	Secret string `json:"secret"`
 }
 
 // +genclient

--- a/test/e2e/util/okd_client.go
+++ b/test/e2e/util/okd_client.go
@@ -214,6 +214,15 @@ func (c ExternalOKD) CreateOrUpdateConfigMap(name string, filePath string, names
 	}
 }
 
+// DeleteConfigMap deletes a ConfigMap resource in the given namespace
+func (c ExternalOKD) DeleteConfigMap(name string, namespace string) {
+	configSvc := c.coreClient.ConfigMaps(namespace)
+	e := configSvc.Delete(name, &deleteOpts)
+	if e != nil {
+		panic(e)
+	}
+}
+
 // Creates or updates a Role in the given namespace
 func (c ExternalOKD) CreateOrUpdateRole(role *authv1.Role, namespace string) {
 	existing, _ := c.authClient.Roles(namespace).Get(role.ObjectMeta.Name, metaV1.GetOptions{})
@@ -516,5 +525,22 @@ func resolveRoutePort(portString string) *routev1.RoutePort {
 	}
 	return &routev1.RoutePort{
 		TargetPort: routePort,
+	}
+}
+
+// CreateSecret creates a Secret resource in the given namespace
+func (c ExternalOKD) CreateSecret(secret *v1.Secret, namespace string) {
+	_, e := c.coreClient.Secrets(namespace).Create(secret)
+	if e != nil {
+		panic(e)
+	}
+}
+
+// DeleteSecret deletes a Secret resource in the given namespace
+func (c ExternalOKD) DeleteSecret(name string, namespace string) {
+	secretSvc := c.coreClient.Secrets(namespace)
+	e := secretSvc.Delete(name, &deleteOpts)
+	if e != nil {
+		panic(e)
 	}
 }


### PR DESCRIPTION
User can mount secret into pod declaring its name in the
config.cluster-secrets customer resource yaml file.
Volume will be mounted as folder under the 'standalone/configuration'.
Secret must be created in advance and then user can setup a custom
configuration .xml that uses the secret's content:
user, password, keystore...

https://issues.jboss.org/browse/ISPN-10053