### PR TITLE
Set values on existing xsite

### DIFF
--- a/pkg/controller/utils/infinispan/configuration/xsite.go
+++ b/pkg/controller/utils/infinispan/configuration/xsite.go
@@ -18,7 +18,7 @@ import (
 )
 
 // ComputeXSite compute the xsite struct for cross site function
-func (xsite XSite) ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *util.Kubernetes, service *corev1.Service, logger logr.Logger) error {
+func (xsite *XSite) ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *util.Kubernetes, service *corev1.Service, logger logr.Logger) error {
 	if infinispan.HasSites() {
 		siteServiceName := infinispan.GetSiteServiceName()
 		localSiteHost, localSitePort, err := getCrossSiteServiceHostPort(service, kubernetes, logger)
@@ -39,11 +39,9 @@ func (xsite XSite) ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *util.
 			"port", localSitePort,
 		)
 
-		xsite := &XSite{
-			Address: localSiteHost,
-			Name:    infinispan.Spec.Service.Sites.Local.Name,
-			Port:    localSitePort,
-		}
+		xsite.Address = localSiteHost
+		xsite.Name = infinispan.Spec.Service.Sites.Local.Name
+		xsite.Port = localSitePort
 
 		remoteLocations := findRemoteLocations(xsite.Name, infinispan)
 		for _, remoteLocation := range remoteLocations {
@@ -53,7 +51,7 @@ func (xsite XSite) ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *util.
 			}
 		}
 
-		logger.Info("x-site configured", "configuration", *xsite)
+		logger.Info("x-site configured", "configuration", xsite)
 	}
 	return nil
 }


### PR DESCRIPTION
Instead of creating a new XSite struct, set values on the existing reference.

Creating a new `XSite` struct and reassigning `xsite` to that https://github.com/infinispan/infinispan-operator/blob/21d35fe983b504649dd773c23e74af9abac37696/pkg/controller/utils/infinispan/configuration/xsite.go#L42-L46 was resulting in `xsite` in `infinispan_controller.go` https://github.com/infinispan/infinispan-operator/blob/21d35fe983b504649dd773c23e74af9abac37696/pkg/controller/infinispan/infinispan_controller.go#L179 never being assigned the values.

Resolves #525 