### PR TITLE
Improve `kubectl wait` integration

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -116,6 +116,10 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		return reconcile.Result{}, err
 	}
 
+	if infinispan.Status.Conditions == nil {
+		infinispan.Status.Conditions = []infinispanv1.InfinispanCondition{}
+	}
+
 	// Check if the deployment already exists, if not create a new one
 	found := &appsv1beta1.StatefulSet{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: infinispan.Name, Namespace: infinispan.Namespace}, found)

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -308,6 +308,11 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
+	// View didn't form, requeue until view has formed
+	if currConds[0].Status == "False" {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
 	// Check if pods container runs the right image
 	for _, item := range podList.Items {
 		if len(item.Spec.Containers) == 1 {


### PR DESCRIPTION
So that we can consistently rely on:

```
kubectl wait --for condition=wellFormed --timeout=120s infinispan/example-infinispan
```

It offers a way to wait until the pods are up and the expected cluster forms.

Fixes #184 and #187.