### PR TITLE
85/enhanced tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,35 @@ jobs:
         - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get events --all-namespaces
         - docker ps -a
         - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
+    - stage: "Test"
+      env:
+        - WATCH_NAMESPACE=namespace-for-testing
+        - APP_USER=APPLICATION_USER
+        - APP_PASS=APPLICATION_PASSWORD
+        - MGMT_USER=ADMIN_USER
+        - MGMT_PASS=ADMIN_PASSWORD
+        - 'ENTRY_POINT_ARGS="[]"'
+        - 'PROBES="{\"readiness\": \"/opt/datagrid/bin/readinessProbe.sh\", \"liveness\": \"/opt/datagrid/bin/livenessProbe.sh\"}"'
+        - 'ADDITIONAL_VARS="[\"IMAGE\",\"NUMBER_OF_INSTANCE\",\"HOTROD_AUTHENTICATION\"]"'
+        - 'VOLUME_MOUNTS="[{\"MountPath\": \"/opt/datagrid/standalone/data\", \"Name": \"srv-data\"},{\"MountPath\": \"/var/run/secrets/java.io/keystores\", \"Name\": \"keystore-volume\"},{\"MountPath\": \"/var/run/secrets/openshift.io/serviceaccount\", \"Name\": \"service-certs\"}]"'
+        - 'VOLUME_CLAIMS=[{\"metadata\": {\"Name\": \"srv-data\"}, \"Spec\":{\"AccessModes\": [\"ReadWriteOnce\"], \"Resources\": {\"Requests\": {\"storage\": \"1Gi\"}}}}]"'
+        - 'IMAGE=registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:latest'
+        - CLI_CMD=/opt/datagrid/bin/cli.sh
+        - 'DEFAULT_IMAGE=registry.access.redhat.com/jboss-datagrid-7/datagrid73-openshift:latest'
+        - HOTROD_AUTHENTICATION=true
+        - VOLUME_KEYSTORE_NAME=keystore-volume
+        - VOLUME_SECRET_NAME=service-certs
+        - TEST_MGMT_ENABLED=false
+      name: "OpenShift Custom Image"
+      script:
+        - env
+        - go get -u github.com/golang/dep/cmd/dep
+        - ci/start-okd-4.0.0.sh
+        - make test KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig
+        - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get pods --all-namespaces
+        - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get events --all-namespaces
+        - docker ps -a
+        - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
 # Minikube test is unstable (lack of resources?). Disabling temporarily
 #    - stage: "Test"
 #      name: "Minikube"

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -600,32 +600,16 @@ func appendVolumes(m *infinispanv1.Infinispan, dep *appsv1beta1.StatefulSet) {
 
 	v := &dep.Spec.Template.Spec.Volumes
 
-	var volumeKeystore string
-	envVar, defined = os.LookupEnv("VOLUME_KEYSTORE_NAME")
+	volumeKeystore, defined := os.LookupEnv("VOLUME_KEYSTORE_NAME")
 	if defined {
-		err := json.Unmarshal([]byte(envVar), &volumeKeystore)
-		if err != nil {
-			// In case of error return default add nothing
-			logf.Log.Error(err, "No volume mounts added. Error in parsing user VOLUME_KEYSTORE_NAME value: (%s)", envVar)
-			return
-		}
-
 		*v = append(*v, corev1.Volume{
 			Name:         volumeKeystore,
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		})
 	}
 
-	var volumeSecretName string
-	envVar, defined = os.LookupEnv("VOLUME_SECRET_NAME")
+	volumeSecretName, defined := os.LookupEnv("VOLUME_SECRET_NAME")
 	if defined {
-		err := json.Unmarshal([]byte(envVar), &volumeSecretName)
-		if err != nil {
-			// In case of error return default add nothing
-			logf.Log.Error(err, "No volume mounts added. Error in parsing user VOLUME_SECRET_NAME value: (%s)", envVar)
-			return
-		}
-
 		*v = append(*v, corev1.Volume{
 			Name:         volumeSecretName,
 			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: volumeSecretName}},

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -49,9 +49,34 @@ func TestMain(m *testing.M) {
 	namespace := strings.ToLower(Namespace)
 	okd.NewProject(namespace)
 	stopCh := utilk8s.RunOperator(okd, Namespace, ConfigLocation)
+	setupNamespace()
 	code := m.Run()
+	cleanupNamespace()
 	utilk8s.Cleanup(*okd, Namespace, stopCh)
 	os.Exit(code)
+}
+
+func setupNamespace() {
+	volumeSecretName, defined := os.LookupEnv("VOLUME_SECRET_NAME")
+	if defined {
+		secret := corev1.Secret{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Secret",
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: volumeSecretName},
+			Type:       "Opaque",
+			StringData: map[string]string{"username": "connectorusr", "password": "connectorpass"},
+		}
+		okd.CoreClient().Secrets(Namespace).Create(&secret)
+	}
+}
+
+func cleanupNamespace() {
+	volumeSecretName, defined := os.LookupEnv("VOLUME_SECRET_NAME")
+	if defined {
+		okd.CoreClient().Secrets(Namespace).Delete(volumeSecretName, &deleteOpts)
+	}
 }
 
 // Simple smoke test to check if the OKD is alive
@@ -232,9 +257,7 @@ func TestExternalServiceWithAuth(t *testing.T) {
 
 	client := &http.Client{}
 	hostAddr := okd.WaitForRoute(client, Namespace, "cache-infinispan-0-http", RouteTimeout, "connectorusr", "connectorpass")
-
-	hostAddrMgmt := okd.WaitForRoute(client, Namespace, "cache-infinispan-0-mgmt", RouteTimeout, "connectorusr", "connectorpass")
-
+	mgmtEnabled := os.Getenv("TEST_MGMT_ENABLED")
 	value := "test-operator"
 
 	putViaRoute("http://"+hostAddr+"/rest/default/test", value, client, "connectorusr", "connectorpass")
@@ -243,7 +266,10 @@ func TestExternalServiceWithAuth(t *testing.T) {
 		panic(fmt.Errorf("unexpected actual returned: %v (value %v)", actual, value))
 	}
 
-	mgmtConnectViaRoute("http://"+hostAddrMgmt+"/management", value, client, "connectormgmtusr", "connectormgmtpass")
+	if mgmtEnabled != "false" {
+		hostAddrMgmt := okd.WaitForRoute(client, Namespace, "cache-infinispan-0-mgmt", RouteTimeout, "connectorusr", "connectorpass")
+		mgmtConnectViaRoute("http://"+hostAddrMgmt+"/management", value, client, "connectormgmtusr", "connectormgmtpass")
+	}
 }
 
 func getViaRoute(url string, client *http.Client, user string, pass string) string {


### PR DESCRIPTION
This allows make test to run with custom/enhanced images.

Dummy volume is created if defined in VOLUME_SECRET_NAME env var.
Test on management interface are skipped if the image doesn't expose it (need to set TEST_MGMT_ENABLED=false)

