### PR TITLE
NodePort fix. #325

### DIFF
--- a/doc/design.adoc
+++ b/doc/design.adoc
@@ -94,13 +94,16 @@ is gracefully shut down.
 | v1
 
 | `expose`
-| Expose Infinispan for external access over port 11222.
-At the very least,
-the user must indicate via `type` attribute how the
+| If not empty the operator will expose Infinispan port 11222 externally.
+The `spec.type` attribute must indicate how the
 https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#service-v1-core[Service]
-is exposed.
-`NodePort` is often used while testing locally,
-while `LoadBalancer` is used in production-like environments where an external load-balancer is available.
+is exposed. Two service types are supported: `LoadBalancer, NodePort`.
+
+For the `NodePort` service type the `Spec.Ports[0].nodePort` attribute can be specified, if not port will be selected by the platform.
+
+This is just an helper for a quick service exposition, user can setup it's own service exposition
+if more configurability is needed.
+
 | https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#servicespec-v1-core[core/v1/ServiceSpec]
 | false
 | Infinispan not exposed externally.

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -282,12 +282,23 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 
 		if isExposed(infinispan) {
 			externalService := r.serviceExternal(infinispan)
-			err = r.client.Create(context.TODO(), externalService)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				reqLogger.Error(err, "failed to create external Service", "Service", ser)
-				return reconcile.Result{}, err
+			if externalService != nil {
+				err = r.client.Create(context.TODO(), externalService)
+				if err != nil && !errors.IsAlreadyExists(err) {
+					reqLogger.Error(err, "failed to create external Service", "Service", ser)
+					return reconcile.Result{}, err
+				}
+				infinispan.Spec.Expose = externalService.Spec
+				err = r.client.Update(context.TODO(), infinispan)
+				if err != nil {
+					reqLogger.Error(err, "failed to Infinispan with Service spec", "Service", ser)
+					return reconcile.Result{}, err
+				}
+				reqLogger.Info("Created External Service", "Service", externalService)
+			} else {
+				reqLogger.Info("External Service NOT created. Unsupported type?", "Service", nil)
+
 			}
-			reqLogger.Info("Created External Service", "Service", externalService)
 		}
 
 		// Infinispan resource must have a finalizer
@@ -1571,7 +1582,6 @@ func (r *ReconcileInfinispan) serviceExternal(m *infinispanv1.Infinispan) *corev
 	lsPodSelector := labelsForInfinispan(m.ObjectMeta.Name, "infinispan-pod")
 	lsService := labelsForInfinispan(m.ObjectMeta.Name, "infinispan-service-external")
 	externalServiceType := m.Spec.Expose.Type
-
 	// An external service can be simply achieved with a LoadBalancer
 	// that has same selectors as original service.
 	externalServiceName := getServiceExternalName(m)
@@ -1592,13 +1602,23 @@ func (r *ReconcileInfinispan) serviceExternal(m *infinispanv1.Infinispan) *corev
 				{
 					Port:       int32(11222),
 					TargetPort: intstr.FromInt(11222),
-					// Fix NodePort to match exported port in kind configuration
-					NodePort: int32(30222),
 				},
 			},
 		},
 	}
 
+	if externalServiceType == corev1.ServiceTypeLoadBalancer {
+		// Nothing to do here, keeping the if else struct
+	} else if externalServiceType == corev1.ServiceTypeNodePort {
+		var portNum int32
+		if m.Spec.Expose.Ports != nil || len(m.Spec.Expose.Ports) > 0 {
+			portNum = m.Spec.Expose.Ports[0].NodePort
+			externalService.Spec.Ports[0].NodePort = portNum
+		}
+	} else {
+		// Service type currently unsupported
+		return nil
+	}
 	// Set Infinispan instance as the owner and controller
 	controllerutil.SetControllerReference(m, externalService, r.scheme)
 	return externalService

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -449,7 +449,8 @@ func TestExternalService(t *testing.T) {
 
 func exposeServiceSpec() corev1.ServiceSpec {
 	return corev1.ServiceSpec{
-		Type: exposeServiceType(),
+		Type:  exposeServiceType(),
+		Ports: []corev1.ServicePort{{NodePort: 30222}},
 	}
 }
 


### PR DESCRIPTION
Now NodePort is explicitly specified only for NodePort service type. If not specified by the user port is no more defaulted to 30222, but is left to the cluster platform selection policy.