### PR TITLE
[2.1.x] Operator upgrades from 2.0.x -> 2.1.x fail on restart

### DIFF
--- a/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
@@ -78,6 +78,7 @@ metadata:
     createdAt: 2021-01-26T09:00:00Z
     support: Infinispan
     certified: "false"
+    olm.skipRange: ">=2.1.0 <2.1.5"
   name: infinispan-operator.v2.1.4
   namespace: placeholder
 spec:

--- a/documentation/asciidoc/stories/assembly_installing_operator.adoc
+++ b/documentation/asciidoc/stories/assembly_installing_operator.adoc
@@ -15,6 +15,7 @@ endif::downstream[]
 ifdef::community[]
 include::{topics}/proc_install_operatorhub.adoc[leveloffset=+1]
 include::{topics}/proc_install_manually.adoc[leveloffset=+1]
+include::{topics}/ref_upgrades.adoc[leveloffset=+1]
 endif::community[]
 
 // Restore the parent context.

--- a/documentation/asciidoc/topics/ref_upgrades.adoc
+++ b/documentation/asciidoc/topics/ref_upgrades.adoc
@@ -1,0 +1,17 @@
+[id='upgrades_{context}']
+= {brandname} cluster upgrades
+
+[role="_abstract"]
+{ispn_operator} can automatically upgrade {brandname} clusters when new versions become available.
+You can also perform upgrades manually if you prefer to control when they occur.
+
+[NOTE]
+====
+{ispn_operator} requires the Operator Lifecycle Manager to perform cluster upgrades.
+====
+
+[discrete]
+== Upgrade notes
+
+If you upgrade {brandname} clusters manually and have upgraded the channel for your {ispn_operator} subscription from **2.0.x** to **2.1.x** you should apply the upgrade for the latest {brandname} 12.x version as soon as possible.
+This upgrade avoids potential data loss that can occur in earlier versions with link:https://issues.redhat.com/browse/ISPN-13116[ISPN-13116].

--- a/pkg/controller/constants/constants.go
+++ b/pkg/controller/constants/constants.go
@@ -89,14 +89,16 @@ const (
 	ServerUserIdentitiesPath    = ServerUserIdentitiesRoot + "/" + ServerIdentitiesFilename
 
 	ServerHTTPBasePath         = "rest/v2"
+	ServerHTTPCacheManagerPath = ServerHTTPBasePath + "/cache-managers/" + DefaultCacheManagerName
+	ServerHTTPHealthPath       = ServerHTTPCacheManagerPath + "/health"
 	ServerHTTPServerStop       = ServerHTTPBasePath + "/server?action=stop"
 	ServerHTTPClusterStop      = ServerHTTPBasePath + "/cluster?action=stop"
-	ServerHTTPHealthPath       = ServerHTTPBasePath + "/cache-managers/" + DefaultCacheManagerName + "/health"
 	ServerHTTPHealthStatusPath = ServerHTTPHealthPath + "/status"
 	ServerHTTPLoggersPath      = ServerHTTPBasePath + "/logging/loggers"
 	ServerHTTPModifyLoggerPath = ServerHTTPLoggersPath + "/%s?level=%s"
+	ServerHTTPXSitePath        = ServerHTTPCacheManagerPath + "/x-site/backups"
 
-	EncryptTruststoreKey        = "truststore.p12"
+	EncryptTruststoreKey         = "truststore.p12"
 	EncryptTruststorePasswordKey = "truststore-password"
 
 	DefaultCacheTemplate = `<infinispan>

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -491,6 +491,19 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		// ISPN-13116 If xsite view has been formed, then we must perform state-transfer to all sites if a SFS recovery has occurred
+		if crossSiteViewCondition.Status == metav1.ConditionTrue {
+			podName := podList.Items[0].Name
+			logs, err := kubernetes.Logs(podName, infinispan.Namespace)
+			if err != nil {
+				log.Error(err, fmt.Sprintf("Unable to retrive logs for infinispan pod %s", podName))
+			}
+			if strings.Contains(logs, "ISPN000643") {
+				if err := cluster.XsitePushAllState(podName); err != nil {
+					log.Error(err, "Unable to push xsite state after SFS data recovery")
+				}
+			}
+		}
 		err = r.update(infinispan, func() {
 			infinispan.SetConditions([]infinispanv1.InfinispanCondition{*crossSiteViewCondition})
 		})
@@ -1305,28 +1318,42 @@ func (r *ReconcileInfinispan) reconcileGracefulShutdown(ispn *infinispanv1.Infin
 func (r *ReconcileInfinispan) gracefulShutdownReq(ispn *infinispanv1.Infinispan, podList *corev1.PodList,
 	logger logr.Logger, cluster ispn.ClusterInterface) (*reconcile.Result, error) {
 	logger.Info("Sending graceful shutdown request")
-	// send a graceful shutdown to the first ready pod
-	// if there's no ready pod we're in trouble
+	// Send a graceful shutdown to the first ready pod, if there's no ready pod then terminate any pending pods
+	forceShutdown := true
 	for _, pod := range podList.Items {
 		if kube.IsPodReady(pod) {
-			err := cluster.GracefulShutdown(pod.GetName())
-			if err != nil {
-				logger.Error(err, "failed to exec shutdown command on pod")
-				continue
-			}
-			logger.Info("Executed graceful shutdown on pod: ", "Pod.Name", pod.Name)
+			if err := cluster.GracefulShutdown(pod.GetName()); err != nil {
+				logger.Error(err, "Error encountered on cluster shutdown")
 
-			if err := r.update(ispn, func() {
-				ispn.SetCondition(infinispanv1.ConditionStopping, metav1.ConditionTrue, "")
-				ispn.SetCondition(infinispanv1.ConditionWellFormed, metav1.ConditionFalse, "")
-			}); err != nil {
-				return &reconcile.Result{}, err
+				// ISPN-13141 causes GracefulShutdown to fail if there are issues with the server
+				logger.Info("Cluster Shutdown failed. Attempting to execute GracefulShutdownTask")
+				if err := cluster.GracefulShutdownTask(pod.GetName()); err != nil {
+					logger.Error(err, fmt.Sprintf("Error encountered using GracefulShutdownTask on pod %s", pod.Name))
+					continue
+				}
+			} else {
+				logger.Info("Executed graceful shutdown on pod: ", "Pod.Name", pod.Name)
+				forceShutdown = false
 			}
-			// Stop the work and requeue until cluster is down
-			return &reconcile.Result{Requeue: true, RequeueAfter: time.Second}, nil
 		}
 	}
-	return nil, nil
+
+	if forceShutdown {
+		logger.Info("Forcing GracefulShutdown by deleting all pods")
+		deleteOptions := []client.DeleteAllOfOption{client.MatchingLabels(PodLabels(ispn.Name)), client.InNamespace(ispn.Namespace)}
+		if err := r.client.DeleteAllOf(context.TODO(), &corev1.Pod{}, deleteOptions...); err != nil && !errors.IsNotFound(err) {
+			logger.Error(err, "Error encountered deleting all Pods on GracefulShutdown")
+		}
+	}
+
+	if err := r.update(ispn, func() {
+		ispn.SetCondition(infinispanv1.ConditionStopping, metav1.ConditionTrue, "")
+		ispn.SetCondition(infinispanv1.ConditionWellFormed, metav1.ConditionFalse, "")
+	}); err != nil {
+		return &reconcile.Result{}, err
+	}
+	// Stop the work and requeue until cluster is down
+	return &reconcile.Result{Requeue: true, RequeueAfter: time.Second}, nil
 }
 
 // reconcileContainerConf reconcile the .Container struct is changed in .Spec. This needs a cluster restart

--- a/pkg/controller/infinispan/infinispan_controller_test.go
+++ b/pkg/controller/infinispan/infinispan_controller_test.go
@@ -66,6 +66,10 @@ func (m mockCluster) GracefulShutdown(podName string) error {
 	return nil
 }
 
+func (m mockCluster) GracefulShutdownTask(podName string) error {
+	return nil
+}
+
 func (m mockCluster) GetClusterSize(podName string) (int, error) {
 	return 0, nil
 }
@@ -110,6 +114,10 @@ func (m mockCluster) GetLoggers(podName string) (map[string]string, error) {
 }
 
 func (m mockCluster) SetLogger(podName, loggerName, loggerLevel string) error {
+	return nil
+}
+
+func (m mockCluster) XsitePushAllState(podName string) error {
 	return nil
 }
 

--- a/pkg/infinispan/cluster.go
+++ b/pkg/infinispan/cluster.go
@@ -57,6 +57,7 @@ func (i CacheManagerInfo) GetSitesView() (map[string]bool, error) {
 type ClusterInterface interface {
 	GetClusterSize(podName string) (int, error)
 	GracefulShutdown(podName string) error
+	GracefulShutdownTask(podName string) error
 	GetClusterMembers(podName string) ([]string, error)
 	ExistsCache(cacheName, podName string) (bool, error)
 	CreateCacheWithTemplate(cacheName, cacheXML, podName string) error
@@ -68,6 +69,7 @@ type ClusterInterface interface {
 	GetCacheManagerInfo(cacheManagerName, podName string) (*CacheManagerInfo, error)
 	GetLoggers(podName string) (map[string]string, error)
 	SetLogger(podName, loggerName, loggerLevel string) error
+	XsitePushAllState(podName string) error
 }
 
 // NewClusterNoAuth creates a new instance of Cluster without authentication
@@ -112,6 +114,55 @@ func (c Cluster) GetClusterSize(podName string) (int, error) {
 func (c Cluster) GracefulShutdown(podName string) error {
 	rsp, err, reason := c.Client.Post(podName, consts.ServerHTTPClusterStop, "", nil)
 	return validateResponse(rsp, reason, err, "during graceful shutdown", http.StatusNoContent)
+}
+
+// ISPN-13141 Upload custom task to perform graceful shutdown that does not fail on cache errors
+// This task calls Cache#shutdown which disables rebalancing on the cache before stopping it
+func (c Cluster) GracefulShutdownTask(podName string) error {
+	scriptName := "___org.infinispan.operator.gracefulshutdown.js"
+	url := fmt.Sprintf("%s/tasks/%s", consts.ServerHTTPBasePath, scriptName)
+	headers := map[string]string{"Content-Type": "text/plain"}
+	task := `
+	/* mode=local,language=javascript */
+	print("Executing operator shutdown task");
+	var System = Java.type("java.lang.System");
+	var HashSet = Java.type("java.util.HashSet");
+	var InternalCacheRegistry = Java.type("org.infinispan.registry.InternalCacheRegistry");
+
+	var stdErr = System.err;
+	var icr = cacheManager.getGlobalComponentRegistry().getComponent(InternalCacheRegistry.class);
+
+	var cacheNames = cacheManager.getCacheNames();
+	shutdown(cacheNames);
+
+	var internalCaches = new HashSet(icr.getInternalCacheNames());
+	/* The ___script_cache is included in both getCacheNames() and getInternalCacheNames so prevent repeated shutdown calls */
+	internalCaches.removeAll(cacheNames);
+	shutdown(internalCaches);
+
+	function shutdown(cacheNames) {
+	   var it = cacheNames.iterator();
+	   while (it.hasNext()) {
+			 name = it.next();
+			 print("Shutting down cache " + name);
+			 try {
+				cacheManager.getCache(name).shutdown();
+			 } catch (err) {
+				stdErr.println("Encountered error trying to shutdown cache " + name + ": " + err);
+			 }
+	   }
+	}
+	`
+	// Remove all new lines to prevent a "100 continue" response
+	task = strings.ReplaceAll(task, "\n", "")
+
+	rsp, err, reason := c.Client.Post(podName, url, task, headers)
+	if err := validateResponse(rsp, reason, err, "Uploading GracefulShutdownTask", http.StatusOK); err != nil {
+		return err
+	}
+
+	rsp, err, reason = c.Client.Post(podName, url+"?action=exec", "", nil)
+	return validateResponse(rsp, reason, err, "Executing GracefulShutdownTask", http.StatusOK)
 }
 
 // GetClusterMembers get the cluster members as seen by a given pod
@@ -312,6 +363,40 @@ func (c Cluster) SetLogger(podName, loggerName, loggerLevel string) error {
 		return err
 	}
 	return nil
+}
+
+func (c Cluster) XsitePushAllState(podName string) (err error) {
+	rsp, err, reason := c.Client.Get(podName, consts.ServerHTTPXSitePath, nil)
+	if err = validateResponse(rsp, reason, err, "Retrieving xsite status", http.StatusOK); err != nil {
+		return
+	}
+
+	defer func() {
+		cerr := rsp.Body.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	type xsiteStatus struct {
+		Status string `json:"status"`
+	}
+	var statuses map[string]xsiteStatus
+	if err := json.NewDecoder(rsp.Body).Decode(&statuses); err != nil {
+		return fmt.Errorf("unable to decode: %v", err)
+	}
+
+	// Statuses will be empty if no xsite caches are configured
+	for k, v := range statuses {
+		if v.Status == "online" {
+			url := fmt.Sprintf("%s/%s?action=start-push-state", consts.ServerHTTPXSitePath, k)
+			rsp, err, reason = c.Client.Post(podName, url, "", nil)
+			if err = validateResponse(rsp, reason, err, "Pushing xsite state", http.StatusOK); err != nil {
+				return
+			}
+		}
+	}
+	return
 }
 
 func validateResponse(rsp *http.Response, reason string, inperr error, entity string, validCodes ...int) (err error) {


### PR DESCRIPTION
To test scenario do:

1. Fetch the latest from this branch `sfs_uprade_issues`
2. Fetch the following tags `2.0.6` `2.1.3.Final`
3. Create `infinispan.yaml` and `identities.yaml` in the operator root
4. Execute [olm-simulator.sh](https://gist.github.com/ryanemerson/a17b208c12a5c91a938f499b24d2691b)

infinispan.yaml:
```
apiVersion: infinispan.org/v1
kind: Infinispan
metadata:
  name: infinispan
spec:
  container:
    memory: 1Gi
  replicas: 2
  security:
    endpointSecretName: auth-secret
  service:
    type: DataGrid
```

identities.yaml
```
credentials:
- username: testuser
  password: testpass
- username: operator
  password: supersecretoperatorpass
```

I still need to add some logic to initiate state-transfer on xsite caches once the upgrade has completed.

For some reason OOM are happening when migrating the server event log .dat file. I'm still investigating this, but strangely when I extract the corrupted .dat file from the Openshift pod, it can be recovered on my local machine using much more restrictive memory settings :shrug: 

Output of OOM:
```
13:06:30,330 INFO  (blocking-thread--p3-t1) [org.infinispan.PERSISTENCE] ISPN000642: Attempting to recover '___event_log_cache' corrupt data ...
java.lang.OutOfMemoryError: Java heap space
Dumping heap to java_pid91.hprof ...
Heap dump file created [46847017 bytes in 0.397 secs]
Terminating due to java.lang.OutOfMemoryError: Java heap space
```