### PR TITLE
Cluster configuration ConfigMap updates on start #1102

### DIFF
--- a/pkg/controller/zerocapacity/zero_controller.go
+++ b/pkg/controller/zerocapacity/zero_controller.go
@@ -432,7 +432,7 @@ func (z *Controller) configureServer(name, namespace string, infinispan *v1.Infi
 		"org.infinispan.server.core.backup": "debug",
 	}
 
-	if err := ispnCtrl.ConfigureServerEncryption(infinispan, config, z.Client); err != nil {
+	if result, err := ispnCtrl.ConfigureServerEncryption(infinispan, config, z.Client); result != nil {
 		return nil, fmt.Errorf("Unable to configure zero-capacity encryption: %w", err)
 	}
 


### PR DESCRIPTION
@dmvolod It turns out I also wasn't configuring the `c.truststore.Password` correctly, which resulted in the ConfigMap values changing on second reconcilliation.