### PR TITLE
Fixed labels check on deployed operator #816

### DIFF
--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -139,8 +139,14 @@ func TestNodeStartup(t *testing.T) {
 			panic("Infinispan CR labels haven't been propagated to pods")
 		}
 	} else {
+		// Get the operator namespace from the env if it's different
+		// from the testsuite one
+		operatorNS := tutils.OperatorNamespace
+		if operatorNS == "" {
+			operatorNS = spec.Namespace
+		}
 		// operator deployed on cluster, labels are set by the deployment
-		if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorPodTargetLabelsEnvVarName, pod.Labels) {
+		if !areOperatorLabelsPropagated(operatorNS, ispnv1.OperatorPodTargetLabelsEnvVarName, pod.Labels) {
 			panic("Operator labels haven't been propagated to pods")
 		}
 	}
@@ -164,6 +170,12 @@ func TestNodeStartup(t *testing.T) {
 				panic("Labels haven't been propagated to services")
 			}
 		} else {
+			// Get the operator namespace from the env if it's different
+			// from the testsuite one
+			operatorNS := tutils.OperatorNamespace
+			if operatorNS == "" {
+				operatorNS = spec.Namespace
+			}
 			// operator deployed on cluster, labels are set by the deployment
 			if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
 				panic("Operator labels haven't been propagated to services")

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -177,7 +177,7 @@ func TestNodeStartup(t *testing.T) {
 				operatorNS = spec.Namespace
 			}
 			// operator deployed on cluster, labels are set by the deployment
-			if !areOperatorLabelsPropagated(spec.Namespace, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
+			if !areOperatorLabelsPropagated(operatorNS, ispnv1.OperatorTargetLabelsEnvVarName, svc.Labels) {
 				panic("Operator labels haven't been propagated to services")
 			}
 		}

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -33,6 +33,7 @@ var (
 	Memory               = constants.GetEnvWithDefault("INFINISPAN_MEMORY", "512Mi")
 	Namespace            = strings.ToLower(constants.GetEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing"))
 	MultiNamespace       = strings.ToLower(constants.GetEnvWithDefault("TESTING_MULTINAMESPACE", "namespace-for-testing-1,namespace-for-testing-2"))
+	OperatorNamespace    = strings.ToLower(constants.GetEnvWithDefault("TESTING_OPERATOR_NAMESPACE", ""))
 	RunLocalOperator     = strings.ToUpper(constants.GetEnvWithDefault("RUN_LOCAL_OPERATOR", "true"))
 	RunSaOperator        = strings.ToUpper(constants.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	OperatorUpgradeStage = strings.ToUpper(constants.GetEnvWithDefault("OPERATOR_UPGRADE_STAGE", OperatorUpgradeStageNone))


### PR DESCRIPTION
When testing a deployed operator labels need to be retrieved from the deployment. Setting them on the test environment doesn't work.