### PR TITLE
Deployment in 1.1.x should use specific image tag instead of latest

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: infinispan-operator
       containers:
         - name: infinispan-operator
-          image: jboss/infinispan-operator:latest
+          image: jboss/infinispan-operator:1.1.2
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
@rigazilla I'm not sure about correct tag 1.1.2 or 1.1.2.Final but not exactly latest , as branch 1.1.x deploys 2.x instead of 1.x