### PR TITLE
[2.0.x] JDG-3643 Missing name for default services port causes prometheus to …

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -1500,6 +1500,7 @@ func (r *ReconcileInfinispan) serviceForInfinispan(m *infinispanv1.Infinispan) *
 			Selector: lsPodSelector,
 			Ports: []corev1.ServicePort{
 				{
+					Name: "hotrod",
 					Port: 11222,
 				},
 			},


### PR DESCRIPTION
https://issues.redhat.com/browse/JDG-3643