### PR TITLE
[2.0.x] Fixed statefulset reconc. #783

### DIFF
--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -207,7 +207,7 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 
 		reqLogger.Info("Creating a new ConfigMap", "ConfigMap.Name", configMap.Name)
 		err = r.client.Create(context.TODO(), configMap)
-		if err != nil {
+		if err != nil && !errors.IsAlreadyExists(err) {
 			reqLogger.Error(err, "failed to create new ConfigMap")
 			return reconcile.Result{}, err
 		}


### PR DESCRIPTION
Ignoring already exists error on configmap creation allows statefulset reconciliation.
Fixes #783 for 2.0.x