### PR TITLE
React on changes to Connector, Management, Container #81

### DIFF
--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -49,8 +49,11 @@ type InfinispanCondition struct {
 // InfinispanStatus defines the observed state of Infinispan
 type InfinispanStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Conditions      []InfinispanCondition `json:"conditions"`
-	StatefulSetName string                `json:"statefulSetName"`
+	Conditions      []InfinispanCondition    `json:"conditions"`
+	StatefulSetName string                   `json:"statefulSetName"`
+	Connector       InfinispanConnectorInfo  `json:"connector"`
+	Management      InfinispanManagementInfo `json:"management"`
+	Container       InfinispanContainerSpec  `json:"container"`
 }
 
 type Config struct {

--- a/pkg/apis/infinispan/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/infinispan/v1/zz_generated.deepcopy.go
@@ -243,6 +243,9 @@ func (in *InfinispanStatus) DeepCopyInto(out *InfinispanStatus) {
 		*out = make([]InfinispanCondition, len(*in))
 		copy(*out, *in)
 	}
+	out.Connector = in.Connector
+	out.Management = in.Management
+	out.Container = in.Container
 	return
 }
 


### PR DESCRIPTION
Changes to the Spec.<Connector|Management|Container> are propagated to the StatefulSet and applied with a RollingUpgrade strategy.

This PR watches only the infinispan CR fields: i.e. secretName change is detected, but changes in the secret content aren't.