### PR TITLE
Print error in case of error only in config controller

### DIFF
--- a/pkg/controller/infinispan/resources/config/config_controller.go
+++ b/pkg/controller/infinispan/resources/config/config_controller.go
@@ -96,8 +96,10 @@ func (c *configResource) Process() (reconcile.Result, error) {
 	}
 
 	if result, err := c.computeAndReconcileConfigMap(xsite); result != nil {
-		c.log.Error(err, "Error while computing and reconciling ConfigMap")
-		return *result, nil
+		if err != nil {
+			c.log.Error(err, "Error while computing and reconciling ConfigMap")
+		}
+		return *result, err
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Error should be printed in case of the real error (when resource not ready empty error can be printed)