### PR TITLE
Fix typos in descriptions

### DIFF
--- a/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
@@ -43,7 +43,7 @@ metadata:
 spec:
   displayName: Infinispan
   description: |
-    Infinispan is a distributed, in-memory data store that increases application performance and delivers open-source capabilites to handle demanding use cases.
+    Infinispan is a distributed, in-memory data store that increases application performance and delivers open-source capabilities to handle demanding use cases.
 
     ### Core Capabilities
     * **Schemaless data structure:** Store different objects as key-value pairs.
@@ -259,7 +259,7 @@ spec:
           - description: Appends JVM options to each Infinispan node.
             displayName: Extra JVM Options
             path: container.extraJvmOpts
-          - description: Name of the secrect that contains auth info.
+          - description: Name of the secret that contains auth info.
             displayName: Endpoint Secret Name
             path: security.endpointSecretName
           - description: Select how encryption certificates are provided [Secret,Service].
@@ -268,7 +268,7 @@ spec:
           - description: Platform service that serves certificates (openshift.io/service-cert is supported).
             displayName: Serving Certs Service Name
             path: security.endpointEncryption.certServiceName
-          - description: Name of the secrect that contains certificates.
+          - description: Name of the secret that contains certificates.
             displayName: Certificates Secret Name
             path: security.endpointEncryption.certSecretName
           - description: Select service type provided [Cache,DataGrid].


### PR DESCRIPTION
They don't affect the functioning of the image, but are an annoyance and need to be fixed anyway.
This probably should be cherry-picked into all active branches: master, 1.1.x, 2.0.x.1, etc.