### PR TITLE
[2.1.x] qos Guarantee

### DIFF
--- a/pkg/apis/infinispan/v1/types_util.go
+++ b/pkg/apis/infinispan/v1/types_util.go
@@ -407,7 +407,7 @@ func (spec *InfinispanContainerSpec) GetCpuResources() (*resource.Quantity, *res
 	if err != nil {
 		return nil, nil, err
 	}
-	cpuRequestsMillis := cpuLimits.MilliValue() / 2
+	cpuRequestsMillis := cpuLimits.MilliValue()
 	cpuRequests := toMilliDecimalQuantity(cpuRequestsMillis)
 	return &cpuRequests, &cpuLimits, nil
 }

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -538,7 +538,7 @@ func TestContainerCPUUpdateWithTwoReplicas(t *testing.T) {
 	}
 	var verifier = func(ss *appsv1.StatefulSet) {
 		limit := resource.MustParse("550m")
-		request := resource.MustParse("275m")
+		request := resource.MustParse("550m")
 		if limit.Cmp(ss.Spec.Template.Spec.Containers[0].Resources.Limits["cpu"]) != 0 ||
 			request.Cmp(ss.Spec.Template.Spec.Containers[0].Resources.Requests["cpu"]) != 0 {
 			panic("CPU field not updated")


### PR DESCRIPTION
This patch changes the qos for the pods from Burstable to Guarantee. 
mitigate #815
discussed for #1173 