### PR TITLE
[test-integration] Verify operator secret and service removal

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/util/CleanUpValidator.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/util/CleanUpValidator.java
@@ -20,6 +20,7 @@ public class CleanUpValidator {
       conditions = new ArrayList<>();
       conditions.add(
             () -> openShift.apps().statefulSets().withName(appName).get() == null &&
+                  openShift.secrets().withName(appName + "-generated-operator-secret").get() == null &&
                   openShift.services().withName(appName).get() == null &&
                   openShift.services().withName(appName + "-ping").get() == null &&
                   openShift.configMaps().withName(appName + "-configuration").get() == null &&


### PR DESCRIPTION
Adds `*-generated-admin-secret` and `*-admin-service` removal verification upon **Infinispan** deletion