### PR TITLE
Quick fix to avoid operator crash

### DIFF
--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -4,4 +4,4 @@ KUBECONFIG=${1-openshift.local.clusterup/openshift-apiserver/admin.kubeconfig}
 
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
-GOCACHE=off go test -v ./test/e2e
+GOCACHE=off go test -timeout 15m -v ./test/e2e

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -246,16 +246,19 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 	res := &found.Spec.Template.Spec.Containers[0].Resources
 	env := &found.Spec.Template.Spec.Containers[0].Env
 	ispnContr := &infinispan.Spec.Container
-	quantity := resource.MustParse(ispnContr.Memory)
-	if quantity.Cmp(res.Requests["memory"]) != 0 {
-		res.Requests["memory"] = quantity
-		updateNeeded = true
+	if ispnContr.Memory != "" {
+		quantity := resource.MustParse(ispnContr.Memory)
+		if quantity.Cmp(res.Requests["memory"]) != 0 {
+			res.Requests["memory"] = quantity
+			updateNeeded = true
+		}
 	}
-
-	quantity = resource.MustParse(ispnContr.CPU)
-	if quantity.Cmp(res.Requests["cpu"]) != 0 {
-		res.Requests["cpu"] = quantity
-		updateNeeded = true
+	if ispnContr.CPU != "" {
+		quantity := resource.MustParse(ispnContr.CPU)
+		if quantity.Cmp(res.Requests["cpu"]) != 0 {
+			res.Requests["cpu"] = quantity
+			updateNeeded = true
+		}
 	}
 
 	index := 0


### PR DESCRIPTION
This is a quick fix to avoid operator break when parsing resources.
Full fix will come, I'll merge this if green CI.
Also increased test timeout 10m seems not enough with test on updates