### PR TITLE
Switch spec.size to spec.replicas #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ metadata:
   name: example-infinispan-minimal
 spec:
   # Sets the number of nodes in the cluster.
-  size: 3
+  replicas: 3
 ```
 
 #### Configure authentication credentials
@@ -154,7 +154,7 @@ kind: Infinispan
 metadata:
   name: example-infinispan
 spec:
-  size: 2
+  replicas: 2
   image: jboss/infinispan-server:latest
   connector:
     authentication:
@@ -181,7 +181,7 @@ config:
   name: clustered.xml
 spec:
   # Sets the number of nodes in the cluster.
-  size: 3
+  replicas: 3
 ```
 
 #### Custom Configuration
@@ -201,7 +201,7 @@ config:
   name: my-config.xml
 spec:
   # Sets the number of nodes in the cluster.
-  size: 3
+  replicas: 3
 ```
 
 ### Testing the Infinispan Operator

--- a/deploy/cr/cr_minimal.yaml
+++ b/deploy/cr/cr_minimal.yaml
@@ -3,5 +3,5 @@ kind: Infinispan
 metadata:
   name: example-infinispan
 spec:
-  size: 2
+  replicas: 2
   image: jboss/infinispan-server:latest

--- a/deploy/cr/cr_minimal_with_auth.yaml
+++ b/deploy/cr/cr_minimal_with_auth.yaml
@@ -3,7 +3,7 @@ kind: Infinispan
 metadata:
   name: example-infinispan
 spec:
-  size: 2
+  replicas: 2
   image: jboss/infinispan-server:latest
   connector:
     authentication:

--- a/deploy/cr/cr_with_configmap.yaml
+++ b/deploy/cr/cr_with_configmap.yaml
@@ -7,4 +7,4 @@ config:
   sourceRef:  infinispan-app-configuration
   name: cloud-ephemeral.xml
 spec:
-  size: 2
+  replicas: 2

--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -27,7 +27,7 @@ type InfinispanManagementInfo struct {
 
 // InfinispanSpec defines the desired state of Infinispan
 type InfinispanSpec struct {
-	Size       int32                    `json:"size"`
+	Replicas   int32                    `json:"replicas"`
 	Image      string                   `json:"image"`
 	Connector  InfinispanConnectorInfo  `json:"connector"`
 	Management InfinispanManagementInfo `json:"management"`

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -145,9 +145,9 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Ensure the deployment size is the same as the spec
-	size := infinispan.Spec.Size
-	if *found.Spec.Replicas != size {
-		found.Spec.Replicas = &size
+	replicas := infinispan.Spec.Replicas
+	if *found.Spec.Replicas != replicas {
+		found.Spec.Replicas = &replicas
 		err = r.client.Update(context.TODO(), found)
 		if err != nil {
 			reqLogger.Error(err, "failed to update Deployment", "Deployment.Namespace", found.Namespace, "Deployment.Name", found.Name)
@@ -245,7 +245,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 		{Name: "IMAGE", Value: m.Spec.Image},
 		{Name: "JGROUPS_PING_PROTOCOL", Value: getEnvWithDefault("JGROUPS_PING_PROTOCOL", defaultJGroupsPingProtocol)},
 		{Name: "OPENSHIFT_DNS_PING_SERVICE_NAME", Value: m.ObjectMeta.Name + "-ping"},
-		{Name: getImageVarNameFromOperatorEnv("NUMBER_OF_INSTANCE"), Value: string(m.Spec.Size)}}
+		{Name: getImageVarNameFromOperatorEnv("NUMBER_OF_INSTANCE"), Value: string(m.Spec.Replicas)}}
 	dep := &appsv1beta1.StatefulSet{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1beta1",

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -72,8 +72,8 @@ func TestClusterFormation(t *testing.T) {
 			Name: "cache-infinispan",
 		},
 		Spec: ispnv1.InfinispanSpec{
-			Size:  2,
-			Image: getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
+			Replicas: 2,
+			Image:    getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
 		},
 	}
 	// Register it
@@ -147,8 +147,8 @@ func TestExternalService(t *testing.T) {
 			Name: "cache-infinispan-0",
 		},
 		Spec: ispnv1.InfinispanSpec{
-			Size:  1,
-			Image: getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
+			Replicas: 1,
+			Image:    getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
 		},
 	}
 
@@ -204,7 +204,7 @@ func TestExternalServiceWithAuth(t *testing.T) {
 			Name: "cache-infinispan-0",
 		},
 		Spec: ispnv1.InfinispanSpec{
-			Size:      1,
+			Replicas:  1,
 			Connector: ispnv1.InfinispanConnectorInfo{Authentication: ispnv1.InfinispanAuthInfo{Secret: ispnv1.InfinispanSecret{Type: "Credentials", SecretName: "conn-secret-test"}}},
 			Image:     getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
 		},
@@ -289,8 +289,8 @@ func TestCreateClusterWithConfigMap(t *testing.T) {
 			Name:       "cloud-ephemeral.xml",
 		},
 		Spec: ispnv1.InfinispanSpec{
-			Size:  2,
-			Image: getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
+			Replicas: 2,
+			Image:    getEnvWithDefault("IMAGE", "jboss/infinispan-server:latest"),
 		},
 	}
 


### PR DESCRIPTION
* spec.replicas used in Deployment and StatefulSet, and so it's more idiomatic for Kubernetes.