### PR TITLE
Add anti-affinity to StatefulSet PodSpec to ensure distribution acros…

### DIFF
--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -4,6 +4,7 @@ package v1
 // NOTE: json tags are required. Any new fields you add must have json tags for the fields to be serialized.
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -149,6 +150,7 @@ type InfinispanSpec struct {
 	Logging   *InfinispanLoggingSpec  `json:"logging,optional,omitempty"`
 	Expose    *ExposeSpec             `json:"expose,optional,omitempty"`
 	Autoscale *Autoscale              `json:"autoscale,optional,omitempty"`
+	Affinity  *corev1.Affinity        `json:"affinity,optional,omitempty"`
 }
 
 type ConditionType string


### PR DESCRIPTION
This ensures that the pod scheduler prioritises the creation of pods across available nodes. The benefit of this is increased availability in the event of node failure(s).

@rigazilla @dmvolod I went with `PreferredDuringSchedulingIgnoredDuringExecution` opposed to `RequiredDuringSchedulingIgnoredDuringExecution` as I felt that was too restrictive, it also prevents solutions such as `minikube`[1] being used for testing. 

[1] minikube does have multi-node support, but it's experimental and my brief attempts to get it to work ended in failure.


https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity

Fixes ##651