### PR TITLE
Infinispan CR should be monospace in docs

### DIFF
--- a/documentation/asciidoc/stories/assembly_setting_up_xsite.adoc
+++ b/documentation/asciidoc/stories/assembly_setting_up_xsite.adoc
@@ -7,7 +7,7 @@ To set up cross-site replication, you configure {ispn_operator} to automatically
 
 [NOTE]
 ====
-You can use both automatic and manual connections for {brandname} clusters in the same **Infinispan** CR.
+You can use both automatic and manual connections for {brandname} clusters in the same `Infinispan` CR.
 However, you must ensure that {brandname} clusters establish connections in the same way at each site.
 ====
 

--- a/documentation/asciidoc/topics/con_services.adoc
+++ b/documentation/asciidoc/topics/con_services.adoc
@@ -16,7 +16,7 @@ Use {cacheservice} if you want a volatile, low-latency data store with minimal c
 [IMPORTANT]
 ====
 Because {cacheservice} nodes are volatile you lose all data when you apply
-changes to the cluster with the **Infinispan** CR or update the {brandname}
+changes to the cluster with the `Infinispan` CR or update the {brandname}
 version.
 ====
 

--- a/documentation/asciidoc/topics/proc_adding_backup_locations.adoc
+++ b/documentation/asciidoc/topics/proc_adding_backup_locations.adoc
@@ -8,7 +8,7 @@ can add backup locations to your cache configurations.
 . Create cache configurations that name remote sites as backup locations.
 +
 {brandname} replicates data based on cache names.
-For this reason, site names in your cache configurations must match site names, `spec.service.sites.local.name`, in your **Infinispan** CRs.
+For this reason, site names in your cache configurations must match site names, `spec.service.sites.local.name`, in your `Infinispan` CRs.
 +
 . Configure backup locations to go offline automatically with the `take-offline` element.
 .. Set the amount of time, in milliseconds, before backup locations go offline with the `min-wait` attribute.

--- a/documentation/asciidoc/topics/proc_adding_custom_credentials.adoc
+++ b/documentation/asciidoc/topics/proc_adding_custom_credentials.adoc
@@ -13,7 +13,7 @@ $ {oc_create} secret generic --from-file=identities.yaml connect-secret
 ----
 +
 . Specify the authentication secret with `spec.security.endpointSecretName` in
-your **Infinispan** CR and then apply the changes.
+your `Infinispan` CR and then apply the changes.
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/proc_backing_up_cluster.adoc
+++ b/documentation/asciidoc/topics/proc_backing_up_cluster.adoc
@@ -4,7 +4,7 @@ Create a backup file that stores {brandname} cluster state to a persistent volum
 
 .Prerequisites
 
-* Create an **Infinispan** CR of `spec.service.type: DataGrid`.
+* Create an `Infinispan` CR of `spec.service.type: DataGrid`.
 * Have some resources on your {brandname} cluster to back up.
 Backups archive all resources that the Cache Manager controls, including caches, cache entries, cache templates, Protobuf schema, counters, scripts, and so on.
 

--- a/documentation/asciidoc/topics/proc_configuring_anti_affinity.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_anti_affinity.adoc
@@ -4,7 +4,7 @@ Specify where {k8s} schedules pods for your {brandname} clusters to ensure avail
 
 .Procedure
 
-. Add the `spec.affinity` field to your **Infinispan** CR.
+. Add the `spec.affinity` field to your `Infinispan` CR.
 . Configure anti-affinity strategies with the `podAntiAffinity` field.
 . Define `kubernetes.io/hostname` and `topology.kubernetes.io/zone` strategies with the `topologyKey` field.
 . Set the `weight` field to give preference to one strategy over another when using hostname and zone anti-affinity strategies together.

--- a/documentation/asciidoc/topics/proc_configuring_autoscaling.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_autoscaling.adoc
@@ -14,13 +14,13 @@ threshold, {ispn_operator} shuts down nodes.
 ====
 Automatic scaling works with the default cache only. If you plan to add other
 caches to your cluster, you should not include the `autoscale` field in your
-**Infinispan** CR. In this case you should use eviction to control the size of
+`Infinispan` CR. In this case you should use eviction to control the size of
 the data container on each node.
 ====
 
 .Procedure
 
-. Add the `spec.autoscale` resource to your **Infinispan** CR to enable automatic scaling.
+. Add the `spec.autoscale` resource to your `Infinispan` CR to enable automatic scaling.
 . Configure memory usage thresholds and number of nodes for your cluster with the `autoscale` field.
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_configuring_logging.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_logging.adoc
@@ -3,7 +3,7 @@
 
 .Procedure
 
-. Specify logging configuration with `spec.logging` in your **Infinispan** CR
+. Specify logging configuration with `spec.logging` in your `Infinispan` CR
 and then apply the changes.
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_configuring_owners.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_owners.adoc
@@ -6,7 +6,7 @@ nodes is two, which duplicates each entry to prevent data loss.
 
 .Procedure
 
-. Specify the number of owners with the `spec.service.replicationFactor` resource in your **Infinispan** CR as follows:
+. Specify the number of owners with the `spec.service.replicationFactor` resource in your `Infinispan` CR as follows:
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/proc_configuring_sites_automatically.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_sites_automatically.adoc
@@ -19,11 +19,11 @@ named `xsite-cluster`.
 
 .Procedure
 
-. Create an **Infinispan** CR for each {brandname} cluster.
+. Create an `Infinispan` CR for each {brandname} cluster.
 . Specify the name of the local site with `spec.service.sites.local.name`.
 . Provide the name, URL, and secret for each {brandname} cluster that acts as a backup location with `spec.service.sites.locations`.
 +
-The following are example **Infinispan** CR definitions for **LON** and **NYC**:
+The following are example `Infinispan` CR definitions for **LON** and **NYC**:
 +
 * **LON**
 +
@@ -87,7 +87,7 @@ include::yaml/xsite_logging.yaml[]
 The preceding configuration decreases logging for JGroups TCP and RELAY2 protocols to reduce excessive messages about cluster backup operations, which can result in a large number of log files that use container storage.
 +
 . Configure nodes with any other {datagridservice} resources.
-. Apply the **Infinispan** CRs.
+. Apply the `Infinispan` CRs.
 . Check node logs to verify that {brandname} clusters form a cross-site view, for example:
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_configuring_sites_manually.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_sites_manually.adoc
@@ -8,11 +8,11 @@ Specify hostnames and ports for {brandname} clusters so they can establish conne
 
 .Procedure
 
-. Create an **Infinispan** CR for each {brandname} cluster.
+. Create an `Infinispan` CR for each {brandname} cluster.
 . Specify the name of the local site with `spec.service.sites.local.name`.
 . Provide the name, host, and port for each {brandname} cluster that acts as a backup location with `spec.service.sites.locations`.
 +
-The following are example **Infinispan** CR definitions for **LON** and **NYC**:
+The following are example `Infinispan` CR definitions for **LON** and **NYC**:
 +
 * **LON**
 +
@@ -78,7 +78,7 @@ protocols to reduce excessive messages about cluster backup operations, which
 can result in a large number of log files that use container storage.
 +
 . Configure nodes with any other {datagridservice} resources.
-. Apply the **Infinispan** CRs.
+. Apply the `Infinispan` CRs.
 . Check node logs to verify that {brandname} clusters form a cross-site view, for example:
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_create_cluster_minimal.adoc
+++ b/documentation/asciidoc/topics/proc_create_cluster_minimal.adoc
@@ -5,7 +5,7 @@ Use {ispn_operator} to create clusters of two or more {brandname} nodes.
 .Procedure
 
 . Specify the number of {brandname} nodes in the cluster with `spec.replicas`
-in your **Infinispan** CR.
+in your `Infinispan` CR.
 +
 For example, create a `cr_minimal.yaml` file as follows:
 +
@@ -14,7 +14,7 @@ For example, create a `cr_minimal.yaml` file as follows:
 include::cmd_examples/cat_cr_minimal.adoc[]
 ----
 +
-. Apply your **Infinispan** CR.
+. Apply your `Infinispan` CR.
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/proc_creating_cache_service.adoc
+++ b/documentation/asciidoc/topics/proc_creating_cache_service.adoc
@@ -5,7 +5,7 @@ nodes.
 
 .Procedure
 
-. Create an **Infinispan** CR.
+. Create an `Infinispan` CR.
 +
 [source,yaml,options="nowrap",subs=attributes+]
 ----
@@ -19,6 +19,6 @@ spec:
     type: Cache <1>
 ----
 +
-<1> Creates nodes {cacheservice} nodes. This is the default for the **Infinispan** CR.
+<1> Creates nodes {cacheservice} nodes. This is the default for the `Infinispan` CR.
 +
-. Apply your **Infinispan** CR to create the cluster.
+. Apply your `Infinispan` CR to create the cluster.

--- a/documentation/asciidoc/topics/proc_creating_dg_service.adoc
+++ b/documentation/asciidoc/topics/proc_creating_dg_service.adoc
@@ -6,7 +6,7 @@ cross-site replication, create clusters of {datagridservice} nodes.
 .Procedure
 
 . Specify `DataGrid` as the value for `spec.service.type` in your
-**Infinispan** CR.
+`Infinispan` CR.
 +
 [source,yaml,options="nowrap",subs=attributes+]
 ----
@@ -20,4 +20,4 @@ change the service type, you must delete the existing nodes and create new ones.
 ====
 +
 . Configure nodes with any other {datagridservice} resources.
-. Apply your **Infinispan** CR to create the cluster.
+. Apply your `Infinispan` CR to create the cluster.

--- a/documentation/asciidoc/topics/proc_encrypting_endpoints_tls_secret.adoc
+++ b/documentation/asciidoc/topics/proc_encrypting_endpoints_tls_secret.adoc
@@ -20,7 +20,7 @@ $ {oc_apply_cr} tls_secret.yaml
 ----
 +
 . Specify the encryption secret with `spec.security.endpointEncryption` in your
-**Infinispan** CR and then apply the changes.
+`Infinispan` CR and then apply the changes.
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/proc_exposing_loadbalancer.adoc
+++ b/documentation/asciidoc/topics/proc_exposing_loadbalancer.adoc
@@ -10,7 +10,7 @@ a load balancer service.
 
 .Procedure
 
-. Include `spec.expose` in your **Infinispan** CR.
+. Include `spec.expose` in your `Infinispan` CR.
 . Specify `LoadBalancer` as the service type with `spec.expose.type`.
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_exposing_nodeport.adoc
+++ b/documentation/asciidoc/topics/proc_exposing_nodeport.adoc
@@ -4,7 +4,7 @@ Use a node port service to expose {brandname} clusters on the network.
 
 .Procedure
 
-. Include `spec.expose` in your **Infinispan** CR.
+. Include `spec.expose` in your `Infinispan` CR.
 . Specify `NodePort` as the service type with `spec.expose.type`.
 +
 [source,options="nowrap",subs=attributes+]

--- a/documentation/asciidoc/topics/proc_exposing_route.adoc
+++ b/documentation/asciidoc/topics/proc_exposing_route.adoc
@@ -13,7 +13,7 @@ endif::productized[]
 
 .Procedure
 
-. Include `spec.expose` in your **Infinispan** CR.
+. Include `spec.expose` in your `Infinispan` CR.
 . Specify `Route` as the service type with `spec.expose.type`.
 . Optionally add a hostname with `spec.expose.host`.
 +

--- a/documentation/asciidoc/topics/proc_install_command_line.adoc
+++ b/documentation/asciidoc/topics/proc_install_command_line.adoc
@@ -75,7 +75,7 @@ NAME                                   READY   STATUS
 infinispan-operator-<id>               1/1     Running
 ----
 +
-.. Change to the project where your {brandname} cluster runs so you can start applying changes with your **Infinispan** CR.
+.. Change to the project where your {brandname} cluster runs so you can start applying changes with your `Infinispan` CR.
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/proc_restoring_cluster.adoc
+++ b/documentation/asciidoc/topics/proc_restoring_cluster.adoc
@@ -29,7 +29,7 @@ include::yaml/cr_restore.yaml[]
 <1> Specifies a **Restore** CR.
 <2> Provides a unique name for the **Restore** CR.
 <3> Specifies the name of the **Backup** CR.
-<4> Specifies the name of the **Infinispan** CR.
+<4> Specifies the name of the `Infinispan` CR.
 +
 . Add the `spec.resources` field to restore specific resources only.
 +

--- a/documentation/asciidoc/topics/proc_verify_cluster.adoc
+++ b/documentation/asciidoc/topics/proc_verify_cluster.adoc
@@ -13,7 +13,7 @@ Review log messages to ensure that {brandname} nodes receive clustered views.
 include::cmd_examples/oc_logs_clusterview.adoc[]
 ----
 
-** Retrieve the **Infinispan** CR for {ispn_operator}.
+** Retrieve the `Infinispan` CR for {ispn_operator}.
 +
 [source,options="nowrap",subs=attributes+]
 ----

--- a/documentation/asciidoc/topics/ref_anti_affinity.adoc
+++ b/documentation/asciidoc/topics/ref_anti_affinity.adoc
@@ -1,11 +1,11 @@
 [id='anti_affinity_configuration-{context}']
 = Anti-Affinity Strategy Configurations
-Configure anti-affinity strategies in your **Infinispan** CR to control where {k8s} schedules {brandname} replica pods.
+Configure anti-affinity strategies in your `Infinispan` CR to control where {k8s} schedules {brandname} replica pods.
 
 [discrete]
 == Schedule pods on different {k8s} nodes
 
-The following is the anti-affinity strategy that {ispn_operator} uses if you do not configure the `spec.affinity` field in your **Infinispan** CR:
+The following is the anti-affinity strategy that {ispn_operator} uses if you do not configure the `spec.affinity` field in your `Infinispan` CR:
 
 ----
 spec:

--- a/documentation/asciidoc/topics/ref_cacheservice_resources.adoc
+++ b/documentation/asciidoc/topics/ref_cacheservice_resources.adoc
@@ -37,7 +37,7 @@ spec:
 
 <1> Names the {brandname} cluster.
 <2> Specifies the number of nodes in the cluster.
-<3> Creates {cacheservice} clusters. This is the default for Infinispan CR.
+<3> Creates {cacheservice} clusters. This is the default for the `Infinispan` CR.
 <4> Configures the number of replicas for each cache entry across the cluster.
 <5> Enables and configures automatic cluster scaling.
 <6> Adds an authentication secret with user credentials.

--- a/documentation/asciidoc/topics/ref_crd.adoc
+++ b/documentation/asciidoc/topics/ref_crd.adoc
@@ -1,21 +1,21 @@
 [id='minimal_crd-{context}']
 = Infinispan Custom Resource (CR)
-{ispn_operator} adds a new Custom Resource (CR) of type **Infinispan** that lets
+{ispn_operator} adds a new Custom Resource (CR) of type `Infinispan` that lets
 you handle {brandname} clusters as complex units on {k8s}.
 
-{ispn_operator} watches for **Infinispan** Custom Resources (CR) that you use to
+{ispn_operator} watches for `Infinispan` Custom Resources (CR) that you use to
 instantiate and configure {brandname} clusters and manage {k8s} resources, such
-as StatefulSets and Services. In this way, the **Infinispan** CR is your
+as StatefulSets and Services. In this way, the `Infinispan` CR is your
 primary interface to {brandname} on {k8s}.
 
-The minimal **Infinispan** CR is as follows:
+The minimal `Infinispan` CR is as follows:
 
 [source,options="nowrap",subs=attributes+]
 ----
 include::yaml/cr_minimal.yaml[]
 ----
 
-<1> Declares the Infinispan API version.
-<2> Declares the Infinispan CR.
+<1> Declares the `Infinispan` API version.
+<2> Declares the `Infinispan` CR.
 <3> Names the {brandname} cluster.
 <4> Specifies the number of nodes in the {brandname} cluster.

--- a/documentation/asciidoc/topics/ref_encryption_service_ca.adoc
+++ b/documentation/asciidoc/topics/ref_encryption_service_ca.adoc
@@ -5,7 +5,7 @@
 in a secret so you can retrieve them and use with remote clients.
 
 If the {openshift} service CA is available, {ispn_operator} adds the following
-`spec.security.endpointEncryption` configuration to the **Infinispan** CR:
+`spec.security.endpointEncryption` configuration to the `Infinispan` CR:
 
 [source,options="nowrap",subs=attributes+]
 ----


### PR DESCRIPTION
's/\*\*Infinispan\*\* CR/`Infinispan` CR/g' to conform with style guidelines for k8s API objects as per https://github.com/redhat-documentation/supplementary-style-guide/issues/13 