### PR TITLE
User can add extra java option via yaml

### DIFF
--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -22,9 +22,9 @@ type InfinispanManagementInfo struct {
 
 // InfinispanContainerSpec specify resource requirements per container
 type InfinispanContainerSpec struct {
-	JvmOptionsAppend string `json:"jvmOptionsAppend"`
-	Memory           string `json:"memory"`
-	CPU              string `json:"cpu"`
+	ExtraJvmOpts string `json:"extraJvmOpts"`
+	Memory       string `json:"memory"`
+	CPU          string `json:"cpu"`
 }
 
 // InfinispanSpec defines the desired state of Infinispan

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -242,6 +242,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 	envVars := []corev1.EnvVar{
 		{Name: "CONFIG_PATH", Value: "/etc/config/infinispan.yaml"},
 		{Name: "IDENTITIES_PATH", Value: "/etc/security/identities.yaml"},
+		{Name: "JAVA_OPTIONS", Value: m.Spec.Container.ExtraJvmOpts},
 	}
 
 	// Adding additional variables listed in ADDITIONAL_VARS env var


### PR DESCRIPTION
This PR changes the name for the additional java opts to `extraJvmOpts` and adds code to pass that info to the container image into the JAVA_OPTIONS envvar.
