### PR TITLE
Review run-local deploy scripts and tests running for OCP and K8S

### DIFF
--- a/build/minikube/run-local.sh
+++ b/build/minikube/run-local.sh
@@ -8,9 +8,6 @@ KUBECONFIG=${2-${HOME}/.kube/config}
 echo "Using KUBECONFIG '$KUBECONFIG'"
 
 kubectl create ns ${NAMESPACE} || true
-kubectl apply -f deploy/role.yaml -n ${NAMESPACE}
-kubectl apply -f deploy/service_account.yaml -n ${NAMESPACE}
-kubectl apply -f deploy/role_binding.yaml -n ${NAMESPACE}
 kubectl apply -f deploy/crds/infinispan.org_infinispans_crd.yaml -n ${NAMESPACE}
 kubectl apply -f deploy/crds/infinispan.org_caches_crd.yaml -n ${NAMESPACE}
 WATCH_NAMESPACE=${NAMESPACE} ./build/_output/bin/infinispan-operator -kubeconfig $KUBECONFIG

--- a/build/run-local.sh
+++ b/build/run-local.sh
@@ -9,9 +9,6 @@ echo "Using PROJECT_NAME '$PROJECT_NAME'"
 
 oc login -u ${OC_USER}
 oc project "$PROJECT_NAME"
-oc apply -f deploy/role.yaml
-oc apply -f deploy/service_account.yaml
-oc apply -f deploy/role_binding.yaml
 oc apply -f deploy/crds/infinispan.org_infinispans_crd.yaml
 oc apply -f deploy/crds/infinispan.org_caches_crd.yaml
 oc wait --for condition=established crd infinispans.infinispan.org --timeout=60s

--- a/test/e2e/util/test_kubernetes.go
+++ b/test/e2e/util/test_kubernetes.go
@@ -205,60 +205,6 @@ func (k TestKubernetes) GracefulRestartInfinispan(infinispan *ispnv1.Infinispan,
 	ExpectNoError(err)
 }
 
-// CreateOrUpdateRole creates or updates a Role in the given namespace
-func (k TestKubernetes) CreateOrUpdateRole(role *rbacv1.Role, namespace string) {
-	ns := types.NamespacedName{Name: role.ObjectMeta.Name, Namespace: namespace}
-	err := k.Kubernetes.Client.Get(context.TODO(), ns, role)
-	if err != nil && errors.IsNotFound(err) {
-		role.Namespace = namespace
-		err = k.Kubernetes.Client.Create(context.TODO(), role)
-		ExpectNoError(err)
-		return
-	} else if err == nil {
-		err = k.Kubernetes.Client.Update(context.TODO(), role)
-		ExpectNoError(err)
-		return
-	}
-
-	ExpectNoError(err)
-}
-
-// CreateOrUpdateSa creates or updates a ServiceAccount in the given namespace
-func (k TestKubernetes) CreateOrUpdateSa(sa *v1.ServiceAccount, namespace string) {
-	ns := types.NamespacedName{Name: sa.ObjectMeta.Name, Namespace: namespace}
-	err := k.Kubernetes.Client.Get(context.TODO(), ns, sa)
-	if err != nil && errors.IsNotFound(err) {
-		sa.Namespace = namespace
-		err = k.Kubernetes.Client.Create(context.TODO(), sa)
-		ExpectNoError(err)
-		return
-	} else if err == nil {
-		err = k.Kubernetes.Client.Update(context.TODO(), sa)
-		ExpectNoError(err)
-		return
-	}
-
-	ExpectNoError(err)
-}
-
-// CreateOrUpdateRoleBinding creates or updates a RoleBinding in the given namespace
-func (k TestKubernetes) CreateOrUpdateRoleBinding(binding *rbacv1.RoleBinding, namespace string) {
-	ns := types.NamespacedName{Name: binding.ObjectMeta.Name, Namespace: namespace}
-	err := k.Kubernetes.Client.Get(context.TODO(), ns, binding)
-	if err != nil && errors.IsNotFound(err) {
-		binding.Namespace = namespace
-		err = k.Kubernetes.Client.Create(context.TODO(), binding)
-		ExpectNoError(err)
-		return
-	} else if err == nil {
-		err = k.Kubernetes.Client.Update(context.TODO(), binding)
-		ExpectNoError(err)
-		return
-	}
-
-	ExpectNoError(err)
-}
-
 // CreateAndWaitForCRD creates a Custom Resource Definition, waiting it to become ready.
 func (k TestKubernetes) CreateAndWaitForCRD(crd *apiextv1beta1.CustomResourceDefinition, namespace string) {
 	fmt.Printf("Create CRD %s\n", crd.ObjectMeta.Name)

--- a/test/e2e/util/test_kubernetes.go
+++ b/test/e2e/util/test_kubernetes.go
@@ -469,39 +469,10 @@ func (k TestKubernetes) DeleteSecret(secret *v1.Secret) {
 
 // RunOperator runs an operator on a Kubernetes cluster
 func (k TestKubernetes) RunOperator(namespace string) chan struct{} {
-	k.installRBAC(namespace)
 	k.installCRD(namespace)
 	stopCh := make(chan struct{})
 	go runOperatorLocally(stopCh, namespace)
 	return stopCh
-}
-
-// Install resources from rbac.yaml required by the Infinispan operator
-func (k TestKubernetes) installRBAC(namespace string) {
-
-	yamlReader, err := getYamlReaderFromFile("../../deploy/role.yaml")
-	ExpectNoError(err)
-	read, _ := yamlReader.Read()
-	role := rbacv1.Role{}
-	err = yaml.NewYAMLToJSONDecoder(strings.NewReader(string(read))).Decode(&role)
-	ExpectNoError(err)
-	k.CreateOrUpdateRole(&role, namespace)
-
-	yamlReader, err = getYamlReaderFromFile("../../deploy/service_account.yaml")
-	ExpectNoError(err)
-	read2, _ := yamlReader.Read()
-	sa := v1.ServiceAccount{}
-	err = yaml.NewYAMLToJSONDecoder(strings.NewReader(string(read2))).Decode(&sa)
-	ExpectNoError(err)
-	k.CreateOrUpdateSa(&sa, namespace)
-
-	yamlReader, err = getYamlReaderFromFile("../../deploy/role_binding.yaml")
-	ExpectNoError(err)
-	read3, _ := yamlReader.Read()
-	binding := rbacv1.RoleBinding{}
-	err = yaml.NewYAMLToJSONDecoder(strings.NewReader(string(read3))).Decode(&binding)
-	ExpectNoError(err)
-	k.CreateOrUpdateRoleBinding(&binding, namespace)
 }
 
 func getYamlReaderFromFile(filename string) (*yaml.YAMLReader, error) {


### PR DESCRIPTION
Fixes #476 

It seems to RBAC doesn't make sense for local run and travis tests.
It's not needed for accounts with cluster admin rights and not enough for non-privileged account.
If we need to run with less privileged account, we need to add scripts for admins and specific RoleBindings and ClusterRoleBindings which will subjects to user. 