### PR TITLE
Allow initContainer image to be specified

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -12,6 +12,9 @@ var (
 	// DefaultImageName is used if a specific image name is not provided
 	DefaultImageName = common.GetEnvWithDefault("DEFAULT_IMAGE", "infinispan/server:latest")
 
+	// InitContainerImageName allows a custom initContainer image to be used
+	InitContainerImageName = common.GetEnvWithDefault("INITCONTAINER_IMAGE", "busybox")
+
 	// JGroupsDiagnosticsFlag is used to enable traces for JGroups
 	JGroupsDiagnosticsFlag = strings.ToUpper(common.GetEnvWithDefault("JGROUPS_DIAGNOSTICS", "FALSE"))
 

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -766,8 +766,9 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 	})
 	// Adding an init container that run chmod if needed
 	if chmod, ok := os.LookupEnv("MAKE_DATADIR_WRITABLE"); ok && chmod == "true" {
+		initContainerImage := consts.InitContainerImageName
 		dep.Spec.Template.Spec.InitContainers = []corev1.Container{{
-			Image:   "busybox",
+			Image:   initContainerImage,
 			Name:    "chmod-pv",
 			Command: []string{"sh", "-c", "chmod -R g+w /opt/infinispan/server/data"},
 			VolumeMounts: []corev1.VolumeMount{{


### PR DESCRIPTION
Using the `INITCONTAINER_IMAGE` environment variable you can now specify a custom image for the initContainer that is used if `MAKE_DATADIR_WRITABLE=true`

Closes #518