### PR TITLE
Fix log info version print

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -8,7 +8,7 @@ GOOS=${1-linux}
 BIN_DIR=${2-$(pwd)/build/_output/bin}
 PROJECT_NAME="infinispan-operator"
 BUILD_PATH="./cmd/manager"
-VERSION="$(git describe --tags --always --dirty)"
-GO_LDFLAGS="-X ./version.Version=${VERSION}"
-echo "building ${PROJECT_NAME}..."
+VERSION=${RELEASE_NAME:-$(git describe --tags --always --dirty)}
+GO_LDFLAGS="-X github.com/infinispan/infinispan-operator/version.Version=${VERSION}"
+echo "building ${PROJECT_NAME}... version ${VERSION}"
 GOOS=${GOOS} GOARCH=amd64 CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} -ldflags "${GO_LDFLAGS}" $BUILD_PATH

--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,9 @@ require (
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/prometheus/client_golang v0.9.2 // indirect
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 // indirect
-	github.com/prometheus/common v0.2.0 // indirect
+	github.com/prometheus/common v0.2.0
 	github.com/prometheus/procfs v0.0.0-20190219184716-e4d4a2206da0 // indirect
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/atomic v1.3.2 // indirect
 	go.uber.org/multierr v1.1.0 // indirect
 	go.uber.org/zap v1.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -211,6 +211,7 @@ github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1l
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -4,9 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	infinispanv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	ispnutil "github.com/infinispan/infinispan-operator/pkg/controller/infinispan/util"
+	"github.com/infinispan/infinispan-operator/version"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,9 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"net"
-	"net/url"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -30,10 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	"sort"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var log = logf.Log.WithName("controller_infinispan")
@@ -119,7 +121,7 @@ type ReconcileInfinispan struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling Infinispan")
+	reqLogger.Info("Reconciling Infinispan. Operator Version: " + version.Version)
 
 	// Fetch the Infinispan instance
 	infinispan := &infinispanv1.Infinispan{}

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -3,13 +3,16 @@ package launcher
 import (
 	"flag"
 	"fmt"
-	"github.com/infinispan/infinispan-operator/pkg/apis"
-	"github.com/infinispan/infinispan-operator/pkg/controller"
-	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
-	sdkVersion "github.com/operator-framework/operator-sdk/version"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // blank import (?)
+	"github.com/spf13/pflag"
 	"os"
 	"runtime"
+
+	"github.com/infinispan/infinispan-operator/pkg/apis"
+	"github.com/infinispan/infinispan-operator/pkg/controller"
+	"github.com/infinispan/infinispan-operator/version"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	sdkv "github.com/operator-framework/operator-sdk/version"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // blank import (?)
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -17,9 +20,10 @@ import (
 )
 
 func printVersion() {
+	logf.Log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
 	logf.Log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	logf.Log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
-	logf.Log.Info(fmt.Sprintf("operator-sdk Version: %v", sdkVersion.Version))
+	logf.Log.Info(fmt.Sprintf("Operator SDK Version: %v", sdkv.Version))
 }
 
 // Parameters represent operator launcher parameters
@@ -29,15 +33,19 @@ type Parameters struct {
 
 // Launch launches operator
 func Launch(params Parameters) {
-	printVersion()
+	//TODO Uncomment after Operator SDK update
+	//pflag.CommandLine.AddFlagSet(zap.FlagSet())
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	flag.Parse()
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will
 	// be propagated through the whole operator, generating
 	// uniform and structured logs.
-	logf.SetLogger(logf.ZapLogger(false))
 	log := logf.Log.WithName("cmd")
+	logf.SetLogger(logf.ZapLogger(false))
+
+	printVersion()
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -1,5 +1,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version string = "undefined"
 )


### PR DESCRIPTION
Fixes #301
@rigazilla please pay attention, as this a little bit related to release process. Now we cant define which operator version is running inside the cluster and docker image as this info is missing in logs.