### PR TITLE
[test-integration] Wait for status presence

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
@@ -63,8 +63,8 @@ public class Infinispan {
       BooleanSupplier bs = () -> {
          sync();
 
-         List<Condition> conditions = infinispanObject.getStatus().getConditions();
-         if (conditions != null) {
+         if (infinispanObject.getStatus() != null) {
+            List<Condition> conditions = infinispanObject.getStatus().getConditions();
             Condition wellFormed = conditions.stream().filter(c -> "WellFormed".equals(c.getType())).findFirst().orElse(null);
             return wellFormed != null && "True".equals(wellFormed.getStatus());
          } else {


### PR DESCRIPTION
Prevents `NullPointerException` in case the `waitFor()` is syncs up earlier then Operator processes the Infinispan CR for the first time