### PR TITLE
Remove duplicate name from the cluster PVC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,13 @@ os: linux
 before_install:
   - |
     if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
-       set -e
-       git fetch origin $TRAVIS_BRANCH
-       git diff --name-only FETCH_HEAD | grep -qvE '(\.md$)|(^(doc|documentation|manual|olm|ci|deploy/cr/|deploy/olm-catalog|build/cekit|build/jenkins|build/minikube|test-integration|.gitignore))/' || {
-         echo "Only docs, manual steps, test-integration,CI and OLM files were updated, stopping build process."
-         travis_terminate 0
-         exit 1
-        }
+      git fetch origin $TRAVIS_BRANCH
+      git diff --name-only FETCH_HEAD | grep -qvE '(\.md$)|(^(doc|documentation|manual|olm|ci|deploy/cr/|deploy/olm-catalog|build/cekit|build/jenkins|build/minikube|test-integration|.gitignore))/' || {
+        set -e
+        echo "Only docs, manual steps, test-integration,CI and OLM files were updated, stopping build process."
+        travis_terminate 0
+        exit 1
+      }
     fi
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       services:
         - docker
       env:
-        - KIND_VERSION=v0.8.1
+        - KIND_VERSION=v0.9.0
       before_script:
         - curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
         - curl -Lo kind https://kind.sigs.k8s.io/dl/${KIND_VERSION}/kind-linux-amd64 && chmod +x kind && sudo mv kind /usr/local/bin/

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.16.9@sha256:7175872357bc85847ec4b1aba46ed1d12fa054c83ac7a8a11f5c268957fd5765
+    image: kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20
     extraPortMappings:
       - containerPort: 30222
         hostPort: 11222

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -46,6 +46,7 @@ import (
 
 const (
 	DataMountPath        = "/opt/infinispan/server/data"
+	DataMountVolume      = "data-volume"
 	EncryptMountPath     = "/etc/encrypt"
 	ConfigVolumeName     = "config-volume"
 	EncryptVolumeName    = "encrypt-volume"
@@ -676,7 +677,7 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 							Name:      IdentitiesVolumeName,
 							MountPath: consts.ServerSecurityRoot,
 						}, {
-							Name:      m.Name,
+							Name:      DataMountVolume,
 							MountPath: DataMountPath,
 						}},
 					}},
@@ -720,7 +721,7 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 		}
 
 		pvc := &corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{
-			Name:      m.Name,
+			Name:      DataMountVolume,
 			Namespace: m.Namespace,
 		},
 			Spec: corev1.PersistentVolumeClaimSpec{
@@ -746,11 +747,11 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 		}
 		dep.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{*pvc}
 
-		AddVolumeChmodInitContainer("data-chmod-pv", m.Name, DataMountPath, &dep.Spec.Template.Spec)
+		AddVolumeChmodInitContainer("data-chmod-pv", DataMountVolume, DataMountPath, &dep.Spec.Template.Spec)
 	} else {
 		volumes := &dep.Spec.Template.Spec.Volumes
 		ephemeralVolume := corev1.Volume{
-			Name: m.Name,
+			Name: DataMountVolume,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},


### PR DESCRIPTION
Fixes #643
In addition to base issue:
- upgrade kind to v0.9.0 (probably backport to 2.0.x)
- Fix `set -e` location for `travis_terminate` to avoid problems with `after_failure` logging (need backport to 2.0.x)