### PR TITLE
Formal Operator configuration design v3

### DIFF
--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -57,25 +57,19 @@ This document describes the types introduced by the Infinispan Operator to be co
 
 | `profile`
 | Profile in use. See <<infinispanprofiles,profiles>> for details.
-| `Secured` / `Performance` / `Development`
+| `Default` / `Performance` / `Development`
 | false
-| `Secured`
+| `Default`
 
-| `cache`
-| Cache configuration.
-| <<infinispancachespec>>
-| false
-|
-
-| `datagrid`
-| Datagrid configuration.
-| <<infinispandatagridspec>>
+| `service`
+| Service specific configuration.
+| <<infinispanservicespec>>
 | false
 |
 
-| `connector`
-| Connector configuration.
-| <<infinispanconnectorspec>>
+| `security`
+| Security configuration.
+| <<infinispansecurityspec>>
 | false
 |
 
@@ -91,35 +85,67 @@ This document describes the types introduced by the Infinispan Operator to be co
 | false
 |
 
-| `management`
-| Management configuration.
-| <<infinispanmgmtspec>>
+|=======================
+
+
+[[infinispanservicespec]]
+#### `InfinispanServiceSpec`
+
+`InfinispanCacheSpec` configures aspects related to the cache or datagrid service.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `type`
+| Type of service
+| `Cache` / `Data Grid`
+| true
+| `Cache`
+
+| `evictionPolicy`
+| Cache service eviction policy
+| `Reject` / `Evict`
+| false
+| `Evict`
+
+| `replicationFactor`
+| Cache service replication factor
+| int32
+| false
+| `1`
+
+| `container`
+| Service specific container configuration.
+| <<infinispanservicecontainerspec>>
+| false
+|
+
+| `sites`
+| Cross-site configuration
+| <<infinispansitesspec>>
 | false
 |
 
 |=======================
 
 
-[[infinispancachespec]]
-#### `InfinispanCacheSpec`
+[[infinispanservicecontainerspec]]
+#### `InfinispanServiceContainerSpec`
 
-`InfinispanCacheSpec` configures how Infinispan is used as a cache.
+`InfinispanServiceContainerSpec` defines service specific container configurations.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `evictionPolicy`
-| Eviction policy
-| `Reject` / `Evict`
+| `storage`
+| Storage per Infinispan container in the data grid service.
+Defines as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
+| string
 | false
-| `Evict`
-
-| `replicationFactor`
-| Replication factor
-| int32
-| false
-| `1`
+| `1Gi`
 
 |=======================
 
@@ -132,7 +158,7 @@ This document describes the types introduced by the Infinispan Operator to be co
 |=======================
 | Profile | Connector Authentication | Connector Encryption | Cluster Authentication | Cluster Encryption
 
-| `Secured`
+| `Default`
 | X
 | X
 | X
@@ -153,19 +179,52 @@ This document describes the types introduced by the Infinispan Operator to be co
 |=======================
 
 
-[[infinispanconnectorspec]]
-#### `InfinispanConnectorSpec`
+[[infinispansecurityspec]]
+#### `InfinispanSecuritySpec`
 
-`InfinispanConnectorSpec` defines how Infinispan is accessed.
+`InfinispanSecuritySpec` defines Infinispan security settings.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `authentication`
-| Authenticates access to Infinispan connectors.
-| <<infinispanauthenticationspec>>
+| `roles`
+| Roles for interacting with Infinispan.
+| []<<infinispanrolespec>>
 | false
+|
+
+| `endpointSecret`
+| Secret containing identities allowed to interact with Infinispan.
+The format of the metadata in the secret can be found <<identities,here>>.
+| string
+| false
+|
+
+|=======================
+
+
+[[infinispanrolespec]]
+#### `InfinispanRoleSpec`
+
+`InfinispanRoleSpec` defines Infinispan role definitions.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `name`
+| Name of role.
+| string
+| true
+|
+
+| `permissions`
+| List of permissions.
+Valid values are defined
+https://infinispan.org/docs/dev/titles/security/security.html#security_embedded_permissions[here].
+| []string
+| true
 |
 
 |=======================
@@ -180,87 +239,15 @@ This document describes the types introduced by the Infinispan Operator to be co
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `jvmOptionsAppend`
-| Extra JVM options to pass to each `Infinispan` container.
-| string
-| false
-|
-
-| `cpu`
-| CPU allocated for each Infinispan container.
-Described as indicated
-https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu[here].
-| string
-| false
-| `500m`
-
-| `memory`
-| Memory allocated for each Infinispan container.
-Described as indicated
-https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory[here].
-| string
-| false
-| `512Mi`
-
-|=======================
-
-
-[[infinispandatagridspec]]
-#### `InfinispanDatagridSpec`
-
-`InfinispanDatagridSpec`.
-
-[options="header,footer"]
-|=======================
-| Field | Description | Scheme | Required | Default
-
-| `storage`
-| Storage per Infinispan container.
-Described as indicated
-https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
-| string
-| false
-| `1Gi`
-
-| `datasources`
-| Datasource list
-| []<<infinispandatasourcespec>>
-| false
-|
-
-| `sites`
-| Cross-site configuration
-| <<infinispansitesspec>>
-| false
-|
-
-|=======================
-
-
-[[infinispandatasourcespec]]
-#### `InfinispanDatasourceSpec`
-
-`InfinispanDatasourceSpec`.
-
-[options="header,footer"]
-|=======================
-| Field | Description | Scheme | Required | Default
-
 | `name`
-| Name of datasource.
+| Name of role.
 | string
 | true
 |
 
-| `driver`
-| Driver for datasource.
-| string
-| true
-|
-
-| `authentication`
-| Authentication information for accessing datasource.
-| <<infinispanauthenticationspec>>
+| `permissions`
+| Permissions associated with this role
+| []string
 | true
 |
 
@@ -298,30 +285,6 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | Logging category name, e.g. `org.infinispan`
 | `error` / `warn` / `info` / `debug` / `trace`
 | true
-|
-
-|=======================
-
-
-[[infinispanmgmtspec]]
-#### `InfinispanManagementSpec`
-
-`InfinispanManagementSpec`.
-
-[options="header,footer"]
-|=======================
-| Field | Description | Scheme | Required | Default
-
-| `prometheus`
-| Prometheus configuration.
-| <<infinispanprometheusspec>>
-| false
-|
-
-| `authentication`
-| Management authentication information.
-| <<infinispanauthenticationspec>>
-| false
 |
 
 |=======================
@@ -402,63 +365,22 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | true
 |
 
-| `type`
-| Type of remote site configuration.
-| `Static` or `Dynamic`
-| true
-|
-
-| `host`
-| Remote site host name.
+| `url`
+| URL for remote site.
+`xsite://` scheme denotes that the remote site is configured with static host:port combination.
+`openshift://` scheme denotes that site external setting sare extracted from the remote OpenShift host:port.
 | string
 | true
 |
 
-| `port`
-| Remote site host port (only for `Static` type).
-| int32
-| false
-|
-
-| `authentication`
-| Authentication information to connect to remote site (only for `Dynamic` type).
-| <<infinispanauthenticationspec>>
-| false
-|
-
-|=======================
-
-
-[[infinispanauthenticationspec]]
-##### `InfinispanAuthenticationSpec`
-
-`InfinispanAuthenticationSpec` defines how authentication secrets are configured.
-
-[options="header,footer"]
-|=======================
-| Field | Description | Scheme | Required | Default
-
-| `type`
-| Type of secret.
-| `Credentials`, `Keystore` or `Token`
-| true
-|
-
-| `secretName`
-| Name of referenced secret.
+| `secret`
+| Only in use with OpenShift URLs.
+Contains the secret details for accessing remote OpenShift instances.
 | string
-| true
+| false
 |
 
 |=======================
-
-If type is `Credentials`, Secret` is expected to contain username and password credentials.
-These would be defined in `stringData/username` and `stringData/password` fields respectively.
-
-If type is `Keystore`, `Secret` is expected to contain base64 encoded data in `data/keystore.p12` field.
-Optional keystore password would be located in `stringData/password` field.
-
-If type is `Token`, `Secret` is expected to contain base64 encoded data in `stringData/token` field.
 
 
 [[infinispanstatus]]
@@ -501,6 +423,132 @@ TODO: @Vittorio, update with your proposal
 
 |=======================
 
+
+[[identities]]
+#### `Identities`
+
+`Identities` defines the identities configuration that's stored within a Secret.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `credentials`
+| Credentials (username and password) based identities.
+| []<<credentials>>
+| true
+
+| `certificates`
+| Certificate (p12 format) based identities.
+| []<<certificate>>
+| true
+
+| `oauth`
+| Identities provided by OAuth servers.
+| []<<oauth>>
+| true
+
+| `tokens`
+| Token-based identities.
+| []<<token>>
+| true
+
+|=======================
+
+
+[[credentials]]
+#### `Credentials`
+
+`Credentials`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `username`
+| Username.
+| string
+| false
+
+| `password`
+| Password.
+| string
+| true
+
+| `roles`
+| Roles of credentials
+| []string
+| false
+
+|=======================
+
+
+[[certificate]]
+#### `Certificate`
+
+`Certificate`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `p12`
+| Certificate encoded in base 64 format.
+| string
+| true
+
+| `roles`
+| Roles of credentials
+| []string
+| false
+
+|=======================
+
+
+[[oauth]]
+#### `OAuth`
+
+`OAuth`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `clientId`
+| TODO
+| string
+| true
+
+| `clientSecret`
+| TODO
+| string
+| true
+
+| `introspectionUrl`
+| TODO
+| string
+| true
+
+|=======================
+
+
+[[token]]
+#### `Token`
+
+`Token`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `token`
+| Authentication token for an identity.
+| string
+| true
+
+|=======================
+
+
 ## Full Cache Example
 
 .full-cache-example.yaml
@@ -514,53 +562,57 @@ spec:
   image: jboss/infinispan-server:latest
   replicas: 4
   profile: Development
-  cache:
+  service:
+    type: Cache
     evictionPolicy: Reject
     replicationFactor: 3
-  connector:
-    authentication:
-      type: Credentials
-      secretName: connect-secret
+  security:
+    roles:
+    - name: admin
+      permissions:
+      - ADMIN
+    - name: developer
+      permissions:
+      - WRITE
+    - name: collaborator
+      permissions:
+      - READ
+    endpointSecret: endpoint-identities
   container:
-    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    extraJvmOpts: "-XX:NativeMemoryTracking=summary"
     cpu: "2000m"
     memory: 1Gi
   logging:
     categories:
       org.infinispan: trace
       org.jgroups: trace
-  management:
-    prometheus:
-      enabled: true
-    authentication:
-      type: Credentials
-      secretName: mgmt-secret
 ----
 
-.connect-secret.yaml
+.endpoint-identities.yaml
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: connect-secret
+  name: endpoint-identities
 type: Opaque
 stringData:
-  username: connectusr
-  password: connectpass
-----
-
-.mgmt-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mgmt-secret
-type: Opaque
-stringData:
-  username: mgmtusr
-  password: mgmtpass
+  identities.yaml: |-
+    credentials
+    - username: connectusr
+      password: connectpass
+      roles:
+      - admin
+      - developer
+      - collaborator
+    certificates:
+    - p12: "FQSmxHHvFvrhEfKIq15axg=="
+      roles:
+      - admin
+    oauth:
+    - clientId: infinispan-server
+      clientSecret: 1fdca4ec-c416-47e0-867a-3d471af7050f
+      introspectionUrl: "http://..."
 ----
 
 
@@ -577,133 +629,62 @@ spec:
   image: jboss/infinispan-server:latest
   replicas: 6
   profile: Performance
-  datagrid:
-    storage: 2Gi
-    datasources:
-    - name: test-pg
-      driver: postgresql
-      authentication:
-        type: Credentials
-        secretName: postgresql-secret
-    - name: test-mysql
-      driver: mysql
-      authentication:
-        type: Credentials
-        secretName: mysql-secret
+  service:
+    type: Data Grid
+    container:
+      storage: 2Gi
     sites:
       local:
         externalService:
           type: LoadBalancer
           ports:
-            port: 12345
+            - port: 12345
       remotes:
       - name: google
-        type: Static
-        host: google.host
-        port: 23456
+        url: xsite://google.host:23456
       - name: azure
-        type: Dynamic
-        host: azure.host
-        authentication:
-          type: Credentials
-          secretName: azure-secret
+        url: openshift://api.azure.host:6443
+        secret: azure-identities
       - name: aws
-        type: Dynamic
-        authentication:
-          type: Token
-          secretName: aws-secret
-  connector:
-    authentication:
-      type: Keystore
-      secretName: connect-auth-secret
+        url: openshift://api.aws.host:6443
+        secret: aws-identities
   container:
-    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    extraJvmOpts: "-XX:NativeMemoryTracking=summary"
     cpu: "1000m"
     memory: 1Gi
   logging:
     categories:
       org.infinispan: debug
       org.jgroups: debug
-  management:
-    prometheus:
-      enabled: true
-    authentication:
-      type: Credentials
-      secretName: mgmt-secret
 ----
 
-.connect-auth-secret.yaml
+.azure-identities.yaml
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: connect-auth-secret
-type: Opaque
-data:
-  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
-----
-
-.postgresql-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: postgresql-secret
+  name: azure-identities
 type: Opaque
 stringData:
-  username: pgusr
-  password: pgpass
+  identities.yaml: |-
+    credentials:
+    - username: openshifazrusr
+      password: openshifazrpass
+    tokens:
+    - gl8xTESu_j_tzMQhpe_P-It6IcWFQUm94WsuR3VFkUw
 ----
 
-.mysql-secret.yaml
+.aws-identities.yaml
 [source,yaml]
 ----
 apiVersion: v1
 kind: Secret
 metadata:
-  name: mysql-secret
+  name: aws-identities
 type: Opaque
 stringData:
-  username: myusr
-  password: mypass
-----
-
-.mgmt-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mgmt-secret
-type: Opaque
-stringData:
-  username: mgmtusr
-  password: mgmtpass
-----
-
-.azure-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: azure-secret
-type: Opaque
-stringData:
-  username: azusr
-  password: azpass
-----
-
-.aws-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: aws-secret
-type: Opaque
-stringData:
-  token: "jd1r/deZpYmY/mpvofUKWQ=="
+  identities.yaml: |-
+    tokens:
+    - LdqA1uM0e3wxhwOf0WRaP7Je3RdOjtrpai1jONQg7z0
 ----

--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -424,7 +424,8 @@ TODO: @Vittorio, update with your proposal
 |=======================
 
 
-[[identities]]
+[[
+ies]]
 #### `Identities`
 
 `Identities` defines the identities configuration that's stored within a Secret.
@@ -598,7 +599,7 @@ metadata:
 type: Opaque
 stringData:
   identities.yaml: |-
-    credentials
+    credentials:
     - username: connectusr
       password: connectpass
       roles:

--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -1,0 +1,627 @@
+= Infinispan Operator - API Documentation
+:toc:               left
+
+This document describes the types introduced by the Infinispan Operator to be consumed by users.
+
+
+[[infinispan]]
+## `Infinispan`
+
+`Infinispan` defines a custom Infinispan resource.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `metadata`
+| Standard object’s metadata
+(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#metadata[more info])
+| https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#objectmeta-v1-meta[metav1.ObjectMeta]
+| false
+
+| `spec`
+| Specification of the desired behaviour of the Infinispan deployment
+(https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status[more info])
+| <<infinispanspec>>
+| true
+
+| `status`
+| Most recent observed status of the Infinispan deployment. Read-only.
+(https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status#spec-and-status[more info])
+| <<infinispanstatus>>
+| false
+
+|
+|=======================
+
+[[infinispanspec]]
+### `InfinispanSpec`
+
+`InfinispanSpec` is a specification of the desired behavior of the Infinispan resource.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `evictionPolicy`
+| Eviction policy (only cache service?).
+| `Reject` / `Evict`
+| false
+| `Evict`
+
+| `image`
+| Operator image
+| string
+| false
+| `jboss/infinispan-server:latest`
+
+| `replicationFactor`
+| Replication factor (only cache service?).
+| int32
+| false
+| `1`
+
+| `size`
+| Number of instances for a Infinispan resource.
+| int32
+| true
+|
+
+| `cluster`
+| Cluster configuration.
+| <<infinispanclusterspec>>
+| false
+|
+
+| `connector`
+| Connector configuration.
+| <<infinispanconnectorspec>>
+| false
+|
+
+| `container`
+| Per instance configuration.
+| <<infinispancontainerspec>>
+| false
+|
+
+| `datasources`
+| Datasource list
+| []<<infinispandatasourcespec>>
+| false
+|
+
+| `logging`
+| Logging categories
+| []<<infinispanloggingcategoryspec>>
+| false
+|
+
+| `management`
+| Management configuration.
+| <<infinispanmgmtspec>>
+| false
+|
+
+| `sites`
+| Cross-site configuration
+| <<infinispansitesspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanclusterspec]]
+#### `InfinispanClusterSpec`
+
+`InfinispanClusterSpec` configures how Infinispan instances talk to each other.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `encryption`
+| Enables cluster encryption.
+| <<infinispanencryptionspec>>
+| false
+|
+
+| `secret`
+| Enables cluster authentication.
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanencryptionspec]]
+##### `InfinispanEncryptionSpec`
+
+`InfinispanEncryptionSpec` configures how encryption between `InfinispanSpec` instances happens.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `type`
+| Type of encryption
+| `Symmetric` or `Asymmetric`
+| true
+|
+
+| `secret`
+| Encrypted secret information.
+Only required with `Symmetric` encryption type.
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanconnectorspec]]
+#### `InfinispanConnectorSpec`
+
+`InfinispanConnectorSpec` defines how Infinispan is accessed.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `secret`
+| Authenticates access to Infinispan connectors.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispancontainerspec]]
+#### `InfinispanContainerSpec`
+
+`InfinispanContainerSpec` is a specification of each Infinispan instance managed by `InfinispanSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `jvmOptionsAppend`
+| Extra JVM options to pass to each `Infinispan` container.
+| string
+| false
+|
+
+| `memory`
+| Memory allocated for each Infinispan container.
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-memory[here].
+| string
+| false
+| `512Mi`
+
+| `storage`
+| Storage per Infinispan container (only data grid service).
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
+| string
+| false
+| `1Gi`
+
+|=======================
+
+
+[[infinispandatasourcespec]]
+#### `InfinispanDatasourceSpec`
+
+`InfinispanDatasourceSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `name`
+| Name of datasource.
+| string
+| true
+|
+
+| `driver`
+| Driver for datasource.
+| string
+| true
+|
+
+| `secret`
+| Secret for accessing datasource.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispanloggingcategoryspec]]
+#### `InfinispanLoggingCategorySpec`
+
+`InfinispanLoggingCategorySpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `category`
+| Name of logging category.
+| string
+| true
+|
+
+| `level`
+| Logging level for category.
+| string
+| true
+|
+
+|=======================
+
+
+[[infinispanmgmtspec]]
+#### `InfinispanManagementSpec`
+
+`InfinispanManagementSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `prometheus`
+| Enable prometheus.
+| boolean
+| false
+| false
+
+| `secret`
+| Management authentication information.
+| <<infinispansecretspec>>
+| true
+|
+
+|=======================
+
+
+[[infinispansitesspec]]
+#### `InfinispanSitesSpec`
+
+`InfinispanSpitesSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `local`
+| Local site information.
+| <<infinispanlocalsitespec>>
+| true
+|
+
+| `remotes`
+| Remote site information.
+| []<<infinispanremotesitespec>>
+| true
+|
+
+|=======================
+
+
+[[infinispanlocalsitespec]]
+#### `InfinispanLocalSiteSpec`
+
+`InfinispanLocalSiteSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `externalService`
+| External service that is accessible from other sites.
+| https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#service-v1-core[coreV1.Service]
+| true
+|
+
+|=======================
+
+
+[[infinispanremotesitespec]]
+#### `InfinispanRemoteSiteSpec`
+
+`InfinispanRemoteSiteSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `name`
+| Name of remote site.
+| string
+| true
+|
+
+| `type`
+| Type of remote site configuration.
+| `Static` or `Dynamic`
+| true
+|
+
+| `host`
+| Remote site host name.
+| string
+| true
+|
+
+| `port`
+| Remote site host port (only for `Static` type).
+| int32
+| false
+|
+
+| `secret`
+| Secret to connect to remote site (only for `Dynamic` type).
+| <<infinispansecretspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispansecretspec]]
+##### `InfinispanSecretSpec`
+
+`InfinispanSecretSpec` defines how `InfinispanSpec` secrets are configured.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `type`
+| Type of secret.
+| `Credentials`, `Keystore` or `Token`
+| true
+|
+
+| `secretName`
+| Name of referenced secret.
+| string
+| true
+|
+
+|=======================
+
+If type is `Credentials`, Secret` is expected to contain username and password credentials.
+These would be defined in `stringData/username` and `stringData/password` fields respectively.
+
+If type is `Keystore`, `Secret` is expected to contain base64 encoded data in `data/keystore.p12` field.
+Optional keystore password would be located in `stringData/password` field.
+
+If type is `Token`, `Secret` is expected to contain base64 encoded data in `stringData/token` field.
+
+
+[[infinispanstatus]]
+### `InfinispanStatus`
+
+`InfinispanStatus` is the most recent observed status of the `InfinispanSpec`. Read-only.
+
+TODO: @Vittorio, update with your proposal
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `pods`
+| Status of the pods.
+| []<<podstatus>>
+| true
+
+|=======================
+
+
+[[podstatus]]
+#### `PodStatus`
+
+`PodStatus` is the most recent observed status of a pod running `InfinispanSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required
+
+| `name`
+| Name of the Pod.
+| string
+| true
+
+| `podIP`
+| IP address allocated to the pod.
+| string
+| true
+
+|=======================
+
+## Full Example
+
+.full-example.yaml
+[source,yaml]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: full-example-infinispan
+spec:
+  evictionPolicy: Reject
+  image: jboss/infinispan-server:latest
+  replicationFactory: 3
+  size: 4
+  cluster:
+    encryption:
+      type: Symmetric
+      secret:
+        type: Keystore
+        secretName: cluster-encrypt-secret
+    secret:
+      type: Credentials
+      secretName: cluster-auth-secret
+  connector:
+    secret:
+      type: Credentials
+      secretName: connect-auth-secret
+  container:
+    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    memory: 1Gi
+    storage: 2Gi
+  datasources:
+  - name: test-pg
+    driver: postgresql
+    secret:
+      type: Credentials
+      secretName: postgresql-secret
+  - name: test-mysql
+    driver: mysql
+    secret:
+      type: Credentials
+      secretName: mysql-secret
+  logging:
+  - category: org.infinispan
+    level: trace
+  - category: org.jgroups
+    level: trace
+  management:
+    prometheus: true
+    secret:
+      type: Credentials
+      secretName: mgmt-secret
+  sites:
+    local:
+      externalService:
+        type: LoadBalancer
+        ports:
+          port: 12345
+    remotes:
+    - name: google
+      type: Static
+      host: google.host
+      port: 23456
+    - name: azure
+      type: Dynamic
+      host: azure.host
+      secret:
+        type: Credentials
+        secretName: azure-secret
+    - name: aws
+      type: Dynamic
+      secret:
+        type: Token
+        secretName: aws-secret
+----
+
+.cluster-encrypt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-encrypt-secret
+type: Opaque
+data:
+  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
+stringData:
+  password: opensesame
+----
+
+.cluster-auth-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cluster-auth-secret
+type: Opaque
+stringData:
+  password: clusterpass
+----
+
+.connect-auth-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: connect-auth-secret
+type: Opaque
+stringData:
+  username: connectusr
+  password: connectpass
+----
+
+.postgresql-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgresql-secret
+type: Opaque
+stringData:
+  username: pgusr
+  password: pgpass
+----
+
+.mysql-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secret
+type: Opaque
+stringData:
+  username: myusr
+  password: mypass
+----
+
+.mgmt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mgmt-secret
+type: Opaque
+stringData:
+  username: mgmtusr
+  password: mgmtpass
+----
+
+.azure-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: azure-secret
+type: Opaque
+stringData:
+  username: azusr
+  password: azpass
+----
+
+.aws-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: aws-secret
+type: Opaque
+stringData:
+  token: "jd1r/deZpYmY/mpvofUKWQ=="
+----

--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -43,33 +43,33 @@ This document describes the types introduced by the Infinispan Operator to be co
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `evictionPolicy`
-| Eviction policy (only cache service?).
-| `Reject` / `Evict`
-| false
-| `Evict`
-
 | `image`
 | Operator image
 | string
 | false
 | `jboss/infinispan-server:latest`
 
-| `replicationFactor`
-| Replication factor (only cache service?).
-| int32
-| false
-| `1`
-
-| `size`
+| `replicas`
 | Number of instances for a Infinispan resource.
 | int32
 | true
 |
 
-| `cluster`
-| Cluster configuration.
-| <<infinispanclusterspec>>
+| `profile`
+| Profile in use. See <<infinispanprofiles,profiles>> for details.
+| `Secured` / `Performance` / `Development`
+| false
+| `Secured`
+
+| `cache`
+| Cache configuration.
+| <<infinispancachespec>>
+| false
+|
+
+| `datagrid`
+| Datagrid configuration.
+| <<infinispandatagridspec>>
 | false
 |
 
@@ -85,12 +85,6 @@ This document describes the types introduced by the Infinispan Operator to be co
 | false
 |
 
-| `datasources`
-| Datasource list
-| []<<infinispandatasourcespec>>
-| false
-|
-
 | `logging`
 | Logging categories
 | []<<infinispanloggingcategoryspec>>
@@ -103,59 +97,57 @@ This document describes the types introduced by the Infinispan Operator to be co
 | false
 |
 
-| `sites`
-| Cross-site configuration
-| <<infinispansitesspec>>
-| false
-|
-
 |=======================
 
 
-[[infinispanclusterspec]]
-#### `InfinispanClusterSpec`
+[[infinispancachespec]]
+#### `InfinispanCacheSpec`
 
-`InfinispanClusterSpec` configures how Infinispan instances talk to each other.
+`InfinispanCacheSpec` configures how Infinispan is used as a cache.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `encryption`
-| Enables cluster encryption.
-| <<infinispanencryptionspec>>
+| `evictionPolicy`
+| Eviction policy
+| `Reject` / `Evict`
 | false
-|
+| `Evict`
 
-| `secret`
-| Enables cluster authentication.
-| <<infinispansecretspec>>
+| `replicationFactor`
+| Replication factor
+| int32
 | false
-|
+| `1`
 
 |=======================
 
 
-[[infinispanencryptionspec]]
-##### `InfinispanEncryptionSpec`
+[[infinispanprofiles]]
 
-`InfinispanEncryptionSpec` configures how encryption between `InfinispanSpec` instances happens.
+#### Profiles
 
 [options="header,footer"]
 |=======================
-| Field | Description | Scheme | Required | Default
+| Profile | Connector Authentication | Connector Encryption | Cluster Authentication | Cluster Encryption
 
-| `type`
-| Type of encryption
-| `Symmetric` or `Asymmetric`
-| true
+| `Secured`
+| X
+| X
+| X
+| X
+
+| `Performance`
+| X
+| X
+| X
 |
 
-| `secret`
-| Encrypted secret information.
-Only required with `Symmetric` encryption type.
-| <<infinispansecretspec>>
-| false
+| `Development`
+|
+|
+|
 |
 
 |=======================
@@ -170,10 +162,10 @@ Only required with `Symmetric` encryption type.
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `secret`
+| `authentication`
 | Authenticates access to Infinispan connectors.
-| <<infinispansecretspec>>
-| true
+| <<infinispanauthenticationspec>>
+| false
 |
 
 |=======================
@@ -194,6 +186,14 @@ Only required with `Symmetric` encryption type.
 | false
 |
 
+| `cpu`
+| CPU allocated for each Infinispan container.
+Described as indicated
+https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu[here].
+| string
+| false
+| `500m`
+
 | `memory`
 | Memory allocated for each Infinispan container.
 Described as indicated
@@ -202,13 +202,37 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | false
 | `512Mi`
 
+|=======================
+
+
+[[infinispandatagridspec]]
+#### `InfinispanDatagridSpec`
+
+`InfinispanDatagridSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
 | `storage`
-| Storage per Infinispan container (only data grid service).
+| Storage per Infinispan container.
 Described as indicated
 https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#local-ephemeral-storage[here].
 | string
 | false
 | `1Gi`
+
+| `datasources`
+| Datasource list
+| []<<infinispandatasourcespec>>
+| false
+|
+
+| `sites`
+| Cross-site configuration
+| <<infinispansitesspec>>
+| false
+|
 
 |=======================
 
@@ -234,33 +258,45 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | true
 |
 
-| `secret`
-| Secret for accessing datasource.
-| <<infinispansecretspec>>
+| `authentication`
+| Authentication information for accessing datasource.
+| <<infinispanauthenticationspec>>
 | true
 |
 
 |=======================
 
 
-[[infinispanloggingcategoryspec]]
-#### `InfinispanLoggingCategorySpec`
+[[infinispanloggingspec]]
+#### `InfinispanLoggingSpec`
 
-`InfinispanLoggingCategorySpec`.
+`InfinispanLoggingSpec` configures logging.
 
 [options="header,footer"]
 |=======================
 | Field | Description | Scheme | Required | Default
 
-| `category`
-| Name of logging category.
-| string
-| true
+| `categories`
+| Logging categories
+| <<infinispanloggingcategoriesspec>>
+| false
 |
 
-| `level`
-| Logging level for category.
-| string
+|=======================
+
+
+[[infinispanloggingcategoriesspec]]
+#### `InfinispanLoggingCategoriesSpec`
+
+`InfinispanLoggingCategoriesSpec` configures logging categories.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `<category-name>`
+| Logging category name, e.g. `org.infinispan`
+| `error` / `warn` / `info` / `debug` / `trace`
 | true
 |
 
@@ -277,16 +313,34 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | Field | Description | Scheme | Required | Default
 
 | `prometheus`
+| Prometheus configuration.
+| <<infinispanprometheusspec>>
+| false
+|
+
+| `authentication`
+| Management authentication information.
+| <<infinispanauthenticationspec>>
+| false
+|
+
+|=======================
+
+
+[[infinispanprometheusspec]]
+#### `InfinispanPrometheusSpec`
+
+`InfinispanPrometheusSpec`.
+
+[options="header,footer"]
+|=======================
+| Field | Description | Scheme | Required | Default
+
+| `enabled`
 | Enable prometheus.
 | boolean
 | false
 | false
-
-| `secret`
-| Management authentication information.
-| <<infinispansecretspec>>
-| true
-|
 
 |=======================
 
@@ -366,19 +420,19 @@ https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-conta
 | false
 |
 
-| `secret`
-| Secret to connect to remote site (only for `Dynamic` type).
-| <<infinispansecretspec>>
+| `authentication`
+| Authentication information to connect to remote site (only for `Dynamic` type).
+| <<infinispanauthenticationspec>>
 | false
 |
 
 |=======================
 
 
-[[infinispansecretspec]]
-##### `InfinispanSecretSpec`
+[[infinispanauthenticationspec]]
+##### `InfinispanAuthenticationSpec`
 
-`InfinispanSecretSpec` defines how `InfinispanSpec` secrets are configured.
+`InfinispanAuthenticationSpec` defines how authentication secrets are configured.
 
 [options="header,footer"]
 |=======================
@@ -447,106 +501,135 @@ TODO: @Vittorio, update with your proposal
 
 |=======================
 
-## Full Example
+## Full Cache Example
 
-.full-example.yaml
+.full-cache-example.yaml
 [source,yaml]
 ----
 apiVersion: infinispan.org/v1
 kind: Infinispan
 metadata:
-  name: full-example-infinispan
+  name: full-cache-example-infinispan
 spec:
-  evictionPolicy: Reject
   image: jboss/infinispan-server:latest
-  replicationFactory: 3
-  size: 4
-  cluster:
-    encryption:
-      type: Symmetric
-      secret:
-        type: Keystore
-        secretName: cluster-encrypt-secret
-    secret:
-      type: Credentials
-      secretName: cluster-auth-secret
+  replicas: 4
+  profile: Development
+  cache:
+    evictionPolicy: Reject
+    replicationFactor: 3
   connector:
-    secret:
+    authentication:
       type: Credentials
+      secretName: connect-secret
+  container:
+    jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    cpu: "2000m"
+    memory: 1Gi
+  logging:
+    categories:
+      org.infinispan: trace
+      org.jgroups: trace
+  management:
+    prometheus:
+      enabled: true
+    authentication:
+      type: Credentials
+      secretName: mgmt-secret
+----
+
+.connect-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: connect-secret
+type: Opaque
+stringData:
+  username: connectusr
+  password: connectpass
+----
+
+.mgmt-secret.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mgmt-secret
+type: Opaque
+stringData:
+  username: mgmtusr
+  password: mgmtpass
+----
+
+
+## Full DataGrid Example
+
+.full-datagrid-example.yaml
+[source,yaml]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: full-datagrid-example-infinispan
+spec:
+  image: jboss/infinispan-server:latest
+  replicas: 6
+  profile: Performance
+  datagrid:
+    storage: 2Gi
+    datasources:
+    - name: test-pg
+      driver: postgresql
+      authentication:
+        type: Credentials
+        secretName: postgresql-secret
+    - name: test-mysql
+      driver: mysql
+      authentication:
+        type: Credentials
+        secretName: mysql-secret
+    sites:
+      local:
+        externalService:
+          type: LoadBalancer
+          ports:
+            port: 12345
+      remotes:
+      - name: google
+        type: Static
+        host: google.host
+        port: 23456
+      - name: azure
+        type: Dynamic
+        host: azure.host
+        authentication:
+          type: Credentials
+          secretName: azure-secret
+      - name: aws
+        type: Dynamic
+        authentication:
+          type: Token
+          secretName: aws-secret
+  connector:
+    authentication:
+      type: Keystore
       secretName: connect-auth-secret
   container:
     jvmOptionsAppend: "-XX:NativeMemoryTracking=summary"
+    cpu: "1000m"
     memory: 1Gi
-    storage: 2Gi
-  datasources:
-  - name: test-pg
-    driver: postgresql
-    secret:
-      type: Credentials
-      secretName: postgresql-secret
-  - name: test-mysql
-    driver: mysql
-    secret:
-      type: Credentials
-      secretName: mysql-secret
   logging:
-  - category: org.infinispan
-    level: trace
-  - category: org.jgroups
-    level: trace
+    categories:
+      org.infinispan: debug
+      org.jgroups: debug
   management:
-    prometheus: true
-    secret:
+    prometheus:
+      enabled: true
+    authentication:
       type: Credentials
       secretName: mgmt-secret
-  sites:
-    local:
-      externalService:
-        type: LoadBalancer
-        ports:
-          port: 12345
-    remotes:
-    - name: google
-      type: Static
-      host: google.host
-      port: 23456
-    - name: azure
-      type: Dynamic
-      host: azure.host
-      secret:
-        type: Credentials
-        secretName: azure-secret
-    - name: aws
-      type: Dynamic
-      secret:
-        type: Token
-        secretName: aws-secret
-----
-
-.cluster-encrypt-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-encrypt-secret
-type: Opaque
-data:
-  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
-stringData:
-  password: opensesame
-----
-
-.cluster-auth-secret.yaml
-[source,yaml]
-----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: cluster-auth-secret
-type: Opaque
-stringData:
-  password: clusterpass
 ----
 
 .connect-auth-secret.yaml
@@ -557,9 +640,8 @@ kind: Secret
 metadata:
   name: connect-auth-secret
 type: Opaque
-stringData:
-  username: connectusr
-  password: connectpass
+data:
+  keystore.p12: "FQSmxHHvFvrhEfKIq15axg=="
 ----
 
 .postgresql-secret.yaml


### PR DESCRIPTION
 Version 3 of the operator configuration design here. Noteworthy changes:

General
--------

* Renamed `.spec.container.jvmOptionsAppend` to `.spec.container.extraJvmOpts`.
* Prometheus always enabled, for all profiles. So option for enable/disable it in `.spec.management` gone.
* Datasources gone, these are configured per cache, including their credentials.
* Renamed `Secured` profile to `Default` profile.
* Data grid/cache service selection cannot be combined, so reworked configuration so that you choose one or the other. Both cannot be configured at the same time.

Security
--------

* Reworked security with a secret containing all private information related to identities. This means that management specific authentication has been removed.
* `.spec.management` removed since no separate options are configured for it anymore.
* Secret defines identities that can be `credentials`, `certificate`, `token` or `oauth` type of authentication.
* Each identity can have a list of roles associated to it, except for oauth (roles are defined in keycloak).
* Security configuration added in operator which predefined list of roles.
* Data grid storage has been moved to be under `.spec.service.container.storage`. This has been done because storage is a per-container setting only for data grid service. Adding `.container` makes it clear that is per-container, and not a global storage option for all pods to share.
* Added role definitions in operator along with permissions for each role.
* Identities (except oauth and token) can optionally define the roles that are associated with this identity.

X-Site
------

* xsite static configuration has become url: `xsite://...` format, where the host:port combination define the static external host:port combination.
* xsite dynamic configuration has become url: `openshift://...` format, where host:port combinations define the dynamic nature of remote openshift instances. Operator will connect remotely and figure out what the external host:port is, and it will configure infinispan with that.
* Remote sites that use openshift scheme must have a secret defined. The secret can contain `credentials` and/or `token` to connect to openshift instances

Notes
------
* It's desirable for the operator to be configurable to expose external routes, for HTTP REST and Hot Rod endpoints. However, doing this is non-trivial. So, this is not considered in the formal specification at this stage. The user can always create (based on documentation) external routes,
so not having easy to configure external routes in operator is not a show stopper. More details to come.