### PR TITLE
docs #702 clarification for xsite cluster names

### DIFF
--- a/documentation/asciidoc/topics/proc_configuring_sites_automatically.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_sites_automatically.adoc
@@ -11,9 +11,7 @@ Configure {ispn_operator} to establish cross-site views with {brandname} cluster
 . Create an `Infinispan` CR for each {brandname} cluster.
 . Specify the name of the local site with `spec.service.sites.local.name`.
 . Provide the name, URL, and secret for each {brandname} cluster that acts as a backup location with `spec.service.sites.locations`.
-. Specify cluster names and namespaces for {brandname} clusters at each site with the the `clusterName` and `namespace` fields, if necessary.
-+
-You need to specify cluster names and namespaces for backup locations only if they do not match those for the local {brandname} cluster.
+. If {brandname} cluster names or namespaces at the remote site do not match the local site, specify those values with the `clusterName` and `namespace` fields.
 +
 The following are example `Infinispan` CR definitions for **LON** and **NYC**:
 +
@@ -39,8 +37,8 @@ spec:
           url: openshift://api.rhdg-lon.openshift-aws.myhost.com:6443
           secretName: lon-token
         - name: NYC
-          clusterName: {example_crd_name}
-          namespace: {example_namespace}
+          clusterName: nyc-cluster
+          namespace: nyc-cluster-namespace
           url: openshift://api.rhdg-nyc.openshift-aws.myhost.com:6443
           secretName: nyc-token
 ----
@@ -52,7 +50,7 @@ spec:
 apiVersion: infinispan.org/v1
 kind: Infinispan
 metadata:
-  name: {example_crd_name}
+  name: nyc-cluster
 spec:
   replicas: 2
   service:

--- a/documentation/asciidoc/topics/ref_xsite_crd_automatic.adoc
+++ b/documentation/asciidoc/topics/ref_xsite_crd_automatic.adoc
@@ -27,8 +27,10 @@ This secret contains different authentication objects, depending on your
 Kubernetes environment.
 ====
 +
-<8> Logs error messages for the JGroups TCP protocol.
-<9> Logs fatal messages for the JGroups RELAY2 protocol.
+<8> Specifies the cluster name at the backup location if it is different to the cluster name at the local site.
+<9> Specifies the namespace of the {brandname} cluster at the backup location if it does not match the namespace at the local site.
+<10> Logs error messages for the JGroups TCP protocol.
+<11> Logs fatal messages for the JGroups RELAY2 protocol.
 endif::community[]
 
 //Downstream
@@ -39,7 +41,9 @@ ifdef::downstream[]
 <4> Provides connection information for all backup locations.
 <5> Specifies a backup location that matches `.spec.service.sites.local.name`.
 <6> Specifies the URL of the {openshiftshort} API for the backup location.
-<7> Specifies the secret that contains the service account token for the backup location.
-<8> Logs error messages for the JGroups TCP protocol.
-<9> Logs fatal messages for the JGroups RELAY2 protocol.
+<7> Specifies the secret that contains the service account token for the backup site.
+<8> Specifies the cluster name at the backup location if it is different to the cluster name at the local site.
+<9> Specifies the namespace of the {brandname} cluster at the backup location if it does not match the namespace at the local site.
+<10> Logs error messages for the JGroups TCP protocol.
+<11> Logs fatal messages for the JGroups RELAY2 protocol.
 endif::downstream[]

--- a/documentation/asciidoc/topics/yaml/cr_backup_site_automatic.yaml
+++ b/documentation/asciidoc/topics/yaml/cr_backup_site_automatic.yaml
@@ -12,9 +12,11 @@ spec:
         url: openshift://api.site-a.devcluster.openshift.com:6443 <6>
         secretName: lon-token <7>
       - name: NYC
+        clusterName: nyc-cluster-name <8>
+        namespace: nyc-cluster-namespace <9>
         url: openshift://api.site-b.devcluster.openshift.com:6443
         secretName: nyc-token
   logging:
     categories:
-      org.jgroups.protocols.TCP: error <8>
-      org.jgroups.protocols.relay.RELAY2: fatal <9>
+      org.jgroups.protocols.TCP: error <10>
+      org.jgroups.protocols.relay.RELAY2: fatal <11>

--- a/documentation/asciidoc/topics/yaml/datagrid_service.yaml
+++ b/documentation/asciidoc/topics/yaml/datagrid_service.yaml
@@ -26,7 +26,9 @@ spec:
         url: openshift://api.azure.host:6443
         secretName: azure-token
       - name: aws
+        # Specifies the cluster name at the backup location.
         clusterName: {example_crd_name}
+        # Specifies the namespace for the cluster at the backup location.
         namespace: {example_namespace}
         url: openshift://api.aws.host:6443
         secretName: aws-token


### PR DESCRIPTION
Noticed some oddities in the docs for the backport of #702 and need to fix on master.