### PR TITLE
Check expose type in tests

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -519,7 +519,6 @@ func TestExternalService(t *testing.T) {
 func exposeServiceSpec() *ispnv1.ExposeSpec {
 	return &ispnv1.ExposeSpec{
 		Type:     exposeServiceType(),
-		NodePort: 30222,
 	}
 }
 


### PR DESCRIPTION
This PR contains two test fixes for E2E tests:
* Hard-coded `NodePort` value causes failures on AWS with LoadBalancer when tests are executed sequentially. Tests are being executed faster then OpenShift manages to free the node port upon service deletion which causes that following tests won't create an external service as the `NodePort` is taken.
* Fix `waitForExternalService` to try NodePort only if the external service is set to be `NodePort`. Otherwise it takes 7 minutes for the function to find out that service is exposed as LoadBalancer on AWS doubling time needed for test execution.



