### PR TITLE
[test-integration] Tests stabilizations/fixes

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/identities/Credentials.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/identities/Credentials.java
@@ -3,9 +3,12 @@ package org.infinispan.identities;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.List;
+
 @Getter
 @Setter
 public class Credentials {
    private String username;
    private String password;
+   private List<String> roles;
 }

--- a/test-integration/operator-tests/src/test/resources/infinispans/datagrid_service.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/datagrid_service.yaml
@@ -9,15 +9,15 @@ spec:
       - labelSelector:
           matchLabels:
             app: infinispan-pod
-            clusterName: advanced-setup-a
-            infinispan_cr: advanced-setup-a
+            clusterName: datagrid-service
+            infinispan_cr: datagrid-service
         topologyKey: "topology.kubernetes.io/zone"
   expose:
     type: Route
   container:
     cpu: 1500m
     memory: 1Gi
-    extra-jvm-opts: "-XX:NativeMemoryTracking=summary"
+    extraJvmOpts: "-XX:NativeMemoryTracking=summary"
   logging:
     categories:
       org.infinispan: warn

--- a/test-integration/operator-tests/src/test/resources/libs/custom-filter/pom.xml
+++ b/test-integration/operator-tests/src/test/resources/libs/custom-filter/pom.xml
@@ -10,7 +10,7 @@
     <name>Client Authentication Mapper</name>
 
     <properties>
-        <version.org.infinispan>12.1.1.Final</version.org.infinispan>
+        <version.org.infinispan>12.1.4.Final</version.org.infinispan>
         <version.org.slf4j>1.7.12</version.org.slf4j>
     </properties>
 

--- a/test-integration/operator-tests/src/test/resources/monitoring/grafana_sub.yaml
+++ b/test-integration/operator-tests/src/test/resources/monitoring/grafana_sub.yaml
@@ -8,4 +8,3 @@ spec:
   name: grafana-operator
   source: community-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: grafana-operator.v3.9.0

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <!-- Dependencies versions -->
-        <version.infinispan>12.1.1.Final</version.infinispan>
+        <version.infinispan>12.1.4.Final</version.infinispan>
         <version.fabric8>4.13.0</version.fabric8>
         <version.junit>5.7.0</version.junit>
         <version.lombok>1.16.22</version.lombok>
@@ -102,19 +102,4 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <repositories>
-        <repository>
-            <id>bintray-xtf-cz-xtf</id>
-            <name>Bintray XTF</name>
-            <url>https://dl.bintray.com/xtf-cz/xtf</url>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>always</updatePolicy>
-            </releases>
-        </repository>
-    </repositories>
 </project>

--- a/test-integration/test-server/pom.xml
+++ b/test-integration/test-server/pom.xml
@@ -11,7 +11,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <version.infinispan.hotrod>12.1.1.Final</version.infinispan.hotrod>
+        <version.infinispan.hotrod>12.1.4.Final</version.infinispan.hotrod>
         <version.jboss.servlet>1.0.2.Final</version.jboss.servlet>
         <version.maven.war>3.2.2</version.maven.war>
 


### PR DESCRIPTION
* Fix Credentials class to accept also roles
* Wait for Grafana operator to be running before creating Grafana CRs
* Install latest Grafana CSV rather then specific version
* Fix required role for the grafana-serviceaccount
* Fix cluster pods retrieval
* Fix `extraJvmOpts` field
* Fix label selector for datagrid-service affinity
* Upgrade Infinsipan version to 12.1.3
* XTF framework is now available in maven central