### PR TITLE
Update push-okd4 with cluster roles

### DIFF
--- a/build/push-okd4.sh
+++ b/build/push-okd4.sh
@@ -51,6 +51,8 @@ oc project "${PROJECT_NAME}"
 oc apply -f deploy/role.yaml
 oc apply -f deploy/service_account.yaml
 oc apply -f deploy/role_binding.yaml
+oc apply -f deploy/clusterrole.yaml
 oc apply -f deploy/crds/infinispan.org_infinispans_crd.yaml
 oc apply -f deploy/crds/infinispan.org_caches_crd.yaml
+sed -e "s|namespace:.*|namespace: ${PROJECT_NAME}|" deploy/clusterrole_binding.yaml | oc apply -f -
 sed -e "s|image:.*|image: image-registry.openshift-image-registry.svc:5000/${PROJECT_NAME}/infinispan-operator:${VERSION}|" deploy/operator.yaml | oc apply -f -


### PR DESCRIPTION
This helps to validate Roles and ClusterRoles on local install without remote docker registry
ClusterRoleBinding on-flight update support