### PR TITLE
Adding PreStop hook to pod

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -1162,6 +1162,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 							PeriodSeconds:       10,
 							SuccessThreshold:    1,
 							TimeoutSeconds:      80},
+						Lifecycle: &corev1.Lifecycle{PreStop: ispnutil.NodePreStopHandler(protocolScheme)},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"cpu":    cpuRequests,

--- a/pkg/controller/infinispan/util/cluster.go
+++ b/pkg/controller/infinispan/util/cluster.go
@@ -16,6 +16,7 @@ const ServerHTTPBasePath = "rest/v2"
 const ServerHTTPClusterStop = ServerHTTPBasePath + "/cluster?action=stop"
 const ServerHTTPHealthPath = ServerHTTPBasePath + "/cache-managers/default/health"
 const ServerHTTPHealthStatusPath = ServerHTTPHealthPath + "/status"
+const ServerHTTPPreStopHandlerPath = ServerHTTPBasePath + "server?action=stop"
 
 // Cluster abstracts interaction with an Infinispan cluster
 type Cluster struct {
@@ -219,5 +220,15 @@ func ClusterStatusHandler(scheme corev1.URIScheme) corev1.Handler {
 			Scheme: scheme,
 			Path: ServerHTTPHealthStatusPath,
 			Port: intstr.FromInt(11222)},
+	}
+}
+
+// Return handler for PreStop hook setup
+func NodePreStopHandler(scheme corev1.URIScheme) *corev1.Handler {
+	return &corev1.Handler{
+		HTTPGet: &corev1.HTTPGetAction{
+			Scheme: scheme,
+			Path:   ServerHTTPPreStopHandlerPath,
+			Port:   intstr.FromInt(11222)},
 	}
 }


### PR DESCRIPTION
The PreStop hook is set up to call server stop, for a clean node shutdown.