### PR TITLE
Switch to operator version 2.2 in docs

### DIFF
--- a/documentation/asciidoc/topics/attributes/community-attributes.adoc
+++ b/documentation/asciidoc/topics/attributes/community-attributes.adoc
@@ -21,16 +21,16 @@
 :conf_path: /opt/infinispan/server/conf
 :backup_path: /opt/infinispan/backups
 :server_image: quay.io/infinispan/server
-:server_image_version: 12.1
+:server_image_version: 13.0
 
 //
 // Infinispan
 //
 
 :ispn_operator: Infinispan Operator
-:ispn_operator_version: 2.1
-:ispn_version: 12.0
-:server_image_version: 12.0
+:ispn_operator_version: 2.2
+:ispn_version: 13.0
+:server_image_version: 13.0
 :brandname: Infinispan
 :fullbrandname: Infinispan
 :datagridservice: Data Grid Service


### PR DESCRIPTION
I'm not sure about correct version for Operator and Infinispan server