### PR TITLE
Remove TestSimple test

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -102,12 +102,6 @@ func TestMain(m *testing.M) {
 	}
 }
 
-// Simple smoke test to check if the Kubernetes/OpenShift is alive
-func TestSimple(t *testing.T) {
-	fmt.Printf("%v\n", testKube.Nodes())
-	fmt.Printf("%s\n", testKube.Kubernetes.PublicIP())
-}
-
 // Test operator and cluster version upgrade flow
 func TestOperatorUpgrade(t *testing.T) {
 	spec := DefaultSpec.DeepCopy()


### PR DESCRIPTION
Removes TestSimple:
* Test isn't related to the Operator and doesn't provide any added value.
* If run as non-admin user the test fail as regular user doesn't have access to cluster nodes resource