### PR TITLE
Fixed labels check on deployed operator #816

### DIFF
--- a/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
@@ -193,12 +193,12 @@ spec:
             replicas: 1
             selector:
               matchLabels:
-                name: infinispan-operator-alm-owned
+                name: infinispan-operator
             template:
               metadata:
-                name: infinispan-operator-alm-owned
+                name: infinispan-operator
                 labels:
-                  name: infinispan-operator-alm-owned
+                  name: infinispan-operator
               spec:
                 serviceAccountName: infinispan-operator
                 containers:

--- a/test/e2e/constants/constants.go
+++ b/test/e2e/constants/constants.go
@@ -35,6 +35,7 @@ var (
 	Memory               = consts.GetEnvWithDefault("INFINISPAN_MEMORY", "512Mi")
 	Namespace            = strings.ToLower(consts.GetEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing"))
 	MultiNamespace       = strings.ToLower(consts.GetEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing-1,namespace-for-testing-2"))
+	OperatorNamespace    = strings.ToLower(consts.GetEnvWithDefault("TESTING_OPERATOR_NAMESPACE", ""))
 	RunLocalOperator     = strings.ToUpper(consts.GetEnvWithDefault("RUN_LOCAL_OPERATOR", "true"))
 	RunSaOperator        = strings.ToUpper(consts.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	OperatorUpgradeStage = strings.ToUpper(consts.GetEnvWithDefault("OPERATOR_UPGRADE_STAGE", OperatorUpgradeStageNone))

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -132,7 +132,7 @@ func TestNodeStartup(t *testing.T) {
 			operatorNS = spec.Namespace
 		}
 		// operator deployed on cluster, labels are set by the deployment
-		if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorPodTargetLabelsEnvVarName, pod.Labels) {
+		if !areOperatorLabelsPropagated(operatorNS, ispnv1.OperatorPodTargetLabelsEnvVarName, pod.Labels) {
 			panic("Operator labels haven't been propagated to pods")
 		}
 	}
@@ -164,7 +164,7 @@ func TestNodeStartup(t *testing.T) {
 				operatorNS = spec.Namespace
 			}
 			// operator deployed on cluster, labels are set by the deployment
-			if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
+			if !areOperatorLabelsPropagated(operatorNS, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
 				panic("Operator labels haven't been propagated to services")
 			}
 		}

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -125,6 +125,12 @@ func TestNodeStartup(t *testing.T) {
 			panic("Infinispan CR labels haven't been propagated to pods")
 		}
 	} else {
+		// Get the operator namespace from the env if it's different
+		// from the testsuite one
+		operatorNS := tconst.OperatorNamespace
+		if operatorNS == "" {
+			operatorNS = spec.Namespace
+		}
 		// operator deployed on cluster, labels are set by the deployment
 		if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorPodTargetLabelsEnvVarName, pod.Labels) {
 			panic("Operator labels haven't been propagated to pods")
@@ -151,6 +157,12 @@ func TestNodeStartup(t *testing.T) {
 				panic("Labels haven't been propagated to services")
 			}
 		} else {
+			// Get the operator namespace from the env if it's different
+			// from the testsuite one
+			operatorNS := tconst.OperatorNamespace
+			if operatorNS == "" {
+				operatorNS = spec.Namespace
+			}
 			// operator deployed on cluster, labels are set by the deployment
 			if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
 				panic("Operator labels haven't been propagated to services")


### PR DESCRIPTION
When testing a deployed operator labels need to be retrieved from the deployment. Setting them on the test environment doesn't work.
