### PR TITLE
HotRod does not work with ClientCert 'Validate' strategy #1190

### DIFF
--- a/pkg/controller/infinispan/resources/config/config_controller.go
+++ b/pkg/controller/infinispan/resources/config/config_controller.go
@@ -124,7 +124,7 @@ func (c configResource) computeAndReconcileConfigMap(xsite *configuration.XSite)
 	lsConfigMap := infinispan.LabelsResource(name, "infinispan-configmap-configuration")
 
 	var roleMapper string
-	if c.infinispan.IsClientCertEnabled() {
+	if c.infinispan.IsClientCertEnabled() && c.infinispan.Spec.Security.EndpointEncryption.ClientCert == ispnv1.ClientCertAuthenticate {
 		roleMapper = "commonName"
 	} else {
 		roleMapper = "cluster"

--- a/test/e2e/main/main_test.go
+++ b/test/e2e/main/main_test.go
@@ -423,6 +423,18 @@ func TestClientCertValidate(t *testing.T) {
 	})
 }
 
+func TestClientCertValidateNoAuth(t *testing.T) {
+	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
+		spec.Spec.Security.EndpointAuthentication = pointer.BoolPtr(false)
+		authType = ispnv1.ClientCertValidate
+		serverName := tutils.GetServerName(spec)
+		keystore, truststore, tlsConfig := tutils.CreateKeyAndTruststore(serverName, false)
+		keystoreSecret = tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
+		truststoreSecret = tutils.EncryptionSecretClientTrustore(spec.Name, tutils.Namespace, truststore)
+		return
+	})
+}
+
 func TestClientCertAuthenticate(t *testing.T) {
 	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
 		authType = ispnv1.ClientCertAuthenticate
@@ -434,45 +446,45 @@ func TestClientCertAuthenticate(t *testing.T) {
 	})
 }
 
-// #1098 Test disabled until ISPN-13089 resolved
-// func TestClientCertValidateWithAuthorization(t *testing.T) {
-// 	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
-// 		spec.Spec.Security.Authorization = &v1.Authorization{
-// 			Enabled: true,
-// 			Roles: []ispnv1.AuthorizationRole{
-// 				{
-// 					Name:        "client",
-// 					Permissions: []string{"ALL"},
-// 				},
-// 			},
-// 		}
-// 		authType = ispnv1.ClientCertValidate
-// 		keystore, truststore, tlsConfig := tutils.CreateKeyAndTruststore(false)
-// 		keystoreSecret = tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
-// 		truststoreSecret = tutils.EncryptionSecretClientTrustore(spec.Name, tutils.Namespace, truststore)
-// 		return
-// 	})
-// }
+func TestClientCertValidateWithAuthorization(t *testing.T) {
+	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
+		spec.Spec.Security.Authorization = &v1.Authorization{
+			Enabled: true,
+			Roles: []ispnv1.AuthorizationRole{
+				{
+					Name:        "client",
+					Permissions: []string{"ALL"},
+				},
+			},
+		}
+		authType = ispnv1.ClientCertValidate
+		serverName := tutils.GetServerName(spec)
+		keystore, truststore, tlsConfig := tutils.CreateKeyAndTruststore(serverName, false)
+		keystoreSecret = tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
+		truststoreSecret = tutils.EncryptionSecretClientTrustore(spec.Name, tutils.Namespace, truststore)
+		return
+	})
+}
 
-// #1098 Test disabled until ISPN-13089 resolved
-// func TestClientCertAuthenticateWithAuthorization(t *testing.T) {
-// 	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
-// 		spec.Spec.Security.Authorization = &v1.Authorization{
-// 			Enabled: true,
-// 			Roles: []ispnv1.AuthorizationRole{
-// 				{
-// 					Name:        "client",
-// 					Permissions: []string{"MONITOR"},
-// 				},
-// 			},
-// 		}
-// 		authType = ispnv1.ClientCertAuthenticate
-// 		keystore, truststore, tlsConfig := tutils.CreateKeyAndTruststore(true)
-// 		keystoreSecret = tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
-// 		truststoreSecret = tutils.EncryptionSecretClientTrustore(spec.Name, tutils.Namespace, truststore)
-// 		return
-// 	})
-// }
+func TestClientCertAuthenticateWithAuthorization(t *testing.T) {
+	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {
+		spec.Spec.Security.Authorization = &v1.Authorization{
+			Enabled: true,
+			Roles: []ispnv1.AuthorizationRole{
+				{
+					Name:        "client",
+					Permissions: []string{"ALL"},
+				},
+			},
+		}
+		authType = ispnv1.ClientCertAuthenticate
+		serverName := tutils.GetServerName(spec)
+		keystore, truststore, tlsConfig := tutils.CreateKeyAndTruststore(serverName, true)
+		keystoreSecret = tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
+		truststoreSecret = tutils.EncryptionSecretClientTrustore(spec.Name, tutils.Namespace, truststore)
+		return
+	})
+}
 
 func TestClientCertGeneratedTruststoreAuthenticate(t *testing.T) {
 	testClientCert(t, func(spec *v1.Infinispan) (authType v1.ClientCertType, keystoreSecret, truststoreSecret *corev1.Secret, tlsConfig *tls.Config) {

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -265,15 +265,26 @@ func HTTPClientAndHost(i *ispnv1.Infinispan, kube *TestKubernetes) (string, HTTP
 }
 
 func HTTPSClientAndHost(i *v1.Infinispan, tlsConfig *tls.Config, kube *TestKubernetes) (string, HTTPClient) {
+
+	userAndPassword := func() (string, string) {
+		user := constants.DefaultDeveloperUser
+		pass, err := users.UserPassword(user, i.GetSecretName(), i.Namespace, kube.Kubernetes)
+		ExpectNoError(err)
+		return user, pass
+	}
+
 	var client HTTPClient
 	clientCert := i.Spec.Security.EndpointEncryption.ClientCert
 	if clientCert != "" && clientCert != ispnv1.ClientCertNone {
-		client = NewHTTPSClientCert(tlsConfig)
+		if clientCert == ispnv1.ClientCertAuthenticate || !i.IsAuthenticationEnabled() {
+			client = NewHTTPSClientCert(tlsConfig)
+		} else {
+			user, pass := userAndPassword()
+			client = NewHTTPSClientCertWithDigestAuth(user, pass, tlsConfig)
+		}
 	} else {
 		if i.IsAuthenticationEnabled() {
-			user := constants.DefaultDeveloperUser
-			pass, err := users.UserPassword(user, i.GetSecretName(), i.Namespace, kube.Kubernetes)
-			ExpectNoError(err)
+			user, pass := userAndPassword()
 			client = NewHTTPSClient(user, pass, tlsConfig)
 		} else {
 			client = NewHTTPSClientNoAuth(tlsConfig)

--- a/test/e2e/utils/httpClient.go
+++ b/test/e2e/utils/httpClient.go
@@ -64,6 +64,10 @@ func NewHTTPSClientCert(tlsConfig *tls.Config) HTTPClient {
 	return newClient(authCert, nil, nil, "https", tlsConfig)
 }
 
+func NewHTTPSClientCertWithDigestAuth(username, password string, tlsConfig *tls.Config) HTTPClient {
+	return newClient(authDigest, &username, &password, "https", tlsConfig)
+}
+
 func NewHTTPSClient(username, password string, tlsConfig *tls.Config) HTTPClient {
 	return newClient(authDigest, &username, &password, "https", tlsConfig)
 }


### PR DESCRIPTION

Requires 12.1.7.Final image release before the tests will pass.