### PR TITLE
Tidy up CR examples

### DIFF
--- a/deploy/cr/cr_conn_secret.yaml
+++ b/deploy/cr/cr_conn_secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: conn-auth-secret
-type: Opaque
-stringData:
-  username: connectorusr
-  password: connectorpass

--- a/deploy/cr/cr_minimal.yaml
+++ b/deploy/cr/cr_minimal.yaml
@@ -4,4 +4,3 @@ metadata:
   name: example-infinispan
 spec:
   replicas: 2
-  image: jboss/infinispan-server:latest

--- a/deploy/cr/cr_minimal_with_auth.yaml
+++ b/deploy/cr/cr_minimal_with_auth.yaml
@@ -4,14 +4,7 @@ metadata:
   name: example-infinispan
 spec:
   replicas: 2
-  image: jboss/infinispan-server:latest
   connector:
     authentication:
-      secret:
-        type: Credentials
-        secretName: conn-auth-secret
-  management:
-    authentication:
-      secret:
-        type: Credentials
-        secretName: mngt-auth-secret
+      type: Credentials
+      secretName: connect-secret

--- a/deploy/cr/cr_mngt_secret.yaml
+++ b/deploy/cr/cr_mngt_secret.yaml
@@ -1,8 +1,0 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mngt-auth-secret
-type: Opaque
-stringData:
-  username: managementusr
-  password: managementpass


### PR DESCRIPTION
* Remove .spec.image from minimal example,
since that attribute is not really needed.
If the example is minimal, it should have minimal configuration.
The documentation can explain how to use an alternative image.
* Simplified the custom connect authentication example,
by removing the image and management sections.
* Remove secret definitions since these are not CR examples per se.
Even if we have a config map example,
we don't provide the config map definition.