### PR TITLE
Abort cluster startup on insufficient pod memory #471

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -55,4 +55,6 @@ const (
 	DefaultMinimumAutoscalePollPeriod = 5 * time.Second
 	//DefaultRequeueOnCreateExposeServiceDelay requeue delay before retry exposed service creation
 	DefaultRequeueOnCreateExposeServiceDelay = 5 * time.Second
+	//DefaultRequeueOnWrongSpec requeue delay on wrong values in Spec
+	DefaultRequeueOnWrongSpec = 5 * time.Second
 )


### PR DESCRIPTION
This aborts infinispan deployment if a CacheService is requested and pods have to little memory