### PR TITLE
Random generated credentials if not provided #72

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -834,6 +834,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/go-logr/logr",
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
     "k8s.io/api/apps/v1beta1",

--- a/documentation/asciidoc/stories/managing_cluster_credentials.adoc
+++ b/documentation/asciidoc/stories/managing_cluster_credentials.adoc
@@ -1,0 +1,22 @@
+[id='managing_cluster_credentials']
+== Managing Cluster Credentials
+:context: managing_cluster_credentials
+
+Perform tasks to manage authentication for {brandname} clusters.
+
+.Prerequisites
+
+ifndef::productized[]
+* A `kubectl` client in your `$PATH`.
+endif::productized[]
+ifdef::productized[]
+* An `oc` client in your `$PATH`.
+endif::productized[]
+
+[id='getting_credentials-{context}']
+=== Retrieving Cluster Credentials
+include::topics/proc_get_cluster_credentials.adoc[]
+
+// Restore the parent context.
+ifdef::parent-context[:context: {parent-context}]
+ifndef::parent-context[:!context:]

--- a/documentation/asciidoc/titles/stories.adoc
+++ b/documentation/asciidoc/titles/stories.adoc
@@ -1,2 +1,3 @@
 include::topics/con_infinispan_operator.adoc[]
 include::stories/spinning-up-clusters.adoc[]
+include::stories/managing_cluster_credentials.adoc[]

--- a/documentation/asciidoc/topics/cmd_examples/oc_get_pods.adoc
+++ b/documentation/asciidoc/topics/cmd_examples/oc_get_pods.adoc
@@ -1,0 +1,5 @@
+$ oc get pods
+
+NAME                   READY     STATUS    RESTARTS   AGE
+example-infinispan-0   1/1       Running   0          1m
+example-infinispan-1   1/1       Running   0          49s

--- a/documentation/asciidoc/topics/cmd_examples/oc_get_pods_w.adoc
+++ b/documentation/asciidoc/topics/cmd_examples/oc_get_pods_w.adoc
@@ -1,0 +1,10 @@
+$ oc get pods -w
+
+NAME                                   READY     STATUS              RESTARTS   AGE
+example-infinispan-54c66fd755-28lvx    0/1       ContainerCreating   0          4s
+example-infinispan-54c66fd755-7c4zc    0/1       ContainerCreating   0          4s
+example-infinispan-54c66fd755-8gbxf    0/1       ContainerCreating   0          5s
+infinispan-operator-69d7d4469d-f62ws   1/1       Running             0          3m
+example-infinispan-54c66fd755-8gbxf    1/1       Running             0          8s
+example-infinispan-54c66fd755-7c4zc    1/1       Running             0          8s
+example-infinispan-54c66fd755-28lvx    1/1       Running             0          8s

--- a/documentation/asciidoc/topics/proc_apply_crd.adoc
+++ b/documentation/asciidoc/topics/proc_apply_crd.adoc
@@ -1,4 +1,5 @@
 
+.Procedure
 . Specify a custom resource definition for the {brandname} cluster.
 +
 [source,options="nowrap"]
@@ -8,15 +9,7 @@ $ oc apply -f example-infinispan.yaml
 +
 . Verify that the {ispn_operator} creates the pods.
 +
-[source,options="nowrap"]
+[source,options="nowrap",subs=attributes+]
 ----
-$ oc get pods -w
-NAME                                   READY     STATUS              RESTARTS   AGE
-example-infinispan-54c66fd755-28lvx    0/1       ContainerCreating   0          4s
-example-infinispan-54c66fd755-7c4zc    0/1       ContainerCreating   0          4s
-example-infinispan-54c66fd755-8gbxf    0/1       ContainerCreating   0          5s
-infinispan-operator-69d7d4469d-f62ws   1/1       Running             0          3m
-example-infinispan-54c66fd755-8gbxf    1/1       Running             0          8s
-example-infinispan-54c66fd755-7c4zc    1/1       Running             0          8s
-example-infinispan-54c66fd755-28lvx    1/1       Running             0          8s
+include::cmd_examples/oc_get_pods_w.adoc[]
 ----

--- a/documentation/asciidoc/topics/proc_get_cluster_credentials.adoc
+++ b/documentation/asciidoc/topics/proc_get_cluster_credentials.adoc
@@ -1,0 +1,62 @@
+You can retrieve credentials for your {brandname} clusters as base64-encoded strings from secrets in your cluster namespace.
+
+[NOTE]
+====
+If you do not specify credentials when you create clusters, the {ispn_operator} automatically generates passwords and sets default usernames as follows:
+
+* Management user is `admin`.
+* Application user is `developer`.
+====
+
+.Procedure
+. List the pods for the cluster, for example:
++
+[source,options="nowrap",subs=attributes+]
+----
+include::cmd_examples/oc_get_pods.adoc[]
+----
++
+. Get the secrets from one of the pods as `yaml` output, for example:
++
+ifndef::productized[]
+[source,options="nowrap",subs=attributes+]
+----
+$ oc get pod/example-infinispan-0 -o yaml
+
+include::yaml_examples/credentials_ispn.yaml[]
+----
+endif::productized[]
+ifdef::productized[]
+[source,options="nowrap",subs=attributes+]
+----
+$ oc get pod/example-infinispan-0 -o yaml
+
+include::yaml_examples/credentials_rhdg.yaml[]
+----
+endif::productized[]
++
+Credentials reside in the following secrets:
++
+* `example-infinispan-mgmt-generated-secret` contains credentials for the management user.
+* `example-infinispan-app-generated-secret` contains credentials for the application user.
++
+. Get the credentials from the secret. For example, to get the password for the application user:
++
+[source,options="nowrap",subs=attributes+]
+----
+$ oc get secret example-infinispan-app-generated-secret -n my_namespace -o jsonpath="{.data.password}" | base64 --decode
+----
++
+[TIP]
+====
+Use the `jp` JSON processor to retrieve credentials as follows:
+
+----
+$ oc get secret example-infinispan-app-generated-secret -n my_namespace -o json | jq '.data | map_values(@base64d)'
+
+{
+  "password": "tUElqbfoJmT,NJVN",
+  "username": "developer"
+}
+----
+====

--- a/documentation/asciidoc/topics/yaml_examples/credentials_ispn.yaml
+++ b/documentation/asciidoc/topics/yaml_examples/credentials_ispn.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+...
+spec:
+  containers:
+    env:
+    - name: MGMT_USER
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: example-infinispan-mgmt-generated-secret
+    - name: MGMT_PASS
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: example-infinispan-mgmt-generated-secret
+    - name: APP_USER
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: example-infinispan-app-generated-secret
+    - name: APP_PASS
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: example-infinispan-app-generated-secret
+...

--- a/documentation/asciidoc/topics/yaml_examples/credentials_rhdg.yaml
+++ b/documentation/asciidoc/topics/yaml_examples/credentials_rhdg.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+...
+spec:
+  containers:
+    env:
+    - name: ADMIN_USER
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: example-infinispan-mgmt-generated-secret
+    - name: ADMIN_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: example-infinispan-mgmt-generated-secret
+    - name: APPLICATION_USER
+      valueFrom:
+        secretKeyRef:
+          key: username
+          name: example-infinispan-app-generated-secret
+    - name: APPLICATION_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          key: password
+          name: example-infinispan-app-generated-secret
+...

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -225,7 +225,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 		}
 	}
 	if appUser == "" {
-		appUser = getRandomStringForAuth(16)
+		appUser = "developer"
 	}
 	if appPass == "" {
 		appPass = getRandomStringForAuth(16)
@@ -242,7 +242,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 		}
 	}
 	if mgmtUser == "" {
-		mgmtUser = getRandomStringForAuth(16)
+		mgmtUser = "admin"
 	}
 	if mgmtPass == "" {
 		mgmtPass = getRandomStringForAuth(16)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -139,12 +139,9 @@ func TestExternalService(t *testing.T) {
 		panic(err.Error())
 	}
 
-	pods, err := okd.GetPods(Namespace, "app=infinispan-pod")
-	if err != nil {
-		panic(err.Error())
-	}
-	appUser := getEnvVar(pods[0].Spec.Containers[0].Env, "APP_USER")
-	appPass := getEnvVar(pods[0].Spec.Containers[0].Env, "APP_PASS")
+	appUser := okd.GetSecret(Namespace, "username", "cache-infinispan-0-app-generated-secret")
+	appPass := okd.GetSecret(Namespace, "password", "cache-infinispan-0-app-generated-secret")
+
 	okd.CreateRoute(Namespace, "cache-infinispan-0", "http")
 	defer okd.DeleteRoute(Namespace, "cache-infinispan-0-http")
 

--- a/test/e2e/util/k8s/k8s_client.go
+++ b/test/e2e/util/k8s/k8s_client.go
@@ -561,3 +561,11 @@ func (c ExternalK8s) DeleteRoute(ns, serviceName string) {
 func (c ExternalK8s) GetClusterSize(namespace, namePod string) (int, error) {
 	return c.ispnCliHelper.GetClusterSize(namespace, namePod)
 }
+
+func (c ExternalK8s) GetSecret(ns, field string, name string) string {
+	secret, err := c.coreClient.Secrets(ns).Get(name, metaV1.GetOptions{})
+	if err != nil {
+		panic(err.Error())
+	}
+	return string(secret.Data[field])
+}


### PR DESCRIPTION
This picks up @rigazilla's work in #74. Apart from fixing the rebase, it:

* Sets default app username as `developer` and default admin user as `admin`. So these are not generated any more if the user does not provide them.
* Generated passwords are now stored in secrets (along with usernames), so whether the user provides the secret or we create it, the behaviour is the same.
* This means that secret values, username and passwords, cannot be read just by looking at the pod details. Individual secrets need to be inspected to extract this information. This is a more secured set up.
* Finally, the production code does not need to inspect the secrets since env variable values can referenced from secrets as shown [here](https://kubernetes.io/docs/concepts/configuration/secret/#using-secrets-as-environment-variables).
* The tests do extract the password and userrname secrets to use them when making the corresponding HTTP calls but that's expected.