### PR TITLE
[2.0.x] Simple fix for upgrade

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -949,6 +949,7 @@ func (r *ReconcileInfinispan) scheduleUpgradeIfNeeded(infinispan *infinispanv1.I
 			"pod default image", podDefaultImage,
 			"desired image", desiredImage)
 		infinispan.Spec.Replicas = 0
+		infinispan.Spec.Image = desiredImage
 		r.client.Update(context.TODO(), infinispan)
 		infinispan.SetCondition("upgrade", "True", "")
 		r.client.Status().Update(context.TODO(), infinispan)


### PR DESCRIPTION
This fixes #600. During upgrade infinispan.image is set to the new DEFAULT_IMAGE and used for the restart.
Also cluster running custom image will be updated.