### PR TITLE
Move entities model outside the infinispan_controller code (Stage I)

### DIFF
--- a/pkg/apis/infinispan/v1/types_util.go
+++ b/pkg/apis/infinispan/v1/types_util.go
@@ -1,5 +1,16 @@
 package v1
 
+import (
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/infinispan/infinispan-operator/pkg/controller/constants"
+	comutil "github.com/infinispan/infinispan-operator/pkg/controller/utils/common"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
 // GetCondition return the Status of the given condition or nil
 // if condition is not present
 func (ispn *Infinispan) GetCondition(condition string) *string {
@@ -40,4 +51,135 @@ func (ispn *Infinispan) SetConditions(conds []InfinispanCondition) bool {
 		changed = changed || ispn.SetCondition(c.Type, c.Status, c.Message)
 	}
 	return changed
+}
+
+func (ispn *Infinispan) ApplyDefaults() {
+	if ispn.Status.Conditions == nil {
+		ispn.Status.Conditions = []InfinispanCondition{}
+	}
+	if ispn.Spec.Service.Type == "" {
+		ispn.Spec.Service.Type = ServiceTypeCache
+	}
+	if ispn.Spec.Image == "" {
+		ispn.Spec.Image = constants.DefaultImageName
+	}
+	if ispn.Spec.Container.Memory == "" {
+		ispn.Spec.Container.Memory = constants.DefaultMemorySize.String()
+	}
+}
+
+func (ispn *Infinispan) IsDataGrid() bool {
+	return ServiceTypeDataGrid == ispn.Spec.Service.Type
+}
+
+func (ispn *Infinispan) IsConditionTrue(name string) bool {
+	upgradeCondition := ispn.GetCondition(name)
+	return upgradeCondition != nil && *upgradeCondition == "True"
+}
+
+func (ispn *Infinispan) IsUpgradeCondition() bool {
+	return ispn.IsConditionTrue("upgrade")
+}
+
+func (ispn *Infinispan) GetServiceExternalName() string {
+	return fmt.Sprintf("%s-external", ispn.ObjectMeta.Name)
+}
+
+func (ispn *Infinispan) IsCache() bool {
+	return ServiceTypeCache == ispn.Spec.Service.Type
+}
+
+func (ispn *Infinispan) HasSites() bool {
+	return ispn.IsDataGrid() && len(ispn.Spec.Service.Sites.Locations) > 0
+}
+
+func (ispn *Infinispan) IsExposed() bool {
+	return ispn.Spec.Expose.Type != ""
+}
+
+func (ispn *Infinispan) GetSiteServiceName() string {
+	return fmt.Sprintf("%v-site", ispn.Name)
+}
+
+func (ispn *Infinispan) GetEndpointScheme() corev1.URIScheme {
+	if ispn.Spec.Security.EndpointEncryption.Type != "" {
+		return corev1.URISchemeHTTPS
+	}
+	return corev1.URISchemeHTTP
+}
+
+// GetSecretName returns the secret name associated with a server
+func (ispn *Infinispan) GetSecretName() string {
+	if ispn.Spec.Security.EndpointSecretName == "" {
+		return fmt.Sprintf("%v-generated-secret", ispn.GetName())
+	}
+	return ispn.Spec.Security.EndpointSecretName
+}
+
+func (ispn *Infinispan) GetEncryptionSecretName() string {
+	return ispn.Spec.Security.EndpointEncryption.CertSecretName
+}
+
+func (ispn *Infinispan) GetCpuResources() (resource.Quantity, resource.Quantity) {
+	if ispn.Spec.Container.CPU != "" {
+		cpuLimits := resource.MustParse(ispn.Spec.Container.CPU)
+		cpuRequestsMillis := cpuLimits.MilliValue() / 2
+		cpuRequests := comutil.ToMilliDecimalQuantity(int64(cpuRequestsMillis))
+		return cpuRequests, cpuLimits
+	}
+
+	cpuLimits := comutil.ToMilliDecimalQuantity(constants.DefaultCPULimit)
+	cpuRequests := comutil.ToMilliDecimalQuantity(constants.DefaultCPULimit / 2)
+	return cpuRequests, cpuLimits
+}
+
+func (ispn *Infinispan) GetJavaOptions() (string, error) {
+	switch ispn.Spec.Service.Type {
+	case ServiceTypeDataGrid:
+		return ispn.Spec.Container.ExtraJvmOpts, nil
+	case ServiceTypeCache:
+		javaOptions := fmt.Sprintf(
+			"-Xmx%dM -Xms%dM -XX:MaxRAM=%dM %s %s",
+			constants.CacheServiceFixedMemoryXmxMb,
+			constants.CacheServiceFixedMemoryXmxMb,
+			constants.CacheServiceMaxRamMb,
+			constants.CacheServiceAdditionalJavaOptions,
+			ispn.Spec.Container.ExtraJvmOpts,
+		)
+		return javaOptions, nil
+	default:
+		return "", fmt.Errorf("unknown service type '%s'", ispn.Spec.Service.Type)
+	}
+}
+
+func (ispn *Infinispan) FindNodePortExternalIP() (string, error) {
+	localSiteName := ispn.Spec.Service.Sites.Local.Name
+	locations := ispn.Spec.Service.Sites.Locations
+	for _, location := range locations {
+		if location.Name == localSiteName {
+			masterURL, err := url.Parse(location.URL)
+			if err != nil {
+				return "", nil
+			}
+			host, _, err := net.SplitHostPort(masterURL.Host)
+			if err != nil {
+				return "", nil
+			}
+			return host, nil
+		}
+	}
+	return "", fmt.Errorf("could not find node port external IP, check local site name matches one of the members")
+}
+
+func (ispn *Infinispan) CopyLoggingCategories() map[string]string {
+	categories := ispn.Spec.Logging.Categories
+	if categories != nil {
+		copied := make(map[string]string, len(categories))
+		for category, level := range categories {
+			copied[category] = level
+		}
+		return copied
+	}
+
+	return make(map[string]string)
 }

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -1,0 +1,41 @@
+package constants
+
+import (
+	"github.com/infinispan/infinispan-operator/pkg/controller/utils/common"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+var (
+	// DefaultImageName is used if a specific image name is not provided
+	DefaultImageName = common.GetEnvWithDefault("DEFAULT_IMAGE", "infinispan/server:latest")
+
+	// DefaultMemorySize string with default size for memory
+	DefaultMemorySize = resource.MustParse("512Mi")
+
+	// DefaultPVSize default size for persistent volume
+	DefaultPVSize = resource.MustParse("1Gi")
+
+	// DefaultCPUSize string with default size for CPU
+	DefaultCPULimit int64 = 500
+
+	DeploymentAnnotations = map[string]string{
+		"description":                    "Infinispan 10 (Ephemeral)",
+		"iconClass":                      "icon-infinispan",
+		"openshift.io/display-name":      "Infinispan 10 (Ephemeral)",
+		"openshift.io/documentation-url": "http://infinispan.org/documentation/",
+	}
+)
+
+const (
+	CacheServiceFixedMemoryXmxMb            = 200
+	CacheServiceJvmNativeMb                 = 220
+	CacheServiceMaxRamMb                    = CacheServiceFixedMemoryXmxMb + CacheServiceJvmNativeMb
+	CacheServiceAdditionalJavaOptions       = "-Dsun.zip.disableMemoryMapping=true -XX:+UseSerialGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10"
+	CacheServiceJvmNativePercentageOverhead = 1
+	InfinispanFinalizer                     = "finalizer.infinispan.org"
+
+	ServerHTTPBasePath         = "rest/v2"
+	ServerHTTPClusterStop      = ServerHTTPBasePath + "/cluster?action=stop"
+	ServerHTTPHealthPath       = ServerHTTPBasePath + "/cache-managers/default/health"
+	ServerHTTPHealthStatusPath = ServerHTTPHealthPath + "/status"
+)

--- a/pkg/controller/infinispan/util/cluster.go
+++ b/pkg/controller/infinispan/util/cluster.go
@@ -6,17 +6,13 @@ import (
 	"strconv"
 	"strings"
 
+	consts "github.com/infinispan/infinispan-operator/pkg/controller/constants"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
 var log = logf.Log.WithName("cluster_util")
-
-const ServerHTTPBasePath = "rest/v2"
-const ServerHTTPClusterStop = ServerHTTPBasePath + "/cluster?action=stop"
-const ServerHTTPHealthPath = ServerHTTPBasePath + "/cache-managers/default/health"
-const ServerHTTPHealthStatusPath = ServerHTTPHealthPath + "/status"
 
 // Cluster abstracts interaction with an Infinispan cluster
 type Cluster struct {
@@ -59,7 +55,7 @@ func (c Cluster) GracefulShutdown(secretName, podName, namespace, protocol strin
 	if err != nil {
 		return err
 	}
-	httpURL := fmt.Sprintf("%s://%v:11222/%s", protocol, podIP, ServerHTTPClusterStop)
+	httpURL := fmt.Sprintf("%s://%v:11222/%s", protocol, podIP, consts.ServerHTTPClusterStop)
 	commands := []string{"curl", "-X", "GET", "--insecure", "-u", fmt.Sprintf("operator:%v", pass), httpURL}
 
 	logger := log.WithValues("Request.Namespace", namespace, "Secret.Name", secretName, "Pod.Name", podName)
@@ -95,7 +91,7 @@ func (c Cluster) GetClusterMembers(secretName, podName, namespace, protocol stri
 		return nil, err
 	}
 
-	httpURL := fmt.Sprintf("%s://%v:11222/%s", protocol, podIP, ServerHTTPHealthPath)
+	httpURL := fmt.Sprintf("%s://%v:11222/%s", protocol, podIP, consts.ServerHTTPHealthPath)
 	commands := []string{"curl", "--insecure", "-u", fmt.Sprintf("operator:%v", pass), httpURL}
 
 	logger := log.WithValues("Request.Namespace", namespace, "Secret.Name", secretName, "Pod.Name", podName)
@@ -250,7 +246,7 @@ func ClusterStatusHandler(scheme corev1.URIScheme) corev1.Handler {
 	return corev1.Handler{
 		HTTPGet: &corev1.HTTPGetAction{
 			Scheme: scheme,
-			Path:   ServerHTTPHealthStatusPath,
+			Path:   consts.ServerHTTPHealthStatusPath,
 			Port:   intstr.FromInt(11222)},
 	}
 }

--- a/pkg/controller/infinispan/util/security.go
+++ b/pkg/controller/infinispan/util/security.go
@@ -2,8 +2,6 @@ package util
 
 import (
 	"errors"
-	"fmt"
-	infinispanv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	"gopkg.in/yaml.v2"
 	"math/rand"
 	"time"
@@ -86,13 +84,5 @@ func FindPassword(usr string, descriptor []byte) (string, error) {
 	}
 
 	return "", errors.New("no operator credentials found")
-}
-
-// GetSecretName returns the secret name associated with a server
-func GetSecretName(m *infinispanv1.Infinispan) string {
-	if m.Spec.Security.EndpointSecretName == "" {
-		return fmt.Sprintf("%v-generated-secret", m.GetName())
-	}
-	return m.Spec.Security.EndpointSecretName
 }
 

--- a/pkg/controller/utils/common/common.go
+++ b/pkg/controller/utils/common/common.go
@@ -1,0 +1,65 @@
+package common
+
+import (
+	"net"
+	"os"
+	"strings"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// GetEnvWithDefault return GetEnv(name) if exists else return defVal
+func GetEnvWithDefault(name, defVal string) string {
+	str := os.Getenv(name)
+	if str != "" {
+		return str
+	}
+	return defVal
+}
+
+func GetEnvVarIndex(envVarName string, env *[]corev1.EnvVar) int {
+	for i, value := range *env {
+		if value.Name == envVarName {
+			return i
+		}
+	}
+	return 0
+}
+
+func Contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func Remove(list []string, s string) []string {
+	for i, v := range list {
+		if v == s {
+			list = append(list[:i], list[i+1:]...)
+		}
+	}
+	return list
+}
+
+func ToMilliDecimalQuantity(value int64) resource.Quantity {
+	return *resource.NewMilliQuantity(value, resource.DecimalSI)
+}
+
+func GetURISchemeProtocol(URIScheme corev1.URIScheme) string {
+	return strings.ToLower(string(URIScheme))
+}
+
+func LookupHost(host string, logger logr.Logger) (string, error) {
+	addresses, err := net.LookupHost(host)
+	if err != nil {
+		logger.Error(err, "host does not resolve")
+		return "", err
+	}
+	logger.Info("host resolved", "host", host, "addresses", addresses)
+	return host, nil
+}

--- a/pkg/controller/utils/common/labels.go
+++ b/pkg/controller/utils/common/labels.go
@@ -1,0 +1,10 @@
+package common
+
+// LabelsResource returns the labels that must me applied to the resource
+func LabelsResource(name, resourceType string) map[string]string {
+	m := map[string]string{"infinispan_cr": name, "clusterName": name}
+	if resourceType != "" {
+		m["app"] = resourceType
+	}
+	return m
+}

--- a/pkg/controller/utils/common/pods.go
+++ b/pkg/controller/utils/common/pods.go
@@ -1,0 +1,46 @@
+package common
+
+import corev1 "k8s.io/api/core/v1"
+
+// GetPodDefaultImage returns an Infinispan pod's default image.
+// If the default image cannot be found, it returns the running image.
+func GetPodDefaultImage(container corev1.Container) string {
+	envs := container.Env
+	for _, env := range envs {
+		if env.Name == "DEFAULT_IMAGE" {
+			return env.Value
+		}
+	}
+
+	return container.Image
+}
+
+func AreAllPodsReady(podList *corev1.PodList) bool {
+	for _, pod := range podList.Items {
+		containerStatuses := pod.Status.ContainerStatuses
+		if len(containerStatuses) == 0 || !containerStatuses[0].Ready {
+			return false
+		}
+	}
+
+	return true
+}
+
+func ArePodIPsReady(pods *corev1.PodList) bool {
+	for _, pod := range pods.Items {
+		if pod.Status.PodIP == "" {
+			return false
+		}
+	}
+
+	return true
+}
+
+func IsPodReady(pod corev1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == corev1.ContainersReady && cond.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
+}

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -1,0 +1,43 @@
+package constants
+
+import (
+	"strings"
+	"time"
+
+	comutil "github.com/infinispan/infinispan-operator/pkg/controller/utils/common"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	TestTimeout      = 5 * time.Minute
+	SinglePodTimeout = 5 * time.Minute
+	RouteTimeout     = 240 * time.Second
+	// Default retry time when waiting for resources
+	DefaultPollPeriod = 1 * time.Second
+	// Maximum time to wait for resources
+	MaxWaitTimeout      = 120 * time.Second
+	DefaultClusterPort  = 11222
+	DefaultClusterName  = "test-node-startup"
+	ClusterUpKubeConfig = "../../openshift.local.clusterup/kube-apiserver/admin.kubeconfig"
+)
+
+var (
+	CPU               = comutil.GetEnvWithDefault("INFINISPAN_CPU", "500m")
+	Memory            = comutil.GetEnvWithDefault("INFINISPAN_MEMORY", "512Mi")
+	Namespace         = strings.ToLower(comutil.GetEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing"))
+	RunLocalOperator  = comutil.GetEnvWithDefault("RUN_LOCAL_OPERATOR", "true")
+	ImageName         = comutil.GetEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server")
+	ExposeServiceType = comutil.GetEnvWithDefault("EXPOSE_SERVICE_TYPE", "NodePort")
+)
+
+// Options used when deleting resources
+var DeleteOpts = []client.DeleteOption{
+	client.GracePeriodSeconds(int64(0)),
+	client.PropagationPolicy(metav1.DeletePropagationBackground),
+}
+
+var InfinispanTypeMeta = metav1.TypeMeta{
+	APIVersion: "infinispan.org/v1",
+	Kind:       "Infinispan",
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -13,6 +13,7 @@ import (
 
 	ispnv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	"github.com/infinispan/infinispan-operator/pkg/controller/infinispan/util"
+	tconst "github.com/infinispan/infinispan-operator/test/e2e/constants"
 	testutil "github.com/infinispan/infinispan-operator/test/e2e/util"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -23,35 +24,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-const TestTimeout = 5 * time.Minute
-const SinglePodTimeout = 5 * time.Minute
-const RouteTimeout = 240 * time.Second
-const DefaultPollPeriod = 1 * time.Second
-
-var CPU = getEnvWithDefault("INFINISPAN_CPU", "500m")
-var Memory = getEnvWithDefault("INFINISPAN_MEMORY", "512Mi")
-var Namespace = getEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing")
-var RunLocalOperator = getEnvWithDefault("RUN_LOCAL_OPERATOR", "true")
-
 var kubernetes = testutil.NewTestKubernetes()
 var cluster = util.NewCluster(kubernetes.Kubernetes)
 
-var DefaultClusterName = "test-node-startup"
-
 var DefaultSpec = ispnv1.Infinispan{
-	TypeMeta: testutil.InfinispanTypeMeta,
+	TypeMeta: tconst.InfinispanTypeMeta,
 	ObjectMeta: metav1.ObjectMeta{
-		Name: DefaultClusterName,
+		Name: tconst.DefaultClusterName,
 	},
 	Spec: ispnv1.InfinispanSpec{
 		Service: ispnv1.InfinispanServiceSpec{
 			Type: ispnv1.ServiceTypeDataGrid,
 		},
 		Container: ispnv1.InfinispanContainerSpec{
-			CPU:    CPU,
-			Memory: Memory,
+			CPU:    tconst.CPU,
+			Memory: tconst.Memory,
 		},
-		Image:    getEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server"),
+		Image:    tconst.ImageName,
 		Replicas: 1,
 		Expose:   exposeServiceSpec(),
 	},
@@ -63,22 +52,22 @@ var MinimalSpec = ispnv1.Infinispan{
 		Kind:       "Infinispan",
 	},
 	ObjectMeta: metav1.ObjectMeta{
-		Name: DefaultClusterName,
+		Name: tconst.DefaultClusterName,
 	},
 	Spec: ispnv1.InfinispanSpec{
-		Image:    getEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server"),
+		Image:    tconst.ImageName,
 		Replicas: 2,
 	},
 }
 
 func TestMain(m *testing.M) {
-	namespace := strings.ToLower(Namespace)
-	if "true" == getEnvWithDefault("RUN_LOCAL_OPERATOR", "true") {
+	namespace := strings.ToLower(tconst.Namespace)
+	if "true" == tconst.RunLocalOperator {
 		kubernetes.DeleteNamespace(namespace)
 		kubernetes.DeleteCRD("infinispans.infinispan.org")
 		kubernetes.DeleteCRD("caches.infinispan.org")
 		kubernetes.NewNamespace(namespace)
-		stopCh := kubernetes.RunOperator(Namespace)
+		stopCh := kubernetes.RunOperator(namespace)
 		code := m.Run()
 		close(stopCh)
 		os.Exit(code)
@@ -101,8 +90,8 @@ func TestNodeStartup(t *testing.T) {
 	name := "test-node-startup"
 	spec.ObjectMeta.Name = name
 	// Register it
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, 1)
 }
 
@@ -114,8 +103,8 @@ func TestClusterFormation(t *testing.T) {
 	spec.ObjectMeta.Name = name
 	spec.Spec.Replicas = 2
 	// Register it
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, 2)
 }
 
@@ -133,11 +122,11 @@ func TestClusterFormationWithTLS(t *testing.T) {
 		},
 	}
 	// Create secret
-	kubernetes.CreateSecret(&encryptionSecret, Namespace)
+	kubernetes.CreateSecret(&encryptionSecret, tconst.Namespace)
 	defer kubernetes.DeleteSecret(&encryptionSecret)
 	// Register it
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, 2)
 }
 
@@ -195,8 +184,8 @@ func genericTestForContainerUpdated(ispn ispnv1.Infinispan, modifier func(*ispnv
 	spec := ispn.DeepCopy()
 	name := "test-node-startup"
 	spec.ObjectMeta.Name = name
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, int(ispn.Spec.Replicas))
 	// Get the latest version of the Infinispan resource
 	err := kubernetes.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}, spec)
@@ -217,14 +206,14 @@ func genericTestForContainerUpdated(ispn ispnv1.Infinispan, modifier func(*ispnv
 	// Change the Infinispan spec
 	modifier(spec)
 	// Workaround for OpenShift local test (clear GVK on decode in the client)
-	spec.TypeMeta = testutil.InfinispanTypeMeta
+	spec.TypeMeta = tconst.InfinispanTypeMeta
 	err = kubernetes.Kubernetes.Client.Update(context.TODO(), spec)
 	if err != nil {
 		panic(err.Error())
 	}
 
 	// Wait for a new generation to appear
-	err = wait.Poll(DefaultPollPeriod, SinglePodTimeout, func() (done bool, err error) {
+	err = wait.Poll(tconst.DefaultPollPeriod, tconst.SinglePodTimeout, func() (done bool, err error) {
 		kubernetes.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}, &ss)
 		return ss.Status.ObservedGeneration >= generation+1, nil
 	})
@@ -234,7 +223,7 @@ func genericTestForContainerUpdated(ispn ispnv1.Infinispan, modifier func(*ispnv
 
 	// Wait that current and update revisions match
 	// this ensure that the rolling upgrade completes
-	err = wait.Poll(DefaultPollPeriod, SinglePodTimeout, func() (done bool, err error) {
+	err = wait.Poll(tconst.DefaultPollPeriod, tconst.SinglePodTimeout, func() (done bool, err error) {
 		kubernetes.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}, &ss)
 		return ss.Status.CurrentRevision == ss.Status.UpdateRevision, nil
 	})
@@ -254,17 +243,17 @@ func TestCacheService(t *testing.T) {
 	spec.Spec.Service.Type = ispnv1.ServiceTypeCache
 	spec.Spec.Expose = exposeServiceSpec()
 
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, 1)
 
 	user := "developer"
-	password, err := cluster.Kubernetes.GetPassword(user, util.GetSecretName(spec), Namespace)
+	password, err := cluster.Kubernetes.GetPassword(user, util.GetSecretName(spec), tconst.Namespace)
 	testutil.ExpectNoError(err)
 
 	routeName := fmt.Sprintf("%s-external", name)
 	client := &http.Client{}
-	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, user, password, Namespace)
+	hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, user, password, tconst.Namespace)
 
 	cacheName := "default"
 
@@ -287,20 +276,20 @@ func TestPermanentCache(t *testing.T) {
 	cacheName := "test"
 	// Define function for the generic stop/start test procedure
 	var createPermanentCache = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
-		hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+		hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 		createCache(getSchemaForRest(ispn), cacheName, usr, pass, hostAddr, "PERMANENT", client)
 	}
 
 	var usePermanentCache = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
-		hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+		hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 		key := "test"
 		value := "test-operator"
 		keyURL := fmt.Sprintf("%v/%v", cacheURL(getSchemaForRest(ispn), cacheName, hostAddr), key)
@@ -328,22 +317,22 @@ func TestCheckDataSurviveToShutdown(t *testing.T) {
 
 	// Define function for the generic stop/start test procedure
 	var createCacheWithFileStore = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
-		hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+		hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 		createCacheWithXMLTemplate(getSchemaForRest(ispn), cacheName, usr, pass, hostAddr, template, client)
 		keyURL := fmt.Sprintf("%v/%v", cacheURL(getSchemaForRest(ispn), cacheName, hostAddr), key)
 		putViaRoute(keyURL, value, client, usr, pass)
 	}
 
 	var useCacheWithFileStore = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
-		hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+		hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 		schema := getSchemaForRest(ispn)
 		keyURL := fmt.Sprintf("%v/%v", cacheURL(schema, cacheName, hostAddr), key)
 		actual := getViaRoute(keyURL, client, usr, pass)
@@ -361,16 +350,16 @@ func genericTestForGracefulShutdown(clusterName string, modifier func(*ispnv1.In
 	// Register it
 	spec := DefaultSpec.DeepCopy()
 	spec.ObjectMeta.Name = clusterName
-	kubernetes.CreateInfinispan(spec, Namespace)
-	defer kubernetes.DeleteInfinispan(spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(spec, tconst.SinglePodTimeout)
 	waitForPodsOrFail(spec, 1)
 
 	// Do something that needs to be permanent
 	modifier(spec)
 
 	// Delete the cluster
-	kubernetes.GracefulShutdownInfinispan(spec, SinglePodTimeout)
-	kubernetes.GracefulRestartInfinispan(spec, 1, SinglePodTimeout)
+	kubernetes.GracefulShutdownInfinispan(spec, tconst.SinglePodTimeout)
+	kubernetes.GracefulRestartInfinispan(spec, 1, tconst.SinglePodTimeout)
 
 	// Do something that checks that permanent changes are there again
 	verifier(spec)
@@ -379,17 +368,17 @@ func genericTestForGracefulShutdown(clusterName string, modifier func(*ispnv1.In
 func waitForPodsOrFail(spec *ispnv1.Infinispan, num int) {
 	protocol := getSchemaForRest(spec)
 	// Wait that "num" pods are up
-	kubernetes.WaitForPods("app=infinispan-pod", num, SinglePodTimeout, Namespace)
+	kubernetes.WaitForPods("app=infinispan-pod", num, tconst.SinglePodTimeout, tconst.Namespace)
 
-	pods := kubernetes.GetPods("app=infinispan-pod", Namespace)
+	pods := kubernetes.GetPods("app=infinispan-pod", tconst.Namespace)
 	podName := pods[0].Name
 
 	secretName := util.GetSecretName(spec)
 	expectedClusterSize := num
 	// Check that the cluster size is num querying the first pod
 	var lastErr error
-	err := wait.Poll(time.Second, TestTimeout, func() (done bool, err error) {
-		value, err := cluster.GetClusterSize(secretName, podName, Namespace, protocol)
+	err := wait.Poll(time.Second, tconst.TestTimeout, func() (done bool, err error) {
+		value, err := cluster.GetClusterSize(secretName, podName, tconst.Namespace, protocol)
 		if err != nil {
 			lastErr = err
 			return false, nil
@@ -408,14 +397,6 @@ func waitForPodsOrFail(spec *ispnv1.Infinispan, num int) {
 	testutil.ExpectNoError(err)
 }
 
-func getEnvWithDefault(name, defVal string) string {
-	str := os.Getenv(name)
-	if str != "" {
-		return str
-	}
-	return defVal
-}
-
 func TestExternalService(t *testing.T) {
 	name := "test-external-service"
 	usr := "developer"
@@ -431,27 +412,27 @@ func TestExternalService(t *testing.T) {
 		},
 		Spec: ispnv1.InfinispanSpec{
 			Container: ispnv1.InfinispanContainerSpec{
-				CPU:    CPU,
-				Memory: Memory,
+				CPU:    tconst.CPU,
+				Memory: tconst.Memory,
 			},
-			Image:    getEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server"),
+			Image:    tconst.ImageName,
 			Replicas: 1,
 			Expose:   exposeServiceSpec(),
 		},
 	}
 
 	// Register it
-	kubernetes.CreateInfinispan(&spec, Namespace)
-	defer kubernetes.DeleteInfinispan(&spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(&spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(&spec, tconst.SinglePodTimeout)
 
-	kubernetes.WaitForPods("app=infinispan-pod", 1, SinglePodTimeout, Namespace)
+	kubernetes.WaitForPods("app=infinispan-pod", 1, tconst.SinglePodTimeout, tconst.Namespace)
 
-	pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(&spec), Namespace)
+	pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(&spec), tconst.Namespace)
 	testutil.ExpectNoError(err)
 
 	routeName := fmt.Sprintf("%s-external", name)
 	client := &http.Client{}
-	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+	hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 
 	cacheName := "test"
 	schema := getSchemaForRest(&spec)
@@ -477,7 +458,7 @@ func exposeServiceSpec() corev1.ServiceSpec {
 }
 
 func exposeServiceType() corev1.ServiceType {
-	exposeServiceType := getEnvWithDefault("EXPOSE_SERVICE_TYPE", "NodePort")
+	exposeServiceType := tconst.ExposeServiceType
 	switch exposeServiceType {
 	case "ClusterIP":
 		return corev1.ServiceTypeClusterIP
@@ -512,7 +493,7 @@ func TestExternalServiceWithAuth(t *testing.T) {
 		Type:       "Opaque",
 		StringData: map[string]string{"identities.yaml": string(identitiesYaml)},
 	}
-	kubernetes.CreateSecret(&secret, Namespace)
+	kubernetes.CreateSecret(&secret, tconst.Namespace)
 	defer kubernetes.DeleteSecret(&secret)
 
 	name := "text-external-service-with-auth"
@@ -529,18 +510,18 @@ func TestExternalServiceWithAuth(t *testing.T) {
 		Spec: ispnv1.InfinispanSpec{
 			Security: ispnv1.InfinispanSecurity{EndpointSecretName: "conn-secret-test"},
 			Container: ispnv1.InfinispanContainerSpec{
-				CPU:    CPU,
-				Memory: Memory,
+				CPU:    tconst.CPU,
+				Memory: tconst.Memory,
 			},
-			Image:    getEnvWithDefault("IMAGE", "registry.hub.docker.com/infinispan/server"),
+			Image:    tconst.ImageName,
 			Replicas: 1,
 			Expose:   exposeServiceSpec(),
 		},
 	}
-	kubernetes.CreateInfinispan(&spec, Namespace)
-	defer kubernetes.DeleteInfinispan(&spec, SinglePodTimeout)
+	kubernetes.CreateInfinispan(&spec, tconst.Namespace)
+	defer kubernetes.DeleteInfinispan(&spec, tconst.SinglePodTimeout)
 
-	kubernetes.WaitForPods("app=infinispan-pod", 1, SinglePodTimeout, Namespace)
+	kubernetes.WaitForPods("app=infinispan-pod", 1, tconst.SinglePodTimeout, tconst.Namespace)
 	schema := getSchemaForRest(&spec)
 	testAuthentication(schema, name, usr, pass)
 	// Update the auth credentials.
@@ -558,7 +539,7 @@ func TestExternalServiceWithAuth(t *testing.T) {
 		Type:       "Opaque",
 		StringData: map[string]string{"identities.yaml": string(identitiesYaml)},
 	}
-	kubernetes.CreateSecret(&secret1, Namespace)
+	kubernetes.CreateSecret(&secret1, tconst.Namespace)
 	defer kubernetes.DeleteSecret(&secret1)
 
 	// Get the associate statefulset
@@ -579,14 +560,14 @@ func TestExternalServiceWithAuth(t *testing.T) {
 
 	spec.Spec.Security.EndpointSecretName = "conn-secret-test-1"
 	// Workaround for OpenShift local test (clear GVK on decode in the client)
-	spec.TypeMeta = testutil.InfinispanTypeMeta
+	spec.TypeMeta = tconst.InfinispanTypeMeta
 	err = kubernetes.Kubernetes.Client.Update(context.TODO(), &spec)
 	if err != nil {
 		panic(fmt.Errorf(err.Error()))
 	}
 
 	// Wait for a new generation to appear
-	err = wait.Poll(DefaultPollPeriod, SinglePodTimeout, func() (done bool, err error) {
+	err = wait.Poll(tconst.DefaultPollPeriod, tconst.SinglePodTimeout, func() (done bool, err error) {
 		kubernetes.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: spec.Namespace, Name: spec.Name}, &ss)
 		return ss.Status.ObservedGeneration >= generation+1, nil
 	})
@@ -597,14 +578,14 @@ func TestExternalServiceWithAuth(t *testing.T) {
 	// The restart is ongoing and it would that more than 10 sec
 	// so we're not introducing any delay
 	time.Sleep(10 * time.Second)
-	kubernetes.WaitForPods("app=infinispan-pod", 1, SinglePodTimeout, Namespace)
+	kubernetes.WaitForPods("app=infinispan-pod", 1, tconst.SinglePodTimeout, tconst.Namespace)
 	testAuthentication(schema, name, usr, newpass)
 }
 
 func testAuthentication(schema, name, usr, pass string) {
 	routeName := fmt.Sprintf("%s-external", name)
 	client := &http.Client{}
-	hostAddr := kubernetes.WaitForExternalService(routeName, RouteTimeout, client, usr, pass, Namespace)
+	hostAddr := kubernetes.WaitForExternalService(routeName, tconst.RouteTimeout, client, usr, pass, tconst.Namespace)
 
 	cacheName := "test"
 	createCacheBadCreds(schema, cacheName, "badUser", "badPass", hostAddr, client)
@@ -735,7 +716,7 @@ func throwHTTPError(resp *http.Response) {
 func getSchemaForRest(ispn *ispnv1.Infinispan) string {
 	curr := ispnv1.Infinispan{}
 	// Wait for the operator to populate Infinispan CR data
-	err := wait.Poll(DefaultPollPeriod, SinglePodTimeout, func() (done bool, err error) {
+	err := wait.Poll(tconst.DefaultPollPeriod, tconst.SinglePodTimeout, func() (done bool, err error) {
 		kubernetes.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: ispn.Namespace, Name: ispn.Name}, &curr)
 		return len(curr.Status.Conditions) > 0, nil
 	})

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -248,7 +248,7 @@ func TestCacheService(t *testing.T) {
 	waitForPodsOrFail(spec, 1)
 
 	user := "developer"
-	password, err := cluster.Kubernetes.GetPassword(user, util.GetSecretName(spec), tconst.Namespace)
+	password, err := cluster.Kubernetes.GetPassword(user, spec.GetSecretName(), tconst.Namespace)
 	testutil.ExpectNoError(err)
 
 	routeName := fmt.Sprintf("%s-external", name)
@@ -276,7 +276,7 @@ func TestPermanentCache(t *testing.T) {
 	cacheName := "test"
 	// Define function for the generic stop/start test procedure
 	var createPermanentCache = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, ispn.GetSecretName(), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
@@ -285,7 +285,7 @@ func TestPermanentCache(t *testing.T) {
 	}
 
 	var usePermanentCache = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, ispn.GetSecretName(), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
@@ -317,7 +317,7 @@ func TestCheckDataSurviveToShutdown(t *testing.T) {
 
 	// Define function for the generic stop/start test procedure
 	var createCacheWithFileStore = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, ispn.GetSecretName(), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
@@ -328,7 +328,7 @@ func TestCheckDataSurviveToShutdown(t *testing.T) {
 	}
 
 	var useCacheWithFileStore = func(ispn *ispnv1.Infinispan) {
-		pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(ispn), tconst.Namespace)
+		pass, err := cluster.Kubernetes.GetPassword(usr, ispn.GetSecretName(), tconst.Namespace)
 		testutil.ExpectNoError(err)
 		routeName := fmt.Sprintf("%s-external", name)
 		client := &http.Client{}
@@ -373,7 +373,7 @@ func waitForPodsOrFail(spec *ispnv1.Infinispan, num int) {
 	pods := kubernetes.GetPods("app=infinispan-pod", tconst.Namespace)
 	podName := pods[0].Name
 
-	secretName := util.GetSecretName(spec)
+	secretName := spec.GetSecretName()
 	expectedClusterSize := num
 	// Check that the cluster size is num querying the first pod
 	var lastErr error
@@ -427,7 +427,7 @@ func TestExternalService(t *testing.T) {
 
 	kubernetes.WaitForPods("app=infinispan-pod", 1, tconst.SinglePodTimeout, tconst.Namespace)
 
-	pass, err := cluster.Kubernetes.GetPassword(usr, util.GetSecretName(&spec), tconst.Namespace)
+	pass, err := cluster.Kubernetes.GetPassword(usr, spec.GetSecretName(), tconst.Namespace)
 	testutil.ExpectNoError(err)
 
 	routeName := fmt.Sprintf("%s-external", name)

--- a/test/e2e/util/test_kubernetes.go
+++ b/test/e2e/util/test_kubernetes.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	ispnv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
+	consts "github.com/infinispan/infinispan-operator/pkg/controller/constants"
 	"github.com/infinispan/infinispan-operator/pkg/controller/infinispan/util"
 	"github.com/infinispan/infinispan-operator/pkg/launcher"
 	appsv1 "k8s.io/api/apps/v1"
@@ -357,7 +358,7 @@ func (k TestKubernetes) WaitForExternalService(routeName string, timeout time.Du
 }
 
 func checkExternalAddress(client *http.Client, user, password, hostAndPort string) bool {
-	httpURL := fmt.Sprintf("http://%s/%s", hostAndPort, util.ServerHTTPHealthPath)
+	httpURL := fmt.Sprintf("http://%s/%s", hostAndPort, consts.ServerHTTPHealthPath)
 	req, err := http.NewRequest("GET", httpURL, nil)
 	ExpectNoError(err)
 	req.SetBasicAuth(user, password)


### PR DESCRIPTION
This is the just first stage (Stage I) of the code refactoring (only move some simple methods and introduce constants)
This is part of the issue #290
Next stages will be:
Stage II - move common functions from infinispan_controller to the separate pakcages
Stage III - implement model (secrets, services, configmap) outside infinispan_controller
Stage IV - try to split kubernetes and cluster entities
Stage V - simplify using kubernetes client and possible to use https://github.com/redhat-cop/operator-utils