### PR TITLE
Custom label propagation #650

### DIFF
--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -28,9 +28,7 @@ var (
 	DefaultCPULimit int64 = 500
 
 	DeploymentAnnotations = map[string]string{
-		"description":                    "Infinispan 10 (Ephemeral)",
-		"iconClass":                      "icon-infinispan",
-		"openshift.io/display-name":      "Infinispan 10 (Ephemeral)",
+		"openshift.io/display-name":      "Infinispan Cluster",
 		"openshift.io/documentation-url": "http://infinispan.org/documentation/",
 	}
 )

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -187,6 +187,10 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 	err := r.update(infinispan, func() {
 		// Apply defaults and endpoint encryption settings if not already set
 		infinispan.ApplyDefaults()
+		errLabel := infinispan.ApplyOperatorLabels()
+		if errLabel != nil {
+			reqLogger.Error(errLabel, "Error applying operator label")
+		}
 		infinispan.ApplyEndpointEncryptionSettings(kubernetes.GetServingCertsMode(), reqLogger)
 
 		// Perform all the possible preliminary checks before go on
@@ -660,6 +664,9 @@ func podAffinity(i *infinispanv1.Infinispan, matchLabels map[string]string) *cor
 func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispan, secret *corev1.Secret, configMap *corev1.ConfigMap) (*appsv1.StatefulSet, error) {
 	reqLogger := log.WithValues("Request.Namespace", m.Namespace, "Request.Name", m.Name)
 	lsPod := PodLabels(m.Name)
+	labelsForPod := PodLabels(m.Name)
+	m.AddOperatorLabelsForPods(labelsForPod)
+	m.AddLabelsForPods(labelsForPod)
 
 	memory := resource.MustParse(m.Spec.Container.Memory)
 	replicas := m.Spec.Replicas
@@ -672,7 +679,7 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 			Name:        m.Name,
 			Namespace:   m.Namespace,
 			Annotations: consts.DeploymentAnnotations,
-			Labels:      map[string]string{"template": "infinispan-ephemeral"},
+			Labels:      map[string]string{},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
@@ -682,7 +689,7 @@ func (r *ReconcileInfinispan) statefulSetForInfinispan(m *infinispanv1.Infinispa
 			Replicas: &replicas,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels:      lsPod,
+					Labels:      labelsForPod,
 					Annotations: map[string]string{"updateDate": time.Now().String()},
 				},
 				Spec: corev1.PodSpec{

--- a/pkg/controller/infinispan/resources/service/service_controller.go
+++ b/pkg/controller/infinispan/resources/service/service_controller.go
@@ -193,7 +193,7 @@ func setupServiceForEncryption(ispn *ispnv1.Infinispan, service *corev1.Service)
 }
 
 func computeService(ispn *ispnv1.Infinispan) *corev1.Service {
-	return &corev1.Service{
+	service := corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -214,10 +214,14 @@ func computeService(ispn *ispnv1.Infinispan) *corev1.Service {
 			},
 		},
 	}
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(service.Labels)
+	ispn.AddLabelsForServices(service.Labels)
+	return &service
 }
 
 func computePingService(ispn *ispnv1.Infinispan) *corev1.Service {
-	return &corev1.Service{
+	pingService := corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -239,6 +243,10 @@ func computePingService(ispn *ispnv1.Infinispan) *corev1.Service {
 			},
 		},
 	}
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(pingService.Labels)
+	ispn.AddLabelsForServices(pingService.Labels)
+	return &pingService
 }
 
 // computeServiceExternal compute the external service
@@ -269,7 +277,7 @@ func computeServiceExternal(ispn *ispnv1.Infinispan) *corev1.Service {
 		exposeSpec.Ports[0].NodePort = exposeConf.NodePort
 	}
 
-	externalService := &corev1.Service{
+	externalService := corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -277,7 +285,10 @@ func computeServiceExternal(ispn *ispnv1.Infinispan) *corev1.Service {
 		ObjectMeta: metadata,
 		Spec:       exposeSpec,
 	}
-	return externalService
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(externalService.Labels)
+	ispn.AddLabelsForServices(externalService.Labels)
+	return &externalService
 }
 
 // computeSiteService compute the XSite service
@@ -337,13 +348,15 @@ func computeSiteService(ispn *ispnv1.Infinispan) *corev1.Service {
 		ObjectMeta: objectMeta,
 		Spec:       exposeSpec,
 	}
-
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(siteService.Labels)
+	ispn.AddLabelsForServices(siteService.Labels)
 	return &siteService
 }
 
 // computeRoute compute the Route object
 func computeRoute(ispn *ispnv1.Infinispan) *routev1.Route {
-	route := &routev1.Route{
+	route := routev1.Route{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Route",
@@ -363,7 +376,11 @@ func computeRoute(ispn *ispnv1.Infinispan) *routev1.Route {
 	if ispn.GetEncryptionSecretName() != "" && !ispn.IsEncryptionDisabled() {
 		route.Spec.TLS = &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}
 	}
-	return route
+
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(route.Labels)
+	ispn.AddLabelsForServices(route.Labels)
+	return &route
 }
 
 // computeIngress compute the Ingress object
@@ -400,6 +417,9 @@ func computeIngress(ispn *ispnv1.Infinispan) *networkingv1beta1.Ingress {
 			},
 		}
 	}
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(ingress.Labels)
+	ispn.AddLabelsForServices(ingress.Labels)
 	return &ingress
 }
 

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/iancoleman/strcase"
 	ispnv1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
+	v1 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v1"
 	cconsts "github.com/infinispan/infinispan-operator/pkg/controller/constants"
 	ispnctrl "github.com/infinispan/infinispan-operator/pkg/controller/infinispan"
 	"github.com/infinispan/infinispan-operator/pkg/controller/infinispan/resources/config"
@@ -23,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
@@ -103,10 +105,42 @@ func TestOperatorUpgrade(t *testing.T) {
 func TestNodeStartup(t *testing.T) {
 	// Create a resource without passing any config
 	spec := DefaultSpec.DeepCopy()
+	spec.Annotations = make(map[string]string)
+	spec.Annotations[v1.TargetLabels] = "my-svc-label"
+	spec.Labels = make(map[string]string)
+	spec.Labels["my-svc-label"] = "my-svc-value"
+	os.Setenv(v1.OperatorTargetLabelsEnvVarName, "{\"operator-svc-label\":\"operator-svc-value\"}")
+	defer os.Unsetenv(v1.OperatorTargetLabelsEnvVarName)
+	spec.Annotations[v1.PodTargetLabels] = "my-pod-label"
+	spec.Labels["my-svc-label"] = "my-svc-value"
+	spec.Labels["my-pod-label"] = "my-pod-value"
+	os.Setenv(v1.OperatorPodTargetLabelsEnvVarName, "{\"operator-pod-label\":\"operator-pod-value\"}")
+	defer os.Unsetenv(v1.OperatorPodTargetLabelsEnvVarName)
 	// Register it
 	testKube.CreateInfinispan(spec, tutils.Namespace)
 	defer testKube.DeleteInfinispan(spec, tutils.SinglePodTimeout)
 	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
+	ispn := ispnv1.Infinispan{}
+	pod := corev1.Pod{}
+	tutils.ExpectNoError(testKube.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Name: spec.Name, Namespace: tutils.Namespace}, &ispn))
+	tutils.ExpectNoError(testKube.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Name: spec.Name + "-0", Namespace: tutils.Namespace}, &pod))
+	if pod.Labels["my-pod-label"] != ispn.Labels["my-pod-label"] ||
+		pod.Labels["operator-pod-label"] != "operator-pod-value" ||
+		ispn.Labels["operator-pod-label"] != "operator-pod-value" {
+		panic("Labels haven't been propagated to pods")
+	}
+	svcList := &corev1.ServiceList{}
+	tutils.ExpectNoError(testKube.Kubernetes.ResourcesList(ispn.ObjectMeta.Namespace, labels.Set{}, svcList))
+	if len(svcList.Items) == 0 {
+		panic("No services found for cluster")
+	}
+	for _, svc := range svcList.Items {
+		if svc.Labels["my-svc-label"] != ispn.Labels["my-svc-label"] ||
+			svc.Labels["operator-svc-label"] != "operator-svc-value" ||
+			ispn.Labels["operator-svc-label"] != "operator-svc-value" {
+			panic("Labels haven't been propagated to services")
+		}
+	}
 }
 
 // Run some functions for testing rights not covered by integration tests


### PR DESCRIPTION
This PR implements issue #650.

User can specify in the infinispan CR the label to be propagated:
```
apiVersion: infinispan.org/v1
kind: Infinispan
metadata:
  annotations:
    infinispan.org/podTargetLabels: propagateMeToPods, meTooToPods
    infinispan.org/targetLabels: propagateMeToServices, meTooToServices
  labels:
    propagateMeToPods: value1
    meTooToPods: value2
    propagateMeToServices: value3
    meTooToServices: value4
```

Operator can add labels to be propagated using dedicated annotations:
```
  annotations:
    infinispan.org/operatorPodTargetLabels: propagateMeToPods, meTooToPods
    infinispan.org/operatorTargetLabels: propagateMeToServices, meTooToServices
```
User can specify these annotations in json syntax via operator env vars:
```
INFINISPAN_OPERATOR_TARGET_LABELS={"operator-svc-label":"operator-svc-value"}
INFINISPAN_OPERATOR_POD_TARGET_LABELS={"operator-pod-label":"operator-pod-value"}
```
fixes #488 also