### PR TITLE
Documentation change

### DIFF
--- a/documentation/asciidoc/topics/con_creating_caches.adoc
+++ b/documentation/asciidoc/topics/con_creating_caches.adoc
@@ -1,8 +1,8 @@
 [id='creating_caches-{context}']
 = Creating {brandname} Caches
-To create caches when running {brandname} on {k8s}, you should:
+To create caches when running {brandname} on {k8s}, you can:
 
-* Use `Cache` CR as the primary mechanism for creating caches.
+* Use `Cache` CR.
 * Create multiple caches at a time with {brandname} CLI if you do not use `Cache` CR.
 * Access {brandname} Console and create caches in XML or JSON format as an alternative to `Cache` CR or {brandname} CLI.
 * Use Hot Rod clients to create caches either programmatically or through per cache properties only if required.


### PR DESCRIPTION
Rewording for creating caches via Cache CR. Comes from downstream. We should not suggest using tech preview feature as the "primary mechanism".