### PR TITLE
Upgrade to Infinispan 12.1.x

### DIFF
--- a/deploy/operator-install.yaml
+++ b/deploy/operator-install.yaml
@@ -1290,4 +1290,4 @@ spec:
             - name: OPERATOR_NAME
               value: "infinispan-operator"
             - name: RELATED_IMAGE_OPENJDK
-              value: "quay.io/infinispan/server:12.0"
+              value: "quay.io/infinispan/server:12.1"

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -36,4 +36,4 @@ spec:
             - name: OPERATOR_NAME
               value: "infinispan-operator"
             - name: RELATED_IMAGE_OPENJDK
-              value: "quay.io/infinispan/server:12.0"
+              value: "quay.io/infinispan/server:12.1"

--- a/pkg/controller/constants/image.go
+++ b/pkg/controller/constants/image.go
@@ -9,9 +9,9 @@ const (
 	OperandImageOpenJ9 = "RELATED_IMAGE_OPENJ9"
 
 	// DefaultOperandImageOpenJDK default image for OpenJDK stack
-	DefaultOperandImageOpenJDK = "quay.io/infinispan/server:12.0"
+	DefaultOperandImageOpenJDK = "quay.io/infinispan/server:12.1"
 	// DefaultOperandImageOpenJ9 default image for OpenJ9 stack
-	DefaultOperandImageOpenJ9 = "infinispan-for-openj9/server:12.0"
+	DefaultOperandImageOpenJ9 = "infinispan-for-openj9/server:12.1"
 )
 
 // GetDefaultInfinispanJavaImage returns default Infinispan Java image depends of the runtime architecture

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -37,8 +37,8 @@ var (
 	RunSaOperator        = strings.ToUpper(constants.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	OperatorUpgradeStage = strings.ToUpper(constants.GetEnvWithDefault("OPERATOR_UPGRADE_STAGE", OperatorUpgradeStageNone))
 	CleanupInfinispan    = strings.ToUpper(constants.GetEnvWithDefault("CLEANUP_INFINISPAN_ON_FINISH", "true"))
-	ExpectedImage        = constants.GetEnvWithDefault("EXPECTED_IMAGE", "quay.io/infinispan/server:12.0")
-	NativeImageName      = constants.GetEnvWithDefault("NATIVE_IMAGE", "quay.io/infinispan/server-native:12.0")
+	ExpectedImage        = constants.GetEnvWithDefault("EXPECTED_IMAGE", "quay.io/infinispan/server:12.1")
+	NativeImageName      = constants.GetEnvWithDefault("NATIVE_IMAGE", "quay.io/infinispan/server-native:12.1")
 	ExposeServiceType    = constants.GetEnvWithDefault("EXPOSE_SERVICE_TYPE", "NodePort")
 
 	OperatorUpgradeStateFlow = []ispnv1.ConditionType{ispnv1.ConditionUpgrade, ispnv1.ConditionStopping, ispnv1.ConditionWellFormed}


### PR DESCRIPTION
Infinispan 12.1.0.Final is due on the 02/04/21, we should upgrade the operator to CR2 images to ensure there are no issues.