### PR TITLE
Pod limits, cache service and Go 1.13 compatibility

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -836,7 +836,7 @@
     "github.com/operator-framework/operator-sdk/pkg/k8sutil",
     "github.com/operator-framework/operator-sdk/version",
     "gopkg.in/yaml.v2",
-    "k8s.io/api/apps/v1beta1",
+    "k8s.io/api/apps/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/build/minikube/run-tests.sh
+++ b/build/minikube/run-tests.sh
@@ -4,4 +4,4 @@ NAMESPACE=${1}
 
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
-KUBECONFIG=${2-${HOME}/.kube/config} GOCACHE=off go test -v ./test/e2e
+KUBECONFIG=${2-${HOME}/.kube/config} GOCACHE=off go test -v ./test/e2e -timeout 15m

--- a/build/minikube/run-tests.sh
+++ b/build/minikube/run-tests.sh
@@ -4,4 +4,5 @@ NAMESPACE=${1}
 
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
-KUBECONFIG=${2-${HOME}/.kube/config} GOCACHE=off go test -v ./test/e2e -timeout 15m
+go clean -testcache
+KUBECONFIG=${2-${HOME}/.kube/config} go test -v ./test/e2e -timeout 15m

--- a/build/minikube/run-tests.sh
+++ b/build/minikube/run-tests.sh
@@ -5,4 +5,4 @@ NAMESPACE=${1}
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
 go clean -testcache
-KUBECONFIG=${2-${HOME}/.kube/config} go test -v ./test/e2e -timeout 15m
+KUBECONFIG=${2-${HOME}/.kube/config} go test -v ./test/e2e -timeout 30m

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -4,4 +4,4 @@ KUBECONFIG=${1-openshift.local.clusterup/openshift-apiserver/admin.kubeconfig}
 
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
-GOCACHE=off go test -timeout 15m -v ./test/e2e
+GOCACHE=off go test -timeout 15m -v ./test/e2e -timeout 15m

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -5,4 +5,4 @@ KUBECONFIG=${1-openshift.local.clusterup/openshift-apiserver/admin.kubeconfig}
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
 go clean -testcache
-go test -v ./test/e2e -timeout 15m
+go test -v ./test/e2e -timeout 30m

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -4,4 +4,5 @@ KUBECONFIG=${1-openshift.local.clusterup/openshift-apiserver/admin.kubeconfig}
 
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
-GOCACHE=off go test -timeout 15m -v ./test/e2e -timeout 15m
+go clean -testcache
+go test -v ./test/e2e -timeout 15m

--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -111,7 +111,7 @@ while `LoadBalancer` is used in production-like environments where an external l
 
 | `type`
 | Type of service
-| `Cache` / `Data Grid`
+| `Cache` / `DataGrid`
 | true
 | `Cache`
 
@@ -662,7 +662,7 @@ spec:
   replicas: 6
   profile: Performance
   service:
-    type: Data Grid
+    type: DataGrid
     container:
       storage: 2Gi
     sites:

--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -28,9 +28,26 @@ type InfinispanServiceContainerSpec struct {
 	Storage string `json:"storage"`
 }
 
+type ServiceType string
+
+const (
+	// Deploys Infinispan to act like a cache. This means:
+	// Caches are only used for volatile data.
+	// No support for data persistence.
+	// Cache definitions can still be permanent, but PV size is not configurable.
+	// A default cache is created by default,
+	// Additional caches can be created, but only as copies of default cache.
+	ServiceTypeCache ServiceType = "Cache"
+
+	// Deploys Infinispan to act like a data grid.
+	// More flexibility and more configuration options are available:
+	// Cross-site replication, store cached data in persistence store...etc.
+	ServiceTypeDataGrid ServiceType = "DataGrid"
+)
+
 // InfinispanServiceSpec specify configuration for specific service
 type InfinispanServiceSpec struct {
-	Type      string                         `json:"type"`
+	Type      ServiceType                    `json:"type"`
 	Container InfinispanServiceContainerSpec `json:"container"`
 	Sites     InfinispanSitesSpec            `json:"sites"`
 }

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -8,7 +8,7 @@ import (
 	infinispanv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	ispnutil "github.com/infinispan/infinispan-operator/pkg/controller/infinispan/util"
 	"gopkg.in/yaml.v2"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -86,7 +86,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// TODO(user): Modify this to be the types you create that are owned by the primary resource
 	// Watch for changes to secondary resource Pods and requeue the owner Infinispan
-	err = c.Watch(&source.Kind{Type: &appsv1beta1.StatefulSet{}}, &handler.EnqueueRequestForOwner{
+	err = c.Watch(&source.Kind{Type: &appsv1.StatefulSet{}}, &handler.EnqueueRequestForOwner{
 		IsController: true,
 		OwnerType:    &infinispanv1.Infinispan{},
 	})
@@ -143,7 +143,7 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Check if the deployment already exists, if not create a new one
-	found := &appsv1beta1.StatefulSet{}
+	found := &appsv1.StatefulSet{}
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: infinispan.Name, Namespace: infinispan.Namespace}, found)
 	if err != nil && errors.IsNotFound(err) {
 		identities, err := r.findCredentials(infinispan)
@@ -564,7 +564,7 @@ func lookupHost(host string, logger logr.Logger) (string, error) {
 }
 
 // deploymentForInfinispan returns an infinispan Deployment object
-func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan, secret *corev1.Secret, configMap *corev1.ConfigMap) (*appsv1beta1.StatefulSet, error) {
+func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan, secret *corev1.Secret, configMap *corev1.ConfigMap) (*appsv1.StatefulSet, error) {
 	// This field specifies the flavor of the
 	// Infinispan cluster. "" is plain community edition (vanilla)
 	ls := labelsForInfinispan(m.ObjectMeta.Name)
@@ -615,7 +615,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 		}
 	}
 	replicas := m.Spec.Replicas
-	dep := &appsv1beta1.StatefulSet{
+	dep := &appsv1.StatefulSet{
 
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1beta1",
@@ -631,8 +631,8 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 			},
 			Labels: map[string]string{"template": "infinispan-ephemeral"},
 		},
-		Spec: appsv1beta1.StatefulSetSpec{
-			UpdateStrategy: appsv1beta1.StatefulSetUpdateStrategy{Type: appsv1beta1.RollingUpdateStatefulSetStrategyType},
+		Spec: appsv1.StatefulSetSpec{
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
 			Selector: &metav1.LabelSelector{
 				MatchLabels: ls,
 			},
@@ -789,7 +789,7 @@ func setupServiceForEncryption(m *infinispanv1.Infinispan, ser *corev1.Service) 
 	}
 }
 
-func setupVolumesForEncryption(m *infinispanv1.Infinispan, dep *appsv1beta1.StatefulSet) {
+func setupVolumesForEncryption(m *infinispanv1.Infinispan, dep *appsv1.StatefulSet) {
 	secretName := getEncryptionSecretName(m)
 	if secretName != "" {
 		v := &dep.Spec.Template.Spec.Volumes

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -276,6 +276,7 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		quantity := resource.MustParse(ispnContr.Memory)
 		if quantity.Cmp(res.Requests["memory"]) != 0 {
 			res.Requests["memory"] = quantity
+			res.Limits["memory"] = quantity
 			updateNeeded = true
 		}
 	}
@@ -283,6 +284,7 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		quantity := resource.MustParse(ispnContr.CPU)
 		if quantity.Cmp(res.Requests["cpu"]) != 0 {
 			res.Requests["cpu"] = quantity
+			res.Limits["cpu"] = quantity
 			updateNeeded = true
 		}
 	}
@@ -542,8 +544,16 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 							PeriodSeconds:       10,
 							SuccessThreshold:    1,
 							TimeoutSeconds:      80},
-						Resources: corev1.ResourceRequirements{Requests: corev1.ResourceList{"cpu": resource.MustParse(cpu),
-							"memory": resource.MustParse(memory)}},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"cpu":    resource.MustParse(cpu),
+								"memory": resource.MustParse(memory),
+							},
+							Limits: corev1.ResourceList{
+								"cpu":    resource.MustParse(cpu),
+								"memory": resource.MustParse(memory),
+							},
+						},
 						VolumeMounts: []corev1.VolumeMount{{
 							Name:      "config-volume",
 							MountPath: "/etc/config",

--- a/test/e2e/util/test_kubernetes.go
+++ b/test/e2e/util/test_kubernetes.go
@@ -7,7 +7,7 @@ import (
 	ispnv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	"github.com/infinispan/infinispan-operator/pkg/controller/infinispan/util"
 	"github.com/infinispan/infinispan-operator/pkg/launcher"
-	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -57,7 +57,7 @@ func init() {
 	addToScheme(&rbacv1.SchemeBuilder, scheme)
 	addToScheme(&apiextv1beta1.SchemeBuilder, scheme)
 	addToScheme(&ispnv1.SchemeBuilder.SchemeBuilder, scheme)
-	addToScheme(&appsv1beta1.SchemeBuilder, scheme)
+	addToScheme(&appsv1.SchemeBuilder, scheme)
 }
 
 func addToScheme(schemeBuilder *runtime.SchemeBuilder, scheme *runtime.Scheme) {


### PR DESCRIPTION
Several pieces of work:

* Set pod cpu/memory limits (#205), this is required to build the default cache used by cache service (#134).
* Add cache service support (#134).
* Update code to StatefulSet `app/v1` and make it compile/test on Go 1.13.