### PR TITLE
Graceful shutdown #137

### DIFF
--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -55,6 +55,13 @@ This document describes the types introduced by the Infinispan Operator to be co
 | true
 |
 
+| `clusterStatus`
+| Desired cluster status. Can be `STARTED`(default) for a running cluster or
+`STOPPED` for graceful shutdown process.
+| `STARTED`/`STOPPED`
+| false
+| `STARTED`
+
 | `profile`
 | Profile in use. See <<infinispanprofiles,profiles>> for details.
 | `Default` / `Performance` / `Development`

--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -103,9 +103,10 @@ type InfinispanCondition struct {
 // InfinispanStatus defines the observed state of Infinispan
 type InfinispanStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	Conditions      []InfinispanCondition `json:"conditions"`
-	StatefulSetName string                `json:"statefulSetName"`
-	Security        InfinispanSecurity    `json:"security"`
+	Conditions              []InfinispanCondition `json:"conditions"`
+	StatefulSetName         string                `json:"statefulSetName"`
+	Security                InfinispanSecurity    `json:"security"`
+	ReplicasWantedAtRestart int32                 `json:"replicasWantedAtRestart,omitempty"`
 }
 
 // +genclient

--- a/pkg/apis/infinispan/v1/types_util.go
+++ b/pkg/apis/infinispan/v1/types_util.go
@@ -1,0 +1,42 @@
+package v1
+
+// GetCondition return true if condition == status
+func (ispn *Infinispan) GetCondition(condition string) *string {
+	for _, c := range ispn.Status.Conditions {
+		if c.Type == condition {
+			return &c.Status
+		}
+	}
+	return nil
+}
+
+// SetCondition set condition to status
+func (ispn *Infinispan) SetCondition(condition, status, message string) bool {
+	changed := false
+	for idx := range ispn.Status.Conditions {
+		c := &ispn.Status.Conditions[idx]
+		if c.Type == condition {
+			if c.Status != status {
+				c.Status = status
+				changed = true
+			}
+			if c.Message != message {
+				c.Message = message
+				changed = true
+			}
+
+			return changed
+		}
+	}
+	ispn.Status.Conditions = append(ispn.Status.Conditions, InfinispanCondition{Type: condition, Status: status, Message: message})
+	return true
+}
+
+// SetConditions set provided conditions to status
+func (ispn *Infinispan) SetConditions(conds []InfinispanCondition) bool {
+	changed := false
+	for _, c := range conds {
+		changed = changed || ispn.SetCondition(c.Type, c.Status, c.Message)
+	}
+	return changed
+}

--- a/pkg/controller/infinispan/infinispan_controller_test.go
+++ b/pkg/controller/infinispan/infinispan_controller_test.go
@@ -50,6 +50,10 @@ func (m mockCluster) GetClusterMembers(_, podName, _, _ string) ([]string, error
 	return nil, errors.New("error in getting view")
 }
 
+func (m mockCluster) GracefulShutdown(secretName, podName, namespace, protocol string) error {
+	return nil
+}
+
 // TestGetInfinispanConditions test for getInfinispanConditions func
 func TestGetInfinispanConditions(t *testing.T) {
 	var m mockCluster

--- a/pkg/controller/infinispan/util/security.go
+++ b/pkg/controller/infinispan/util/security.go
@@ -78,3 +78,4 @@ func FindPassword(usr string, descriptor []byte) (string, error) {
 func GetSecretName(name string) string {
 	return fmt.Sprintf("%v-generated-secret", name)
 }
+


### PR DESCRIPTION
Graceful shutdown implementation.
To graceful shutdown a cluster user has to set `spec.replicas=0` and change it to the value before he shutdown when he wants to restart. Data will be preserved for all the caches with file-store persistence, i.e.:
```
<infinispan>
<cache-container>
<distributed-cache name ="pcache">
<persistence>
<file-store/>
</persistence>
</distributed-cache>
</cache-container>
</infinispan>
```

Shutdown procedure is:
- disable pods restart
- set `stopping` condition to `True`
- send graceful shutdown to one pod
- wait for all the pods to be not-ready
- save the statefulset.spec.replicas into the infinispan.status.ReplicasWantedAtRestart field
- scale to 0
- wait for statefulset.status.currentReplicas=0
- set `gracefulShutdown` to `True` and `stopping` to `False`

Startup procedure:
- set `infinispan.spec.replicas`=same replicas num before shutdown
- set  `gracefulShutdown` to `False`
 