### PR TITLE
[2.0.x] Support for static XSite configuration #1156

### DIFF
--- a/deploy/cr/xsite-static-loadbalancer/xsite_a.yaml
+++ b/deploy/cr/xsite-static-loadbalancer/xsite_a.yaml
@@ -1,0 +1,20 @@
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: example-infinispan
+spec:
+  replicas: 1
+  expose:
+    type: LoadBalancer
+  service:
+    type: DataGrid
+    sites:
+      local:
+        name: SiteA
+        expose:
+          type: LoadBalancer
+      locations:
+      - name: SiteA
+        url: infinispan+xsite://infinispan-sitea.myhost.com:7900
+      - name: SiteB
+        url: infinispan+xsite://infinispan-siteb.myhost.com:7900

--- a/deploy/cr/xsite-static-loadbalancer/xsite_b.yaml
+++ b/deploy/cr/xsite-static-loadbalancer/xsite_b.yaml
@@ -1,0 +1,20 @@
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: example-infinispan
+spec:
+  replicas: 1
+  expose:
+    type: LoadBalancer
+  service:
+    type: DataGrid
+    sites:
+      local:
+        name: SiteB
+        expose:
+          type: LoadBalancer
+      locations:
+      - name: SiteA
+        url: infinispan+xsite://infinispan-sitea.myhost.com:7900
+      - name: SiteB
+        url: infinispan+xsite://infinispan-siteb.myhost.com:7900

--- a/deploy/crds/infinispan.org_infinispans_crd.yaml
+++ b/deploy/crds/infinispan.org_infinispans_crd.yaml
@@ -506,11 +506,10 @@ spec:
                           secretName:
                             type: string
                           url:
-                            pattern: ^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$
+                            pattern: (^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)|(^(infinispan\+xsite):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)
                             type: string
                         required:
                           - name
-                          - secretName
                           - url
                         type: object
                       type: array

--- a/deploy/operator-install.yaml
+++ b/deploy/operator-install.yaml
@@ -650,11 +650,10 @@ spec:
                           secretName:
                             type: string
                           url:
-                            pattern: ^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$
+                            pattern: (^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)|(^(infinispan\+xsite):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)
                             type: string
                         required:
                           - name
-                          - secretName
                           - url
                         type: object
                       type: array

--- a/documentation/asciidoc/stories/assembly_xsite_replication.adoc
+++ b/documentation/asciidoc/stories/assembly_xsite_replication.adoc
@@ -14,6 +14,8 @@ include::{topics}/proc_creating_sa_tokens.adoc[leveloffset=+1]
 include::{topics}/proc_exchanging_sa_tokens.adoc[leveloffset=+1]
 include::{topics}/proc_configuring_sites.adoc[leveloffset=+1]
 include::{topics}/ref_xsite_crd.adoc[leveloffset=+2]
+include::{topics}/proc_configuring_sites_manually.adoc[leveloffset=+1]
+include::{topics}/ref_xsite_crd_manually.adoc[leveloffset=+2]
 
 
 // Restore the parent context.

--- a/documentation/asciidoc/topics/proc_configuring_sites_manually.adoc
+++ b/documentation/asciidoc/topics/proc_configuring_sites_manually.adoc
@@ -1,0 +1,106 @@
+[id='manual-xsite-views_{context}']
+= Manually connecting {brandname} clusters
+You can specify static network connection details to perform cross-site replication with {brandname} clusters running outside {k8s}.
+Manual cross-site connections are necessary in any scenario where access to the Kubernetes API is not available outside the {k8s} cluster where {brandname} runs.
+
+You can use both automatic and manual connections for {brandname} clusters in the same `Infinispan` CR.
+However, you must ensure that {brandname} clusters establish connections in the same way at each site.
+
+.Prerequisites
+
+Manually connecting {brandname} clusters to form cross-site views requires predictable network locations for {brandname} services.
+
+You need to know the network locations before they are created, which requires you to:
+
+* Have the host names and ports for each {brandname} cluster that you plan to configure as a backup location.
+* Have the host name of the `<cluster-name>-site` service for any remote {brandname} cluster that is running on {k8s}. +
+You must use the `<cluster-name>-site` service to form a cross-site view between a cluster that {ispn_operator} manages and any other cluster.
+
+.Procedure
+
+. Create an `Infinispan` CR for each {brandname} cluster.
+. Specify the name of the local site with `spec.service.sites.local.name`.
+. Provide the name and static URL for each {brandname} cluster that acts as a backup location with `spec.service.sites.locations`, for example:
++
+* **LON**
++
+[source,yaml,options="nowrap",subs=attributes+]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: {example_crd_name}
+spec:
+  replicas: 3
+  service:
+    type: DataGrid
+    sites:
+      local:
+        name: LON
+        expose:
+          type: LoadBalancer
+      locations:
+        - name: NYC
+          url: infinispan+xsite://infinispan-nyc.myhost.com:7900
+----
++
+* **NYC**
++
+[source,yaml,options="nowrap",subs=attributes+]
+----
+apiVersion: infinispan.org/v1
+kind: Infinispan
+metadata:
+  name: {example_crd_name}
+spec:
+  replicas: 3
+  service:
+    type: DataGrid
+    sites:
+      local:
+        name: NYC
+        expose:
+          type: LoadBalancer
+      locations:
+        - name: LON
+          url: infinispan+xsite://infinispan-lon.myhost.com:7900
+----
++
+. Adjust logging levels for cross-site replication as follows:
++
+[source,yaml,options="nowrap",subs=attributes+]
+----
+...
+  logging:
+    categories:
+      org.jgroups.protocols.TCP: error
+      org.jgroups.protocols.relay.RELAY2: fatal
+----
++
+The preceding configuration decreases logging for JGroups TCP and RELAY2
+protocols to reduce excessive messages about cluster backup operations, which
+can result in a large number of log files that use container storage.
++
+. Configure nodes with any other {datagridservice} resources.
+. Apply the `Infinispan` CRs.
+. Check node logs to verify that {brandname} clusters form a cross-site view, for example:
++
+[source,options="nowrap",subs=attributes+]
+----
+$ {oc_logs} {example_crd_name}-0 | grep x-site
+
+INFO  [org.infinispan.XSITE] (jgroups-5,{example_crd_name}-0-<id>) ISPN000439: Received new x-site view: [NYC]
+INFO  [org.infinispan.XSITE] (jgroups-7,{example_crd_name}-0-<id>) ISPN000439: Received new x-site view: [NYC, LON]
+----
+
+.Next steps
+
+If your clusters have formed a cross-site view, you can start adding backup
+locations to caches.
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:#ref_xsite_crd_manually-xsite[Cross-Site Replication Resources]
+* link:#adding_backup_locations-cache-cr[Adding Backup Locations to Caches]
+* link:{xsite_docs}[{brandname} Guide to Cross-Site Replication]

--- a/documentation/asciidoc/topics/ref_xsite_crd_manually.adoc
+++ b/documentation/asciidoc/topics/ref_xsite_crd_manually.adoc
@@ -1,9 +1,9 @@
-[id='ref_xsite_crd-{context}']
+[id='ref_xsite_crd_manually-{context}']
 = Cross-Site Replication Resources
 
 [source,options="nowrap",subs=attributes+]
 ----
-include::yaml/cr_backup_site.yaml[]
+include::yaml/cr_backup_site_manually.yaml[]
 ----
 
 //Community
@@ -15,21 +15,9 @@ ifdef::community[]
 * Use `LoadBalancer` for independent {openshiftshort} clusters.
 <4> Provides connection information for all backup locations.
 <5> Specifies a backup location that matches `spec.service.sites.local.name`.
-<6> Specifies a backup location.
-//* Use `xsite://` if the backup location has a static hostname and port.
-* Use `minikube://` if the backup location is a Minikube instance.
-* Use `openshift://` if the backup location is an {openshiftshort} cluster. You should specify the URL of the Kubernetes API.
-* Use `infinispan+xsite//` if the backup location has a static hostname and port.
-<7> Specifies the access secret for a site.
-+
-[NOTE]
-====
-This secret contains different authentication objects, depending on your
-Kubernetes environment.
-====
-+
-<8> Logs error messages for the JGroups TCP protocol.
-<9> Logs fatal messages for the JGroups RELAY2 protocol.
+<6> Specifies the static URL for the backup location in the format of `infinispan+xsite://<hostname>:<port>`. The default port is `7900`.
+<7> Logs error messages for the JGroups TCP protocol.
+<8> Logs fatal messages for the JGroups RELAY2 protocol.
 endif::community[]
 
 //Downstream
@@ -39,8 +27,7 @@ ifdef::downstream[]
 <3> Specifies `LoadBalancer` as the service that handles communication between backup locations.
 <4> Provides connection information for all backup locations.
 <5> Specifies a backup location that matches `spec.service.sites.local.name`.
-<6> Specifies the URL of the {openshiftshort} API for the backup location.
-<7> Specifies the secret that contains the service account token for the backup site.
-<8> Logs error messages for the JGroups TCP protocol.
-<9> Logs fatal messages for the JGroups RELAY2 protocol.
+<6> Specifies the static URL for the backup location in the format of `infinispan+xsite://<hostname>:<port>`. The default port is `7900`.
+<7> Logs error messages for the JGroups TCP protocol.
+<8> Logs fatal messages for the JGroups RELAY2 protocol.
 endif::downstream[]

--- a/documentation/asciidoc/topics/yaml/cr_backup_site_manually.yaml
+++ b/documentation/asciidoc/topics/yaml/cr_backup_site_manually.yaml
@@ -1,0 +1,16 @@
+spec:
+  ...
+  service:
+    type: DataGrid <1>
+    sites:
+      local:
+        name: LON <2>
+        expose:
+          type: LoadBalancer <3>
+      locations: <4>
+      - name: NYC <5>
+        url: infinispan+xsite://infinispan-nyc.myhost:7900 <6>
+  logging:
+    categories:
+      org.jgroups.protocols.TCP: error <7>
+      org.jgroups.protocols.relay.RELAY2: fatal <8>

--- a/pkg/apis/infinispan/v1/infinispan_types.go
+++ b/pkg/apis/infinispan/v1/infinispan_types.go
@@ -84,9 +84,9 @@ type InfinispanSiteLocationSpec struct {
 	Name        string `json:"name"`
 	Namespace   string `json:"namespace,optional,omitempty"`
 	ClusterName string `json:"clusterName,optional,omitempty"`
-	// +kubebuilder:validation:Pattern=`^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$`
+	// +kubebuilder:validation:Pattern=`(^(minikube|openshift):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)|(^(infinispan\+xsite):\/\/(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])(:[0-9]+)?$)`
 	URL         string `json:"url"`
-	SecretName  string `json:"secretName"`
+	SecretName  string `json:"secretName,optional,omitempty"`
 }
 
 type InfinispanSitesSpec struct {


### PR DESCRIPTION
This makes it possible to use the `infinispan+xsite` scheme when configuring XSite locations. It's based primarily on the changes done in commit [33e718c](https://github.com/infinispan/infinispan-operator/commit/33e718caa244d7d98e888edcbee7ed6f68aa3f9f).

Fixes #1156 