### PR TITLE
Drop Image field from test deployments

### DIFF
--- a/pkg/controller/constants/image.go
+++ b/pkg/controller/constants/image.go
@@ -9,9 +9,9 @@ const (
 	OperandImageOpenJ9 = "RELATED_IMAGE_OPENJ9"
 
 	// DefaultOperandImageOpenJDK default image for OpenJDK stack
-	DefaultOperandImageOpenJDK = "infinispan/server:latest"
+	DefaultOperandImageOpenJDK = "infinispan/server:12.0"
 	// DefaultOperandImageOpenJ9 default image for OpenJ9 stack
-	DefaultOperandImageOpenJ9 = "infinispan-for-openj9/server:latest"
+	DefaultOperandImageOpenJ9 = "infinispan-for-openj9/server:12.0"
 )
 
 // GetDefaultInfinispanJavaImage returns default Infinispan Java image depends of the runtime architecture

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -35,7 +35,7 @@ var (
 	RunSaOperator        = strings.ToUpper(constants.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	OperatorUpgradeStage = strings.ToUpper(constants.GetEnvWithDefault("OPERATOR_UPGRADE_STAGE", OperatorUpgradeStageNone))
 	CleanupInfinispan    = strings.ToUpper(constants.GetEnvWithDefault("CLEANUP_INFINISPAN_ON_FINISH", "true"))
-	ImageName            = constants.GetEnvWithDefault("IMAGE", "infinispan/server:12.0")
+	ExpectedImage	     = constants.GetEnvWithDefault("EXPECTED_IMAGE", "infinispan/server:12.0")
 	ExposeServiceType    = constants.GetEnvWithDefault("EXPOSE_SERVICE_TYPE", "NodePort")
 
 	OperatorUpgradeStateFlow = []string{"upgrade", "stopping", "wellFormed"}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -31,7 +31,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/pointer"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -53,7 +52,6 @@ var DefaultSpec = ispnv1.Infinispan{
 			CPU:    tconst.CPU,
 			Memory: tconst.Memory,
 		},
-		Image:    pointer.StringPtr(tconst.ImageName),
 		Replicas: 1,
 		Expose:   exposeServiceSpec(),
 	},
@@ -65,7 +63,6 @@ var MinimalSpec = ispnv1.Infinispan{
 		Name: tconst.DefaultClusterName,
 	},
 	Spec: ispnv1.InfinispanSpec{
-		Image:    pointer.StringPtr(tconst.ImageName),
 		Replicas: 2,
 	},
 }
@@ -125,8 +122,8 @@ func TestOperatorUpgrade(t *testing.T) {
 		err := testKube.Kubernetes.ResourcesList(tconst.Namespace, ispnctrl.PodLabels(spec.Name), pods)
 		tutils.ExpectNoError(err)
 		for _, pod := range pods.Items {
-			if pod.Spec.Containers[0].Image != tconst.ImageName {
-				tutils.ExpectNoError(fmt.Errorf("upgraded image [%v] in Pod not equal desired cluster image [%v]", pod.Spec.Containers[0].Image, tconst.ImageName))
+			if pod.Spec.Containers[0].Image != tconst.ExpectedImage {
+				tutils.ExpectNoError(fmt.Errorf("upgraded image [%v] in Pod not equal desired cluster image [%v]", pod.Spec.Containers[0].Image, tconst.ExpectedImage))
 			}
 		}
 	default:
@@ -540,7 +537,6 @@ func TestExternalService(t *testing.T) {
 				CPU:    tconst.CPU,
 				Memory: tconst.Memory,
 			},
-			Image:    pointer.StringPtr(tconst.ImageName),
 			Replicas: 1,
 			Expose:   exposeServiceSpec(),
 		},
@@ -637,7 +633,6 @@ func TestExternalServiceWithAuth(t *testing.T) {
 				CPU:    tconst.CPU,
 				Memory: tconst.Memory,
 			},
-			Image:    pointer.StringPtr(tconst.ImageName),
 			Replicas: 1,
 			Expose:   exposeServiceSpec(),
 		},


### PR DESCRIPTION
Operator already has server image mapping defined and that image should be used for test deployments by default. Current settings where each deployments has `Image` field set up leads or could lead to potential issues:
* Default image of the Operator forgets to be updated  and tests won't run with the server that will be used to create clusters by default
* Server image mapping breaks in the code but tests won't recognize this as they set the Image
* Alternative Operator that uses alternative server runs with Infinispan server instead

Possible test extensions:
* Verification that cluster is deployed with expected server (basically done by `TestOperatorUpgrade`)
* Verification that `Image` field is really used when (Unit tests seems to be ideal in this case)
