### PR TITLE
Use default service account #63

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -295,7 +295,6 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse("0.5"),
 							"memory": resource.MustParse("512Mi")}},
 					}},
-					ServiceAccountName: "infinispan-operator",
 				},
 			},
 		},


### PR DESCRIPTION
This PR makes configurable the ServiceAccountName of the Infinispan pods setting `Infinispan.Spec.ServiceAccountName` field. If empty pods will run with the `default` service account.