### PR TITLE
Infinispan-957: Remove redundant v1.GetEndpointURIScheme function

### DIFF
--- a/pkg/apis/infinispan/v1/types_util.go
+++ b/pkg/apis/infinispan/v1/types_util.go
@@ -257,15 +257,11 @@ func (ispn *Infinispan) GetSiteServiceName() string {
 
 // GetEndpointScheme returns the protocol scheme used by the Infinispan cluster
 func (ispn *Infinispan) GetEndpointScheme() string {
-	return strings.ToLower(string(ispn.GetEndpointURIScheme()))
-}
-
-// GetEndpointURIScheme returns the protocol URI scheme used by the Infinispan cluster
-func (ispn *Infinispan) GetEndpointURIScheme() corev1.URIScheme {
+	endPointSchema := corev1.URISchemeHTTP
 	if ispn.IsEncryptionCertSourceDefined() && !ispn.IsEncryptionDisabled() {
-		return corev1.URISchemeHTTPS
+		endPointSchema = corev1.URISchemeHTTPS
 	}
-	return corev1.URISchemeHTTP
+	return strings.ToLower(string(endPointSchema))
 }
 
 // GetSecretName returns the secret name associated with a server


### PR DESCRIPTION
Remove "func (ispn *Infinispan) GetEndpointURIScheme()" and move the logic to "unc (ispn *Infinispan) GetEndpointScheme() string"