### PR TITLE
[2.0.x] Utilize CreateOrUpdate for all Infinispan CR's updates in test

### DIFF
--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -320,6 +320,7 @@ func genericTestForContainerUpdated(ispn ispnv1.Infinispan, modifier func(*ispnv
 	kubernetes.CreateInfinispan(spec, tconst.Namespace)
 	defer kubernetes.DeleteInfinispan(name, tconst.Namespace, tconst.SinglePodTimeout)
 	kubernetes.WaitForInfinispanPods(int(ispn.Spec.Replicas), tconst.SinglePodTimeout, spec.Name, spec.Namespace)
+	kubernetes.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)
 	// Get the associate StatefulSet
 	ss := appsv1.StatefulSet{}
 


### PR DESCRIPTION
With #566 minor fixes required for the downstream (2.0.x) test stability