### PR TITLE
Use Kubernetes-in-docker (kind) in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+go:
+  - '1.11.x'
+
 sudo: required
 
 services:
@@ -9,13 +12,6 @@ cache:
   directories:
   - $GOPATH/pkg/dep
 
-env:
-  global:
-    - VM_DRIVER=none
-    - KUBE_VERSION=v1.15.0
-    - MINIKUBE_VERSION=v1.2.0
-    - CHANGE_MINIKUBE_NONE_USER=true
-
 jobs:
   include:
     - stage: "Unit Test"
@@ -23,16 +19,7 @@ jobs:
       script:
         - go get -u github.com/golang/dep/cmd/dep
         - make unit-test
-    - stage: "Test"
-      name: "OpenShift"
-      script:
-        - go get -u github.com/golang/dep/cmd/dep
-        - ci/start-okd-4.0.0.sh
-        - make test KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig
-        - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get pods --all-namespaces
-        - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get events --all-namespaces
-        - docker ps -a
-        - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
+
 #    - stage: "Test"
 #      env:
 #        - WATCH_NAMESPACE=namespace-for-testing
@@ -62,27 +49,20 @@ jobs:
 #        - KUBECONFIG=/tmp/openshift-dind-cluster/openshift/openshift.local.config/master/admin.kubeconfig ./oc get events --all-namespaces
 #        - docker ps -a
 #        - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
-#    - stage: "Test"
-#      env:
-#        - 'INFINISPAN_CPU=0.25'
-#        - INFINISPAN_MEMORY=384Mi
-#      name: "Minikube"
-#      dist: xenial
-#      script:
-#        - go get -u github.com/golang/dep/cmd/dep
-#        - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl
-#        - chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-#        - curl -Lo minikube https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
-#        - chmod +x minikube && sudo mv minikube /usr/local/bin/
-#        - sudo minikube start --vm-driver=none --kubernetes-version=${KUBE_VERSION}
-#        - minikube update-context
-#        - JSONPATH='{range .items[*]}{@.metadata.name}:{range @.status.conditions[*]}{@.type}={@.status};{end}{end}'; until kubectl get nodes -o jsonpath="$JSONPATH" 2>&1 | grep -q "Ready=True"; do sleep 1; done
-#        - make test KUBECONFIG=${HOME}/.kube/config
-#        - kubectl get events --all-namespaces
-#        - kubectl cluster-info
-#        - df -h
-#        - sudo minikube status
-#        - sudo minikube logs
-#        - docker ps -a
-#        - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done
-#        - sudo minikube stop
+
+    - stage: "Test"
+      name: "Kubernetes"
+      before_script:
+        - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        - GO111MODULE=on go get sigs.k8s.io/kind
+        - kind create cluster --config kind-config.yaml
+        - export KUBECONFIG="$(kind get kubeconfig-path)"
+      script:
+        - go get -u github.com/golang/dep/cmd/dep
+        - make test
+      after_failure:
+        - kubectl get events --all-namespaces
+        - kubectl cluster-info
+        - df -h
+        - docker ps -a
+        - for log in $(docker ps -qa | xargs); do docker logs --tail 500 $log; done

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,7 @@
+kind: Cluster
+apiVersion: kind.sigs.k8s.io/v1alpha3
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30222
+        hostPort: 11222

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -725,12 +725,15 @@ func (r *ReconcileInfinispan) serviceExternal(internalService *corev1.Service, m
 			Namespace: m.ObjectMeta.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			Type:     corev1.ServiceTypeLoadBalancer,
+			// TODO: temporarily set to NodePort to make kind work (soon it'll be configurable)
+			Type:     corev1.ServiceTypeNodePort,
 			Selector: internalService.Spec.Selector,
 			Ports: []corev1.ServicePort{
 				{
 					Port:       int32(11222),
 					TargetPort: intstr.FromInt(11222),
+					// Fix NodePort to match exported port in kind configuration
+					NodePort: int32(30222),
 				},
 			},
 		},

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -308,7 +308,7 @@ func TestExternalService(t *testing.T) {
 
 	routeName := fmt.Sprintf("%s-external", name)
 	client := &http.Client{}
-	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, Namespace)
+	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
 
 	cacheName := "test"
 	createCache(cacheName, usr, pass, hostAddr, client)
@@ -404,7 +404,7 @@ func TestExternalServiceWithAuth(t *testing.T) {
 func testAuthentication(name, usr, pass string) {
 	routeName := fmt.Sprintf("%s-external", name)
 	client := &http.Client{}
-	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, Namespace)
+	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
 
 	cacheName := "test"
 	createCacheBadCreds(cacheName, "badUser", "badPass", hostAddr, client)


### PR DESCRIPTION
* Use custom kind configuration so that port forward can be enabled,
to enable external services to be acessible.
* Custom kind configuration exposes nodeport 30222 on port 11222.
* If running kind, check external services via 127.0.0.1:11222.
* Disable OpenShift (dind) 4 testing.
* Remove CPU/memory limitations for Infinispan with kind.
* No longer running a VM, so such strict Infinispan server pod limitations
should not be needed.
* Fix check address so that Infinispan 10 endpoints are checked.