### PR TITLE
update nodePort example value

### DIFF
--- a/documentation/asciidoc/topics/yaml_annotated/cr_external_service.yaml
+++ b/documentation/asciidoc/topics/yaml_annotated/cr_external_service.yaml
@@ -2,4 +2,4 @@ spec:
   ...
   expose: <1>
     type: LoadBalancer <2>
-    nodePort: 22333 <3>
+    nodePort: 30000 <3>


### PR DESCRIPTION
from @Crumby: "This isn't a good example value. From the OpenShift docs on NodePort:
NodePorts are in the 30000-32767 range by default"