### PR TITLE
[2.1.x] ConfigMap changes on update cause startup failures #1150

### DIFF
--- a/pkg/controller/infinispan/resources/config/config_controller.go
+++ b/pkg/controller/infinispan/resources/config/config_controller.go
@@ -75,8 +75,13 @@ func Add(mgr manager.Manager) error {
 }
 
 func (c *configResource) Process() (reconcile.Result, error) {
-	// Don't update the ConfigMap if an update is required
+	// Don't update the ConfigMap if an update is about to be scheduled
 	if req, err := ispnctrl.IsUpgradeRequired(c.infinispan); req || err != nil {
+		return reconcile.Result{RequeueAfter: consts.DefaultWaitOnCreateResource}, nil
+	}
+
+	// Don't update the configMap if an update is in progress
+	if c.infinispan.IsConditionTrue(ispnv1.ConditionUpgrade) {
 		return reconcile.Result{RequeueAfter: consts.DefaultWaitOnCreateResource}, nil
 	}
 


### PR DESCRIPTION
- Add missing check for upgrade in progress

@dmvolod In our discussion [here](https://github.com/infinispan/infinispan-operator/pull/1152#pullrequestreview-687390671) I concluded that we could remove the `IsConditionTrue(ispnv1.ConditionUpgrade)` check. This isn't the case. The first check `IsUpgradeRequired` guards against an upgrade being scheduled in the near future and `IsConditionTrue(ispnv1.ConditionUpgrade)` guards against an upgrade currently being in progress.