### PR TITLE
Tests should setup OSDK_FORCE_RUN_MODE=local if operator runs locally

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ jobs:
         - docker
       env:
         - KIND_VERSION=v0.11.0
-        - OSDK_FORCE_RUN_MODE=local
       before_script:
         - source ./build/travis/configure-travis-ci.sh
         - go mod vendor
@@ -57,7 +56,6 @@ jobs:
         - docker
       env:
         - KIND_VERSION=v0.11.0
-        - OSDK_FORCE_RUN_MODE=local
       before_script:
         - source ./build/travis/configure-travis-ci.sh
         - go mod vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 go:
   - '1.13.x'
 
+cache:
+  directories:
+    - $GOPATH/pkg/mod
+
 dist: focal
 os: linux
 

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -622,6 +622,7 @@ func runOperatorLocally(stopCh chan struct{}, namespace string) {
 	kubeConfig := kube.FindKubeConfig()
 	_ = os.Setenv("WATCH_NAMESPACE", namespace)
 	_ = os.Setenv("KUBECONFIG", kubeConfig)
+	_ = os.Setenv("OSDK_FORCE_RUN_MODE", "local")
 	launcher.Launch(launcher.Parameters{StopChannel: stopCh})
 }
 func (k TestKubernetes) DeleteCache(cache *ispnv2.Cache) {


### PR DESCRIPTION
Can't wait for someone could fix this issue, as need to be remember this env var option every local test run :smile: 