### PR TITLE
TLS on by default with service-ca available #190

### DIFF
--- a/pkg/controller/infinispan/util/kubernetes.go
+++ b/pkg/controller/infinispan/util/kubernetes.go
@@ -67,6 +67,7 @@ func NewKubernetesFromController(mgr manager.Manager) *Kubernetes {
 		restClient: restClient,
 		RestConfig: config,
 	}
+
 }
 
 // NewKubernetesFromMasterURL creates a new Kubernetes from the Kubernetes master URL to connect to
@@ -96,7 +97,6 @@ func (k Kubernetes) GetSecret(secretName, namespace string) (*v1.Secret, error) 
 	if err != nil {
 		return nil, err
 	}
-
 	return secret, err
 }
 
@@ -249,4 +249,16 @@ func (k Kubernetes) GetMaxMemoryUnboundedBytes(podName, namespace string) (uint6
 	}
 
 	return 0, fmt.Errorf("meminfo lacking MemTotal information")
+}
+
+// ServiceCAsCRDResourceExists returns true if the platform
+// has the servicecas.operator.openshift.io custom resource deployed
+// Used to check if serviceca operator is serving TLS certificates
+func (k Kubernetes) HasServiceCAsCRDResource() bool {
+	// Using an ad-hoc path
+	req := k.restClient.Get().AbsPath("apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/servicecas.operator.openshift.io")
+	result := req.Do()
+	var status int
+	result.StatusCode(&status)
+	return status >= 200 && status < 299
 }


### PR DESCRIPTION
Enable TLS by default if running on openshift and service-ca is available.
Certificates are stored in the secret specified by the field `infinispan.spec.security.endpointEncryption.certSecretName`, if not provided it will be set to `<clustername>-cert-secret`

If empty, fields under `infinispan.spec.security.endpointEncryption` will be populated accordingly. I.e.:
````
    security:
      endpointEncryption:
        certSecretName: example-infinispan-cert-secret
        certServiceName: service.beta.openshift.io
        type: service
````