### PR TITLE
Self signed cert handling #131

### DIFF
--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -35,6 +35,7 @@ type InfinispanSpec struct {
 	Image     string                  `json:"image"`
 	Security  InfinispanSecurity      `json:"security"`
 	Container InfinispanContainerSpec `json:"container"`
+	Profile   string                  `json:"profile"`
 }
 
 // InfinispanCondition define a condition of the cluster

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -487,6 +487,11 @@ func setupConfigForEncryption(m *infinispanv1.Infinispan, c *ispnutil.Infinispan
 			c.Keystore.Alias = "server"
 		}
 	}
+	// If no service nor tls secret name are provided
+	// and the user profile is Development. Request a self signed certificate
+	if m.Spec.Profile == "Development" {
+		c.Keystore.SelfSignCert = true
+	}
 	return nil
 }
 

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -454,7 +454,7 @@ func setupConfigForEncryption(m *infinispanv1.Infinispan, c *ispnutil.Infinispan
 	if ee.Type == "service" {
 		if strings.Contains(ee.CertService, "openshift.io") {
 			c.Keystore.CrtPath = "/etc/encrypt"
-			c.Keystore.Path = "/opt/infinispan/server/conf/keystore"
+			c.Keystore.Path = "/opt/infinispan/server/conf/keystore.p12"
 			c.Keystore.Password = "password"
 			c.Keystore.Alias = "server"
 			return nil
@@ -482,7 +482,7 @@ func setupConfigForEncryption(m *infinispanv1.Infinispan, c *ispnutil.Infinispan
 		} else {
 			// ... else suppose tls.key and tls.crt are provided
 			c.Keystore.CrtPath = "/etc/encrypt"
-			c.Keystore.Path = "/opt/infinispan/server/conf/keystore"
+			c.Keystore.Path = "/opt/infinispan/server/conf/keystore.p12"
 			c.Keystore.Password = "password"
 			c.Keystore.Alias = "server"
 		}

--- a/pkg/controller/infinispan/util/configuration.go
+++ b/pkg/controller/infinispan/util/configuration.go
@@ -13,11 +13,11 @@ type InfinispanConfiguration struct {
 
 // Keystore configuration info for connector encryption
 type Keystore struct {
-	Path         string
-	Password     string
-	Alias        string
+	Path     string `yaml:"path,omitempty"`
+	Password string `yaml:"password,omitempty"`
+	Alias    string `yaml:"alias,omitempty"`
 	CrtPath      string `yaml:"crtPath,omitempty"`
-	SelfSignCert bool   `yaml:"selfSignCert"`
+	SelfSignCert bool   `yaml:"selfSignCert,omitempty"`
 }
 
 // JGroups configures clustering layer

--- a/pkg/controller/infinispan/util/configuration.go
+++ b/pkg/controller/infinispan/util/configuration.go
@@ -13,10 +13,11 @@ type InfinispanConfiguration struct {
 
 // Keystore configuration info for connector encryption
 type Keystore struct {
-	Path     string
-	Password string
-	Alias    string
-	CrtPath  string `yaml:"crtPath,omitempty"`
+	Path         string
+	Password     string
+	Alias        string
+	CrtPath      string `yaml:"crtPath,omitempty"`
+	SelfSignCert bool   `yaml:"selfSignCert"`
 }
 
 // JGroups configures clustering layer

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -111,6 +111,34 @@ func TestClusterFormationWithTLS(t *testing.T) {
 	waitForPodsOrFail(name, "https")
 }
 
+// Test if the cluster is working correctly
+func TestClusterFormationWithTLSSelfSign(t *testing.T) {
+	// Create a resource without passing any config
+	name := "test-cluster-formation"
+	spec := ispnv1.Infinispan{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infinispan.org/v1",
+			Kind:       "Infinispan",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: ispnv1.InfinispanSpec{
+			Container: ispnv1.InfinispanContainerSpec{
+				CPU:    CPU,
+				Memory: Memory,
+			},
+			Image:    getEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server"),
+			Replicas: 2,
+			Profile:  "Development",
+		},
+	}
+	// Register it
+	kubernetes.CreateInfinispan(&spec, Namespace)
+	defer kubernetes.DeleteInfinispan(&spec, SinglePodTimeout)
+	waitForPodsOrFail(name, "https")
+}
+
 func waitForPodsOrFail(name, protocol string) {
 	// Wait that 2 pods are up
 	kubernetes.WaitForPods("app=infinispan-pod", 2, SinglePodTimeout, Namespace)


### PR DESCRIPTION
This enables the generation of self signed certificates by Infinispan.
To have self signed certificates user must:
- set spec.profile = Development
- not provide any certificates, keystore nor platform service

This must go after:
 https://github.com/infinispan/infinispan-image-artifacts/pull/1

Relates to:
https://github.com/infinispan/infinispan-images/issues/15
https://github.com/infinispan/infinispan-operator/issues/131
