### PR TITLE
Formal Operator configuration design v2

### DIFF
--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -1,0 +1,627 @@
+= Infinispan Operator - API Documentation
+:toc:               left
+
+This document describes the types introduced by the Infinispan Operator to be consumed by users.
+
+
+[[infinispan]]
+## `Infinispan`
+
+`Infinispan` defines a custom Infinispan resource.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `metadata`
+| Standard object’s metadata
+(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata[more info])
+| https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#objectmeta-v1-meta[metav1.ObjectMeta]
+| false
+
+| `spec`
+| Specification of the desired behaviour of the Infinispan deployment
+(https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status[more info])
+| <<infinispanspec>>
+| true
+
+| `status`
+| Most recent observed status of the Infinispan deployment. Read-only.
+(https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status#spec-and-status[more info])
+| <<infinispanstatus>>
+| false
+
+|
+|=======================
+
+[[infinispanspec]]
+### `InfinispanSpec`
+
+`InfinispanSpec` is a specification of the desired behavior of the Infinispan resource.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `evictionPolicy`
+| Eviction policy (only cache service?).
+| `Reject` / `Evict`
+| false
+| `Evict`
+
+| `image`
+| Operator image
+| string
+| false
+| `jboss/infinispan-server:latest`
+
+| `replicationFactor`
+| Replication factor (only cache service?).
+| int32
+| false
+| `1`
+
+| `size`
+| Number of instances for a Infinispan resource.
+| int32
+| true
+|
+
+| `cluster`
+| Cluster configuration.
+| <<infinispanclusterspec>>
+| false
+|
+
+| `connector`
+| Connector configuration.
+| <<infinispanconnectorspec>>
+| false
+|
+
+| `container`
+| Per instance configuration.
+| <<infinispancontainerspec>>
+| false
+|
+
+| `datasources`
+| Datasource list
+| []<<infinispandatasourcespec>>
+| false
+|
+
+| `logging`
+| Logging categories
+| []<<infinispanloggingcategoryspec>>
+| false
+|
+
+| `management`
+| Management configuration.
+| <<infinispanmgmtspec>>
+| false
+|
+
+| `sites`
+| Cross-site configuration
+| <<infinispansitesspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanclusterspec]]
+#### `InfinispanClusterSpec`
+
+`InfinispanClusterSpec` configures how Infinispan instances talk to each other.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `encryption`
+| Enables cluster encryption.
+| <<infinispanencryptionspec>>
+| false
+|
+
+| `secret`
+| Enables cluster authentication.
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanencryptionspec]]
+##### `InfinispanEncryptionSpec`
+
+`InfinispanEncryptionSpec` configures how encryption between `InfinispanSpec` instances happens.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `type`
+| Type of encryption
+| `Symmetric` or `Asymmetric`
+| true
+|
+
+| `secret`
+| Encrypted secret information.
+Only required with `Symmetric` encryption type.
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanconnectorspec]]
+#### `InfinispanConnectorSpec`
+
+`InfinispanConnectorSpec` defines how Infinispan is accessed.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `secret`
+| Authenticates access to Infinispan connectors.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispancontainerspec]]
+#### `InfinispanContainerSpec`
+
+`InfinispanContainerSpec` is a specification of each Infinispan instance managed by `InfinispanSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `jvmOptionsAppend`
+| Extra JVM options to pass to each `Infinispan` container.
+| string
+| false
+|
+
+| `memory`
+| Memory allocated for each Infinispan container.
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory[here].
+| string
+| false
+| `512Mi`
+
+| `storage`
+| Storage per Infinispan container (only data grid service).
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
+| string
+| false
+| `1Gi`
+
+|=======================
+
+
+[[infinispandatasourcespec]]
+#### `InfinispanDatasourceSpec`
+
+`InfinispanDatasourceSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `name`
+| Name of datasource.
+| string
+| true
+|
+
+| `driver`
+| Driver for datasource.
+| string
+| true
+|
+
+| `secret`
+| Secret for accessing datasource.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispanloggingcategoryspec]]
+#### `InfinispanLoggingCategorySpec`
+
+`InfinispanLoggingCategorySpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `category`
+| Name of logging category.
+| string
+| true
+|
+
+| `level`
+| Logging level for category.
+| string
+| true
+|
+
+|=======================
+
+
+[[infinispanmgmtspec]]
+#### `InfinispanManagementSpec`
+
+`InfinispanManagementSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `prometheus`
+| Enable prometheus.
+| boolean
+| false
+| false
+
+| `secret`
+| Management authentication information.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispansitesspec]]
+#### `InfinispanSitesSpec`
+
+`InfinispanSpitesSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `local`
+| Local site information.
+| <<infinispanlocalsitespec>>
+| true
+|
+
+| `remotes`
+| Remote site information.
+| []<<infinispanremotesitespec>>
+| true
+|
+
+|=======================
+
+
+[[infinispanlocalsitespec]]
+#### `InfinispanLocalSiteSpec`
+
+`InfinispanLocalSiteSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `externalService`
+| External service that is accessible from other sites.
+| https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#service-v1-core[coreV1.Service]
+| true
+|
+
+|=======================
+
+
+[[infinispanremotesitespec]]
+#### `InfinispanRemoteSiteSpec`
+
+`InfinispanRemoteSiteSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `name`
+| Name of remote site.
+| string
+| true
+|
+
+| `type`
+| Type of remote site configuration.
+| `Static` or `Dynamic`
+| true
+|
+
+| `host`
+| Remote site host name.
+| string
+| true
+|
+
+| `port`
+| Remote site host port (only for `Static` type).
+| int32
+| false
+|
+
+| `secret`
+| Secret to connect to remote site (only for `Dynamic` type).
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispansecretspec]]
+##### `InfinispanSecretSpec`
+
+`InfinispanSecretSpec` defines how `InfinispanSpec` secrets are configured.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `type`
+| Type of secret.
+| `Credentials`, `Keystore` or `Token`
+| true
+|
+
+| `secretName`
+| Name of referenced secret.
+| string
+| true
+|
+
+|=======================
+
+If type is `Credentials`, Secret` is expected to contain username and password credentials.
+These would be defined in `stringData/username` and `stringData/password` fields respectively.
+
+If type is `Keystore`, `Secret` is expected to contain base64 encoded data in `data/keystore.p12` field.
+Optional keystore password would be located in `stringData/password` field.
+
+If type is `Token`, `Secret` is expected to contain base64 encoded data in `stringData/token` field.
+
+
+[[infinispanstatus]]
+### `InfinispanStatus`
+
+`InfinispanStatus` is the most recent observed status of the `InfinispanSpec`. Read-only.
+
+TODO: @Vittorio, update with your proposal
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `pods`
+| Status of the pods.
+| []<<podstatus>>
+| true
+
+|=======================
+
+
+[[podstatus]]
+#### `PodStatus`
+
+`PodStatus` is the most recent observed status of a pod running `InfinispanSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `name`
+| Name of the Pod.
+| string
+| true
+
+| `podIP`
+| IP address allocated to the pod.
+| string
+| true
+
+|=======================
+
+## Full Example
+
+.full-example.yaml
+[source,yaml]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: full-example-infinispan
+spec:
+  evictionPolicy: Reject
+  image: jboss/infinispan-server:latest
+  replicationFactory: 3
+  size: 4
+  cluster:
+    encryption:
+      type: Symmetric
+      secret:
+        type: Keystore
+        secretName: cluster-encrypt-secret
+    secret:
+      type: Credentials
+      secretName: cluster-auth-secret
+  connector:
+    secret:
+      type: Credentials
+      secretName: connect-auth-secret
+  container:
+    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    memory: 1Gi
+    storage: 2Gi
+  datasources:
+  - name: test-pg
+    driver: postgresql
+    secret:
+      type: Credentials
+      secretName: postgresql-secret
+  - name: test-mysql
+    driver: mysql
+    secret:
+      type: Credentials
+      secretName: mysql-secret
+  logging:
+  - category: org.infinispan
+    level: trace
+  - category: org.jgroups
+    level: trace
+  management:
+    prometheus: true
+    secret:
+      type: Credentials
+      secretName: mgmt-secret
+  sites:
+    local:
+      externalService:
+        type: LoadBalancer
+        ports:
+          port: 12345
+    remotes:
+    - name: google
+      type: Static
+      host: google.host
+      port: 23456
+    - name: azure
+      type: Dynamic
+      host: azure.host
+      secret:
+        type: Credentials
+        secretName: azure-secret
+    - name: aws
+      type: Dynamic
+      secret:
+        type: Token
+        secretName: aws-secret
+----
+
+.cluster-encrypt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-encrypt-secret
+type: Opaque
+data:
+  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
+stringData:
+  password: opensesame
+----
+
+.cluster-auth-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-auth-secret
+type: Opaque
+stringData:
+  password: clusterpass
+----
+
+.connect-auth-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: connect-auth-secret
+type: Opaque
+stringData:
+  username: connectusr
+  password: connectpass
+----
+
+.postgresql-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-secret
+type: Opaque
+stringData:
+  username: pgusr
+  password: pgpass
+----
+
+.mysql-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+type: Opaque
+stringData:
+  username: myusr
+  password: mypass
+----
+
+.mgmt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mgmt-secret
+type: Opaque
+stringData:
+  username: mgmtusr
+  password: mgmtpass
+----
+
+.azure-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-secret
+type: Opaque
+stringData:
+  username: azusr
+  password: azpass
+----
+
+.aws-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-secret
+type: Opaque
+stringData:
+  token: "jd1r/deZpYmY/mpvofUKWQ=="
+----

--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -43,33 +43,33 @@ This document describes the types introduced by the Infinispan Operator to be co
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `evictionPolicy`
-| Eviction policy (only cache service?).
-| `Reject` / `Evict`
-| false
-| `Evict`
-
 | `image`
 | Operator image
 | string
 | false
 | `jboss/infinispan-server:latest`
 
-| `replicationFactor`
-| Replication factor (only cache service?).
-| int32
-| false
-| `1`
-
-| `size`
+| `replicas`
 | Number of instances for a Infinispan resource.
 | int32
 | true
 |
 
-| `cluster`
-| Cluster configuration.
-| <<infinispanclusterspec>>
+| `profile`
+| Profile in use. See <<infinispanprofiles,profiles>> for details.
+| `Secured` / `Performance` / `Development`
+| false
+| `Secured`
+
+| `cache`
+| Cache configuration.
+| <<infinispancachespec>>
+| false
+|
+
+| `datagrid`
+| Datagrid configuration.
+| <<infinispandatagridspec>>
 | false
 |
 
@@ -85,12 +85,6 @@ This document describes the types introduced by the Infinispan Operator to be co
 | false
 |
 
-| `datasources`
-| Datasource list
-| []<<infinispandatasourcespec>>
-| false
-|
-
 | `logging`
 | Logging categories
 | []<<infinispanloggingcategoryspec>>
@@ -103,59 +97,57 @@ This document describes the types introduced by the Infinispan Operator to be co
 | false
 |
 
-| `sites`
-| Cross-site configuration
-| <<infinispansitesspec>>
-| false
-|
-
 |=======================
 
 
-[[infinispanclusterspec]]
-#### `InfinispanClusterSpec`
+[[infinispancachespec]]
+#### `InfinispanCacheSpec`
 
-`InfinispanClusterSpec` configures how Infinispan instances talk to each other.
+`InfinispanCacheSpec` configures how Infinispan is used as a cache.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `encryption`
-| Enables cluster encryption.
-| <<infinispanencryptionspec>>
+| `evictionPolicy`
+| Eviction policy
+| `Reject` / `Evict`
 | false
-|
+| `Evict`
 
-| `secret`
-| Enables cluster authentication.
-| <<infinispansecretspec>>
+| `replicationFactor`
+| Replication factor
+| int32
 | false
-|
+| `1`
 
 |=======================
 
 
-[[infinispanencryptionspec]]
-##### `InfinispanEncryptionSpec`
+[[infinispanprofiles]]
 
-`InfinispanEncryptionSpec` configures how encryption between `InfinispanSpec` instances happens.
+#### Profiles
 
 [options="header,footer"]
 |=======================
-| Field | Description | Scheme | Required | Default
+| Profile | Connector Authentication | Connector Encryption | Cluster Authentication | Cluster Encryption
 
-| `type`
-| Type of encryption
-| `Symmetric` or `Asymmetric`
-| true
+| `Secured`
+| X
+| X
+| X
+| X
+
+| `Performance`
+| X
+| X
+| X
 |
 
-| `secret`
-| Encrypted secret information.
-Only required with `Symmetric` encryption type.
-| <<infinispansecretspec>>
-| false
+| `Development`
+|
+|
+|
 |
 
 |=======================
@@ -170,10 +162,10 @@ Only required with `Symmetric` encryption type.
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `secret`
+| `authentication`
 | Authenticates access to Infinispan connectors.
-| <<infinispansecretspec>>
-| true
+| <<infinispanauthenticationspec>>
+| false
 |
 
 |=======================
@@ -194,6 +186,14 @@ Only required with `Symmetric` encryption type.
 | false
 |
 
+| `cpu`
+| CPU allocated for each Infinispan container.
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu[here].
+| string
+| false
+| `500m`
+
 | `memory`
 | Memory allocated for each Infinispan container.
 Described as indicated
@@ -202,13 +202,37 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | false
 | `512Mi`
 
+|=======================
+
+
+[[infinispandatagridspec]]
+#### `InfinispanDatagridSpec`
+
+`InfinispanDatagridSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
 | `storage`
-| Storage per Infinispan container (only data grid service).
+| Storage per Infinispan container.
 Described as indicated
 https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
 | string
 | false
 | `1Gi`
+
+| `datasources`
+| Datasource list
+| []<<infinispandatasourcespec>>
+| false
+|
+
+| `sites`
+| Cross-site configuration
+| <<infinispansitesspec>>
+| false
+|
 
 |=======================
 
@@ -234,33 +258,45 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | true
 |
 
-| `secret`
-| Secret for accessing datasource.
-| <<infinispansecretspec>>
+| `authentication`
+| Authentication information for accessing datasource.
+| <<infinispanauthenticationspec>>
 | true
 |
 
 |=======================
 
 
-[[infinispanloggingcategoryspec]]
-#### `InfinispanLoggingCategorySpec`
+[[infinispanloggingspec]]
+#### `InfinispanLoggingSpec`
 
-`InfinispanLoggingCategorySpec`.
+`InfinispanLoggingSpec` configures logging.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `category`
-| Name of logging category.
-| string
-| true
+| `categories`
+| Logging categories
+| <<infinispanloggingcategoriesspec>>
+| false
 |
 
-| `level`
-| Logging level for category.
-| string
+|=======================
+
+
+[[infinispanloggingcategoriesspec]]
+#### `InfinispanLoggingCategoriesSpec`
+
+`InfinispanLoggingCategoriesSpec` configures logging categories.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `<category-name>`
+| Logging category name, e.g. `org.infinispan`
+| `error` / `warn` / `info` / `debug` / `trace`
 | true
 |
 
@@ -277,16 +313,34 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | Field | Description | Scheme | Required | Default
 
 | `prometheus`
+| Prometheus configuration.
+| <<infinispanprometheusspec>>
+| false
+|
+
+| `authentication`
+| Management authentication information.
+| <<infinispanauthenticationspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanprometheusspec]]
+#### `InfinispanPrometheusSpec`
+
+`InfinispanPrometheusSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `enabled`
 | Enable prometheus.
 | boolean
 | false
 | false
-
-| `secret`
-| Management authentication information.
-| <<infinispansecretspec>>
-| true
-|
 
 |=======================
 
@@ -366,19 +420,19 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | false
 |
 
-| `secret`
-| Secret to connect to remote site (only for `Dynamic` type).
-| <<infinispansecretspec>>
+| `authentication`
+| Authentication information to connect to remote site (only for `Dynamic` type).
+| <<infinispanauthenticationspec>>
 | false
 |
 
 |=======================
 
 
-[[infinispansecretspec]]
-##### `InfinispanSecretSpec`
+[[infinispanauthenticationspec]]
+##### `InfinispanAuthenticationSpec`
 
-`InfinispanSecretSpec` defines how `InfinispanSpec` secrets are configured.
+`InfinispanAuthenticationSpec` defines how authentication secrets are configured.
 
 [options="header,footer"]
 |=======================
@@ -447,106 +501,135 @@ TODO: @Vittorio, update with your proposal
 
 |=======================
 
-## Full Example
+## Full Cache Example
 
-.full-example.yaml
+.full-cache-example.yaml
 [source,yaml]
 ----
 apiVersion: infinispan.org/v1
 kind: Infinispan
 metadata:
-  name: full-example-infinispan
+  name: full-cache-example-infinispan
 spec:
-  evictionPolicy: Reject
   image: jboss/infinispan-server:latest
-  replicationFactory: 3
-  size: 4
-  cluster:
-    encryption:
-      type: Symmetric
-      secret:
-        type: Keystore
-        secretName: cluster-encrypt-secret
-    secret:
-      type: Credentials
-      secretName: cluster-auth-secret
+  replicas: 4
+  profile: Development
+  cache:
+    evictionPolicy: Reject
+    replicationFactor: 3
   connector:
-    secret:
+    authentication:
       type: Credentials
+      secretName: connect-secret
+  container:
+    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    cpu: "2000m"
+    memory: 1Gi
+  logging:
+    categories:
+      org.infinispan: trace
+      org.jgroups: trace
+  management:
+    prometheus:
+      enabled: true
+    authentication:
+      type: Credentials
+      secretName: mgmt-secret
+----
+
+.connect-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: connect-secret
+type: Opaque
+stringData:
+  username: connectusr
+  password: connectpass
+----
+
+.mgmt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mgmt-secret
+type: Opaque
+stringData:
+  username: mgmtusr
+  password: mgmtpass
+----
+
+
+## Full DataGrid Example
+
+.full-datagrid-example.yaml
+[source,yaml]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: full-datagrid-example-infinispan
+spec:
+  image: jboss/infinispan-server:latest
+  replicas: 6
+  profile: Performance
+  datagrid:
+    storage: 2Gi
+    datasources:
+    - name: test-pg
+      driver: postgresql
+      authentication:
+        type: Credentials
+        secretName: postgresql-secret
+    - name: test-mysql
+      driver: mysql
+      authentication:
+        type: Credentials
+        secretName: mysql-secret
+    sites:
+      local:
+        externalService:
+          type: LoadBalancer
+          ports:
+            port: 12345
+      remotes:
+      - name: google
+        type: Static
+        host: google.host
+        port: 23456
+      - name: azure
+        type: Dynamic
+        host: azure.host
+        authentication:
+          type: Credentials
+          secretName: azure-secret
+      - name: aws
+        type: Dynamic
+        authentication:
+          type: Token
+          secretName: aws-secret
+  connector:
+    authentication:
+      type: Keystore
       secretName: connect-auth-secret
   container:
     jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    cpu: "1000m"
     memory: 1Gi
-    storage: 2Gi
-  datasources:
-  - name: test-pg
-    driver: postgresql
-    secret:
-      type: Credentials
-      secretName: postgresql-secret
-  - name: test-mysql
-    driver: mysql
-    secret:
-      type: Credentials
-      secretName: mysql-secret
   logging:
-  - category: org.infinispan
-    level: trace
-  - category: org.jgroups
-    level: trace
+    categories:
+      org.infinispan: debug
+      org.jgroups: debug
   management:
-    prometheus: true
-    secret:
+    prometheus:
+      enabled: true
+    authentication:
       type: Credentials
       secretName: mgmt-secret
-  sites:
-    local:
-      externalService:
-        type: LoadBalancer
-        ports:
-          port: 12345
-    remotes:
-    - name: google
-      type: Static
-      host: google.host
-      port: 23456
-    - name: azure
-      type: Dynamic
-      host: azure.host
-      secret:
-        type: Credentials
-        secretName: azure-secret
-    - name: aws
-      type: Dynamic
-      secret:
-        type: Token
-        secretName: aws-secret
-----
-
-.cluster-encrypt-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-encrypt-secret
-type: Opaque
-data:
-  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
-stringData:
-  password: opensesame
-----
-
-.cluster-auth-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-auth-secret
-type: Opaque
-stringData:
-  password: clusterpass
 ----
 
 .connect-auth-secret.yaml
@@ -557,9 +640,8 @@ kind: Secret
 metadata:
   name: connect-auth-secret
 type: Opaque
-stringData:
-  username: connectusr
-  password: connectpass
+data:
+  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
 ----
 
 .postgresql-secret.yaml


### PR DESCRIPTION
 Version 2 of the operator configuration design here. Noteworthy changes:

General
--------

* Instead of 1 full example, there are now 2 full examples. One for using it as a cache service, one for using it as a data grid service.
* `spec.size` is now `spec.replicas`.
* `spec.profile` has been added as a result of the feedback on v1. Essentially, this is a way for the user to select the base settings of Infinispan. By default this is `Secured`, that means that both connector and cluster authentication and encryption are enabled. Alternatively, users can select `Development` where both connector and cluster authentication and encryption are disabled for ease of local development. The 3rd option is `Performance` which is like `Secured` but without cluster encryption. Thoughts? @tristantarrant @Crumby.
* `spec.connector.secret.authentication` has been moved to `spec.connector.authentication`.
* `spec.container.cpu` has been added.
* `spec.logging` categories have been moved to `spec.logging.categories`, with attribute names defining package names and values referring to logging levels.
* `spec.management.prometheus` boolean has been transformed to a subtree and `spec.management.prometheus.enabled` flag has been added to enable or disable it. By default would be disabled as in v1. I have some doubts about this though, see question section.
* `spec.management.secret` becomes `spec.management.authentication`.

Cache
------

* `spec.evictionPolicy` has been moved to `spec.cache.evictionPolicy`.
* `spec.replicationFactor` has been moved to `spec.cache.replicationFactor`.

Data Grid
---------

* `spec.container.storage` has been moved to `spec.datagrid.storage` since this option is only relevant for datagrid usages.
* `spec.datasources` has been moved to `spec.datagrid.datasources`.
* `spec.sites` has been moved to `spec.datagrid.sites`.
* `spec.sites.remotes[].secret` has been renamed to `spec.datagrid.sites.remotes[].authentication`

Questions
----------

* `spec.management.prometheus` could be removed completely by making using the profile as a way to signal whether prometheus is enabled or not. As example, with `Secured` and `Performance` prometheus would be enabled, but with `Development` it'd be disabled. Thoughts?