### PR TITLE
Multiarch/531

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -9,7 +9,7 @@ import (
 
 var (
 	// DefaultImageName is used if a specific image name is not provided
-	DefaultImageName = common.GetEnvWithDefault("DEFAULT_IMAGE", "infinispan/server:latest")
+	DefaultImageName = common.GetDefaultInfinispanJavaImage()
 
 	// DefaultMemorySize string with default size for memory
 	DefaultMemorySize = resource.MustParse("512Mi")
@@ -17,7 +17,7 @@ var (
 	// DefaultPVSize default size for persistent volume
 	DefaultPVSize = resource.MustParse("1Gi")
 
-	// DefaultCPUSize string with default size for CPU
+	// DefaultCPULimit string with default size for CPU
 	DefaultCPULimit int64 = 500
 
 	DeploymentAnnotations = map[string]string{

--- a/pkg/controller/utils/common/image.go
+++ b/pkg/controller/utils/common/image.go
@@ -1,0 +1,33 @@
+package common
+
+import "runtime"
+
+const (
+	// OperandImageOpenJDK envvar name for OpenJDK operand image
+	OperandImageOpenJDK = "RELATED_IMAGE_OPENJDK"
+	// OperandImageOpenJ9 envvar name for OpenJ9 operand image
+	OperandImageOpenJ9 = "RELATED_IMAGE_OPENJ9"
+
+	// DefaultOperandImageOpenJDK default image for OpenJDK stack
+	DefaultOperandImageOpenJDK = "infinispan/server:latest"
+	// DefaultOperandImageOpenJ9 default image for OpenJ9 stack
+	DefaultOperandImageOpenJ9 = "infinispan-for-openj9/server:latest"
+)
+
+// GetDefaultInfinispanJavaImage returns default Infinispan Java image depends of the runtime architecture
+func GetDefaultInfinispanJavaImage() string {
+	// Full list of archs might be found here:
+	// https://github.com/golang/go/blob/release-branch.go1.10/src/go/build/syslist.go#L8
+	switch arch := runtime.GOARCH; arch {
+	case "ppc64", "ppc64le", "s390x", "s390":
+		return GetEnvWithDefault(OperandImageOpenJ9, DefaultOperandImageOpenJ9)
+	default:
+		// Try new name RELATED_IMAGE_OPENJDK first
+		retVal := GetEnvWithDefault(OperandImageOpenJDK, "")
+		if retVal != "" {
+			return retVal
+		}
+		// If RELATED_IMAGE_OPENJDK is not defined fallback on old name for backward comp
+		return GetEnvWithDefault("DEFAULT_IMAGE", DefaultOperandImageOpenJDK)
+	}
+}


### PR DESCRIPTION
This allows image selection between the following GOARCH architectures:

-  ppc64, ppc64le, s390x, s390  --> will run the image named in RELATED_IMAGE_OPENJ9 env var
- all the remaining GOARCH --> runs RELATED_IMAGE_OPENJDK env var

Resolves #531 , I've applied a very simplified version of the code referred in the issue