### PR TITLE
2.0.x: [test-integration] Update with recent features/fixes

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
@@ -68,7 +68,7 @@ public class Infinispan {
 
          List<Condition> conditions = infinispanObject.getStatus().getConditions();
          if (conditions != null) {
-            Condition wellFormed = conditions.stream().filter(c -> "wellFormed".equals(c.getType())).findFirst().orElse(null);
+            Condition wellFormed = conditions.stream().filter(c -> "WellFormed".equals(c.getType())).findFirst().orElse(null);
             return wellFormed != null && "True".equals(wellFormed.getStatus());
          } else {
             return false;

--- a/test-integration/operator-tests/src/test/resources/infinispans/advanced_setup_a.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/advanced_setup_a.yaml
@@ -3,6 +3,15 @@ kind: Infinispan
 metadata:
   name: advanced-setup-a
 spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels:
+            app: infinispan-pod
+            clusterName: advanced-setup-a
+            infinispan_cr: advanced-setup-a
+        topologyKey: "topology.kubernetes.io/zone"
   expose:
     type: Route
   container:

--- a/test-integration/operator-tests/src/test/resources/infinispans/advanced_setup_b.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/advanced_setup_b.yaml
@@ -4,12 +4,12 @@ metadata:
   name: advanced-setup-b
 spec:
   autoscale:
-    maxMemUsagePercent: 70
+    maxMemUsagePercent: 40
     maxReplicas: 5
-    minMemUsagePercent: 30
+    minMemUsagePercent: 20
     minReplicas: 3
   expose:
-    type: LoadBalancer
+    type: Route
   service:
     type: Cache
     replicationFactor: 3

--- a/test-integration/operator-tests/src/test/resources/infinispans/minimal_setup.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/minimal_setup.yaml
@@ -6,3 +6,6 @@ spec:
   expose:
     type: Route
   replicas: 2
+  security:
+    endpointEncryption:
+      type: None

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -11,14 +11,14 @@
 
     <properties>
         <!-- Dependencies versions -->
-        <version.infinispan>11.0.3.Final</version.infinispan>
-        <version.fabric8>4.10.2</version.fabric8>
-        <version.junit>5.3.0</version.junit>
-        <version.lombok>1.16.10</version.lombok>
+        <version.infinispan>11.0.9.Final</version.infinispan>
+        <version.fabric8>4.13.0</version.fabric8>
+        <version.junit>5.7.0</version.junit>
+        <version.lombok>1.16.22</version.lombok>
         <version.logback>1.1.3</version.logback>
         <version.slf4j>1.7.30</version.slf4j>
         <version.verifier>1.5</version.verifier>
-        <version.xtf>0.18</version.xtf>
+        <version.xtf>0.21</version.xtf>
 
         <!-- Plugin versions -->
         <version.maven.compiler>3.8.1</version.maven.compiler>

--- a/test-integration/test-server/pom.xml
+++ b/test-integration/test-server/pom.xml
@@ -11,7 +11,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <version.infinispan.hotrod>11.0.3.Final</version.infinispan.hotrod>
+        <version.infinispan.hotrod>11.0.9.Final</version.infinispan.hotrod>
         <version.jboss.servlet>1.0.2.Final</version.jboss.servlet>
         <version.maven.war>3.2.2</version.maven.war>
 

--- a/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/HotRodServlet.java
+++ b/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/HotRodServlet.java
@@ -15,6 +15,9 @@ import org.infinispan.client.hotrod.configuration.SaslQop;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 import org.infinispan.commons.marshall.ProtoStreamMarshaller;
 
+/**
+ * Used by MinimalSetupIT with unencrypted endpoints.
+ */
 @WebServlet("/hotrod/auth")
 public class HotRodServlet extends HttpServlet {
    private static final long serialVersionUID = 1L;
@@ -33,7 +36,6 @@ public class HotRodServlet extends HttpServlet {
          if(username != null || password != null) {
             builder.security().authentication().realm("default").serverName("infinispan").username(username).password(password).enable();
          }
-         builder.security().ssl().trustStorePath("/etc/minimal-setup-cert-secret/tls.crt");
 
          RemoteCacheManager rcm = new RemoteCacheManager(builder.build());
          RemoteCache<String, String> rc = rcm.administration().getOrCreateCache("hotrod-auth-test", "org.infinispan.DIST_SYNC");

--- a/test-integration/test-server/src/main/java/org/infinispan/operator/remote/cluster/HotRodCluster.java
+++ b/test-integration/test-server/src/main/java/org/infinispan/operator/remote/cluster/HotRodCluster.java
@@ -14,6 +14,9 @@ import org.infinispan.client.hotrod.configuration.ClientIntelligence;
 import org.infinispan.client.hotrod.configuration.ConfigurationBuilder;
 import org.infinispan.client.hotrod.exceptions.HotRodClientException;
 
+/**
+ * Used by MinimalSetupIT with unencrypted endpoints.
+ */
 @WebServlet("/hotrod/cluster")
 public class HotRodCluster extends HttpServlet {
    private static final long serialVersionUID = 2L;
@@ -29,7 +32,6 @@ public class HotRodCluster extends HttpServlet {
          ConfigurationBuilder builder = new ConfigurationBuilder();
          builder.addServer().host(serviceName).port(11222);
          builder.security().authentication().realm("default").serverName("infinispan").username(username).password(password).enable();
-         builder.security().ssl().trustStorePath("/etc/minimal-setup-cert-secret/tls.crt");
          builder.clientIntelligence(ClientIntelligence.BASIC);
 
          RemoteCacheManager rcm = new RemoteCacheManager(builder.build());


### PR DESCRIPTION
* Fixes expected `(W|w)ellFormed` condition
* Adds `None` type of encryption to the MinimalSetupIT
* Adds default AntiAffinity settings test
* Adds check that modified affinity configuration is propagated to StatefulSet