### PR TITLE
Create cluster/490

### DIFF
--- a/deploy/cr/cache/cache_cluster.yaml
+++ b/deploy/cr/cache/cache_cluster.yaml
@@ -1,0 +1,4 @@
+apiVersion: infinispan.org/v2alpha1
+kind: Cache
+metadata:
+  name: example-cache

--- a/deploy/crds/infinispan.org_caches_crd.yaml
+++ b/deploy/crds/infinispan.org_caches_crd.yaml
@@ -80,6 +80,8 @@ spec:
               description: Name of the cache to be created. If empty ObjectMeta.Name
                 will be used
               type: string
+            size:
+              type: string
             template:
               description: Cache template in XML format
               type: string

--- a/deploy/olm-catalog/infinispan.org_caches_crd.yaml
+++ b/deploy/olm-catalog/infinispan.org_caches_crd.yaml
@@ -80,6 +80,8 @@ spec:
               description: Name of the cache to be created. If empty ObjectMeta.Name
                 will be used
               type: string
+            size:
+              type: string
             template:
               description: Cache template in XML format
               type: string

--- a/deploy/operator-install.yaml
+++ b/deploy/operator-install.yaml
@@ -475,6 +475,8 @@ spec:
               description: Name of the cache to be created. If empty ObjectMeta.Name
                 will be used
               type: string
+            size:
+              type: string
             template:
               description: Cache template in XML format
               type: string

--- a/pkg/apis/infinispan/v2alpha1/cache_types.go
+++ b/pkg/apis/infinispan/v2alpha1/cache_types.go
@@ -26,6 +26,7 @@ type CacheSpec struct {
 	ClusterName string `json:"clusterName,optional,omitempty"`
 	// Name of the cache to be created. If empty ObjectMeta.Name will be used
 	Name string `json:"name,optional,omitempty"`
+	Size string `json:"size,optional,omitempty"`
 	// Cache template in XML format
 	Template string `json:"template,optional,omitempty"`
 	// Name of the template to be used to create this cache

--- a/pkg/apis/infinispan/v2alpha1/cache_types.go
+++ b/pkg/apis/infinispan/v2alpha1/cache_types.go
@@ -23,7 +23,7 @@ type CacheSpec struct {
 	// Authentication info
 	AdminAuth AdminAuth `json:"adminAuth,omitempty"`
 	// Name of the cluster where to create the cache
-	ClusterName string `json:"clusterName,omitempty"`
+	ClusterName string `json:"clusterName,optional,omitempty"`
 	// Name of the cache to be created. If empty ObjectMeta.Name will be used
 	Name string `json:"name,optional,omitempty"`
 	// Cache template in XML format

--- a/pkg/controller/infinispan/util/kubernetes.go
+++ b/pkg/controller/infinispan/util/kubernetes.go
@@ -108,7 +108,7 @@ func (k Kubernetes) GetSecret(secretName, namespace string) (*v1.Secret, error) 
 func (k Kubernetes) GetPassword(user, secretName, namespace string) (string, error) {
 	secret, err := k.GetSecret(secretName, namespace)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	descriptor := secret.Data["identities.yaml"]

--- a/pkg/controller/utils/common/common.go
+++ b/pkg/controller/utils/common/common.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 )
 
 // GetEnvWithDefault return GetEnv(name) if exists else return defVal
@@ -39,4 +42,30 @@ func LookupHost(host string, logger logr.Logger) (string, error) {
 	}
 	logger.Info("host resolved", "host", host, "addresses", addresses)
 	return host, nil
+}
+
+// IsGroupVersionSupported checks if groupVersion Kind is supported by the platform
+func IsGroupVersionSupported(groupVersion string, kind string, restConfig *rest.Config, log logr.Logger) (bool, error) {
+	// TODO: Consider to save the DiscoverClient in the Reconcile struct, if performance is critical
+	cli, err := discovery.NewDiscoveryClientForConfig(restConfig)
+	if err != nil {
+		log.Error(err, "Failed to return a discovery client for the current reconciler")
+		return false, err
+	}
+
+	res, err := cli.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	for _, v := range res.APIResources {
+		if v.Kind == kind {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }


### PR DESCRIPTION
Resolves #490 implementing this use case:

1. the user creates a cache CR like this:
```
apiVersion: infinispan.org/v2alpha1
kind: Cache
metadata:
  name: example-cache
```
2. the operator create an Infinispan CR:
```
apiVersion: infinispan.org/v1
kind: Infinispan
metadata:
  name: example-cache
spec:
  replicas: 1
  expose:
    type: Route
```
3. when Infinispan is ready the operator creates the cache
4. the operator creates a configmap with connection info


 