### PR TITLE
Include all nodes with label "node-role.kubernetes.io/worker=true"

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -7,13 +7,10 @@ rules:
   - ""
   resources:
   - nodes
-  - nodes/status
-  - nodes/metrics
-  - nodes/spec
-  - nodes/stats
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:

--- a/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
@@ -172,10 +172,6 @@ spec:
               - ""
             resources:
               - nodes
-              - nodes/status
-              - nodes/metrics
-              - nodes/spec
-              - nodes/stats
             verbs:
               - get
               - list

--- a/deploy/operator-install.yaml
+++ b/deploy/operator-install.yaml
@@ -90,13 +90,10 @@ rules:
   - ""
   resources:
   - nodes
-  - nodes/status
-  - nodes/metrics
-  - nodes/spec
-  - nodes/stats
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
Without a `node-role.kubernetes.io/worker` label value of `true`, no worker nodes are returned.

Tested on a Kubernetes 1.15 cluster. Unfortunately I don't have access to a OpenShift cluster to test if this behaviour is consistent but it should be.

Resolves #523 