### PR TITLE
Disable CacheService backup test.

### DIFF
--- a/test/e2e/backup-restore/backup_restore_test.go
+++ b/test/e2e/backup-restore/backup_restore_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 
 func TestBackupRestore(t *testing.T) {
 	t.Run(string(v1.ServiceTypeDataGrid), testBackupRestore(datagridService))
-	t.Run(string(v1.ServiceTypeCache), testBackupRestore(cacheService))
+	// t.Run(string(v1.ServiceTypeCache), testBackupRestore(cacheService))
 }
 
 func TestBackupRestoreTransformations(t *testing.T) {


### PR DESCRIPTION
Temporarily disable the cache service test to ensure that CI is only failing with this case.