### PR TITLE
Compare ignorecase endpointEncryption.Type

### DIFF
--- a/deploy/cr/tls/cr_minimal_with_tls.yaml
+++ b/deploy/cr/tls/cr_minimal_with_tls.yaml
@@ -7,10 +7,10 @@ spec:
   security:
     endpointEncryption:
             # Define the certificate to encrypt endpoint traffic.
-            # `type: service` uses platform service certificate.
-            # `type: secret` uses custom certificates.
-            type: secret
-            # If `type: service`, uncomment the following `certServiceName` line:
+            # `type: Service` uses platform service certificate.
+            # `type: Secret` uses custom certificates.
+            type: Secret
+            # If `type: Service`, uncomment the following `certServiceName` line:
             # certServiceName: service.beta.openshift.io
             # Name the secret that contains encryption certificates.
             certSecretName: tls-secret

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		if getServingCertsMode(kubernetes) == "openshift.io" && (ee.Type == "" || ee.CertSecretName == "") {
 			reqLogger.Info("Serving certificate service present. Configuring into CRD")
 			if ee.Type == "" {
-				ee.Type = "service"
+				ee.Type = "Service"
 				ee.CertServiceName = "service.beta.openshift.io"
 			}
 			if ee.CertSecretName == "" {
@@ -1258,7 +1258,7 @@ func (r *ReconcileInfinispan) deploymentForInfinispan(m *infinispanv1.Infinispan
 
 func setupServiceForEncryption(m *infinispanv1.Infinispan, ser *corev1.Service) {
 	ee := m.Spec.Security.EndpointEncryption
-	if ee.Type == "service" {
+	if strings.EqualFold(ee.Type, "Service") {
 		if strings.Contains(ee.CertServiceName, "openshift.io") {
 			// Using platform service. Only OpenShift is integrated atm
 			secretName := m.GetEncryptionSecretName()
@@ -1286,7 +1286,7 @@ func setupVolumesForEncryption(m *infinispanv1.Infinispan, dep *appsv1.StatefulS
 
 func setupConfigForEncryption(m *infinispanv1.Infinispan, c *ispnutil.InfinispanConfiguration, client client.Client) error {
 	ee := m.Spec.Security.EndpointEncryption
-	if ee.Type == "service" {
+	if strings.EqualFold(ee.Type, "Service") {
 		if strings.Contains(ee.CertServiceName, "openshift.io") {
 			c.Keystore.CrtPath = "/etc/encrypt"
 			c.Keystore.Path = "/opt/infinispan/server/conf/keystore"


### PR DESCRIPTION
This PR allows to uniform the EndpointEncryption.Type values to the CamelCase format