### PR TITLE
Cross Site  - Gossip Router tunnel support

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -81,6 +81,7 @@ rules:
   - apps
   resources:
   - statefulsets
+  - deployments
   - deployments/finalizers
   verbs:
   - get

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -261,6 +261,32 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 		}
 	}
 
+	if infinispan.HasSites() {
+        tunnel := &appsv1.Deployment{}
+		err = r.client.Get(context.TODO(),types.NamespacedName{Namespace: infinispan.Namespace, Name: infinispan.Name}, tunnel)
+		if err != nil && errors.IsNotFound(err) {
+			reqLogger.Info("Configuring the Cross-Site Deployment")
+			deployment, err := r.createGossipRouterTunnel(infinispan)
+			if err != nil {
+				reqLogger.Error(err, "failed to configure new Deployment")
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("Creating a new Deployment", "Deployment.Name", deployment.Name)
+			err = r.client.Create(context.TODO(), deployment)
+			if err != nil {
+				reqLogger.Error(err, "failed to create new Deployment", "Deployment.Name", deployment.Name)
+				return reconcile.Result{}, err
+			}
+
+			// StatefulSet created successfully
+			reqLogger.Info("End of the Cross-Site tunneling Deployment creation")
+		}
+		if err != nil {
+			reqLogger.Error(err, "failed to get Cross-Site Deployment")
+			return reconcile.Result{}, err
+		}
+	}
+
 	// Reconcile the StatefulSet
 	// Check if the StatefulSet already exists, if not create a new one
 	statefulSet := &appsv1.StatefulSet{}
@@ -1547,6 +1573,10 @@ func PodLabels(name string) map[string]string {
 	return LabelsResource(name, "infinispan-pod")
 }
 
+func TunnelPodLabels(name string) map[string]string {
+	return LabelsResource(name, "infinispan-tunnel-pod")
+}
+
 func ServiceLabels(name string) map[string]string {
 	return map[string]string{
 		"clusterName": name,
@@ -1605,18 +1635,21 @@ func remove(list []string, s string) []string {
 }
 
 // returns the tunnel service
-func (r *ReconcileInfinispan) createGossipRouterTunnel(siteServiceName string, m *infinispanv1.Infinispan, logger logr.Logger) (*corev1.Service, error) {
-	lsService := ispncom.LabelsResource(m.ObjectMeta.Name, "infinispan-tunnel-service")
-	lsTunnel := ispncom.LabelsResource(m.ObjectMeta.Name, "infinispan-tunnel")
+func (r *ReconcileInfinispan) createGossipRouterTunnel(m *infinispanv1.Infinispan) (*appsv1.Deployment, error) {
+	name := m.Name + "-tunnel"
+	reqLogger := log.WithValues("Request.Namespace", m.Namespace, "Request.Name", name)
+	//TODO labels
+	lsTunnel := TunnelPodLabels(m.Name)
 
-	logger.Info("Creating GossipRouter (xsite-tunnel) Deployment")
+	// TODO where to create it?
+	reqLogger.Info("Creating GossipRouter (xsite-tunnel) Deployment")
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      m.ObjectMeta.Name + "-tunnel",
+			Name:      name,
 			Namespace: m.ObjectMeta.Namespace,
 			Labels:    lsTunnel,
 		},
@@ -1637,7 +1670,7 @@ func (r *ReconcileInfinispan) createGossipRouterTunnel(siteServiceName string, m
 						Ports: []corev1.ContainerPort{
 							{ContainerPort: 8787, Name: "debug", Protocol: corev1.ProtocolTCP},
 							{ContainerPort: 9000, Name: "netcat", Protocol: corev1.ProtocolTCP},
-							{ContainerPort: 12001, Name: "tunnel", Protocol: corev1.ProtocolTCP},
+							{ContainerPort: consts.CrossSitePort, Name: "tunnel", Protocol: corev1.ProtocolTCP},
 						},
 					}},
 				},
@@ -1645,41 +1678,8 @@ func (r *ReconcileInfinispan) createGossipRouterTunnel(siteServiceName string, m
 		},
 	}
 	// Set Infinispan instance as the owner and controller
-	controllerutil.SetControllerReference(m, deployment, r.scheme)
-
-	err := r.client.Create(context.TODO(), deployment)
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err := controllerutil.SetControllerReference(m, deployment, r.scheme); err != nil {
 		return nil, err
 	}
-
-	logger.Info("Creating GossipRouter (xsite-tunnel) Service")
-	service := &corev1.Service{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Service",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      siteServiceName,
-			Namespace: m.ObjectMeta.Namespace,
-			Labels:    lsService,
-		},
-		// TODO! customize spec.type
-		Spec: corev1.ServiceSpec{
-			Type:     m.Spec.Service.Sites.Local.Expose.Type,
-			Selector: lsTunnel,
-			Ports: []corev1.ServicePort{
-				{Port: 12001, Name: "tunnel", Protocol: corev1.ProtocolTCP},
-			},
-		},
-	}
-
-	// Set Infinispan instance as the owner and controller
-	controllerutil.SetControllerReference(m, service, r.scheme)
-
-	err = r.client.Create(context.TODO(), service)
-	if err != nil && !errors.IsAlreadyExists(err) {
-		return nil, err
-	}
-
-	return service, nil
+	return deployment, nil
 }

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -1603,3 +1603,83 @@ func remove(list []string, s string) []string {
 	}
 	return slice
 }
+
+// returns the tunnel service
+func (r *ReconcileInfinispan) createGossipRouterTunnel(siteServiceName string, m *infinispanv1.Infinispan, logger logr.Logger) (*corev1.Service, error) {
+	lsService := ispncom.LabelsResource(m.ObjectMeta.Name, "infinispan-tunnel-service")
+	lsTunnel := ispncom.LabelsResource(m.ObjectMeta.Name, "infinispan-tunnel")
+
+	logger.Info("Creating GossipRouter (xsite-tunnel) Deployment")
+	deployment := &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      m.ObjectMeta.Name + "-tunnel",
+			Namespace: m.ObjectMeta.Namespace,
+			Labels:    lsTunnel,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: lsTunnel,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      m.ObjectMeta.Name,
+					Namespace: m.ObjectMeta.Namespace,
+					Labels:    lsTunnel,
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "gossiprouter",
+						Image: "belaban/gossiprouter:latest",
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: 8787, Name: "debug", Protocol: corev1.ProtocolTCP},
+							{ContainerPort: 9000, Name: "netcat", Protocol: corev1.ProtocolTCP},
+							{ContainerPort: 12001, Name: "tunnel", Protocol: corev1.ProtocolTCP},
+						},
+					}},
+				},
+			},
+		},
+	}
+	// Set Infinispan instance as the owner and controller
+	controllerutil.SetControllerReference(m, deployment, r.scheme)
+
+	err := r.client.Create(context.TODO(), deployment)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	logger.Info("Creating GossipRouter (xsite-tunnel) Service")
+	service := &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      siteServiceName,
+			Namespace: m.ObjectMeta.Namespace,
+			Labels:    lsService,
+		},
+		// TODO! customize spec.type
+		Spec: corev1.ServiceSpec{
+			Type:     m.Spec.Service.Sites.Local.Expose.Type,
+			Selector: lsTunnel,
+			Ports: []corev1.ServicePort{
+				{Port: 12001, Name: "tunnel", Protocol: corev1.ProtocolTCP},
+			},
+		},
+	}
+
+	// Set Infinispan instance as the owner and controller
+	controllerutil.SetControllerReference(m, service, r.scheme)
+
+	err = r.client.Create(context.TODO(), service)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return nil, err
+	}
+
+	return service, nil
+}

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -262,19 +263,19 @@ func (r *ReconcileInfinispan) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if infinispan.HasSites() {
-        tunnel := &appsv1.Deployment{}
-		err = r.client.Get(context.TODO(),types.NamespacedName{Namespace: infinispan.Namespace, Name: infinispan.Name}, tunnel)
+		tunnel := &appsv1.Deployment{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: infinispan.Namespace, Name: infinispan.Name + "-tunnel"}, tunnel)
 		if err != nil && errors.IsNotFound(err) {
 			reqLogger.Info("Configuring the Cross-Site Deployment")
-			deployment, err := r.createGossipRouterTunnel(infinispan)
+			tunnel, err = r.createGossipRouterTunnel(infinispan)
 			if err != nil {
 				reqLogger.Error(err, "failed to configure new Deployment")
 				return reconcile.Result{}, err
 			}
-			reqLogger.Info("Creating a new Deployment", "Deployment.Name", deployment.Name)
-			err = r.client.Create(context.TODO(), deployment)
+			reqLogger.Info("Creating a new Deployment", "Deployment.Name", tunnel.Name)
+			err = r.client.Create(context.TODO(), tunnel)
 			if err != nil {
-				reqLogger.Error(err, "failed to create new Deployment", "Deployment.Name", deployment.Name)
+				reqLogger.Error(err, "failed to create new Deployment", "Deployment.Name", tunnel.Name)
 				return reconcile.Result{}, err
 			}
 
@@ -589,6 +590,17 @@ func (r *ReconcileInfinispan) destroyResources(infinispan *infinispanv1.Infinisp
 		&appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      infinispan.Name,
+				Namespace: infinispan.Namespace,
+			},
+		})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	err = r.client.Delete(context.TODO(),
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      infinispan.Name + "-tunnel",
 				Namespace: infinispan.Namespace,
 			},
 		})
@@ -1448,9 +1460,9 @@ func (r *ReconcileInfinispan) reconcileContainerConf(ispn *infinispanv1.Infinisp
 
 	externalArtifactsUpd, err := applyExternalArtifactsDownload(ispn, &statefulSet.Spec.Template.Spec)
 	if err != nil {
-		return  &reconcile.Result{}, err
+		return &reconcile.Result{}, err
 	}
-	updateNeeded =  externalArtifactsUpd || updateNeeded
+	updateNeeded = externalArtifactsUpd || updateNeeded
 	updateNeeded = applyExternalDependenciesVolume(ispn, &statefulSet.Spec.Template.Spec) || updateNeeded
 
 	// Validate identities Secret name changes
@@ -1637,12 +1649,9 @@ func remove(list []string, s string) []string {
 // returns the tunnel service
 func (r *ReconcileInfinispan) createGossipRouterTunnel(m *infinispanv1.Infinispan) (*appsv1.Deployment, error) {
 	name := m.Name + "-tunnel"
-	reqLogger := log.WithValues("Request.Namespace", m.Namespace, "Request.Name", name)
-	//TODO labels
 	lsTunnel := TunnelPodLabels(m.Name)
 
 	// TODO where to create it?
-	reqLogger.Info("Creating GossipRouter (xsite-tunnel) Deployment")
 	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -1666,10 +1675,11 @@ func (r *ReconcileInfinispan) createGossipRouterTunnel(m *infinispanv1.Infinispa
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{{
 						Name:  "gossiprouter",
-						Image: "belaban/gossiprouter:latest",
+						Image: m.ImageName(),
+						// TODO! create a script in the server image to be invoked
+						Command: []string{"java"},
+						Args:    []string{"-cp", "/opt/infinispan/lib/jgroups-4.2.12.Final.jar", "org.jgroups.stack.GossipRouter", "-port", strconv.Itoa(consts.CrossSitePort)},
 						Ports: []corev1.ContainerPort{
-							{ContainerPort: 8787, Name: "debug", Protocol: corev1.ProtocolTCP},
-							{ContainerPort: 9000, Name: "netcat", Protocol: corev1.ProtocolTCP},
 							{ContainerPort: consts.CrossSitePort, Name: "tunnel", Protocol: corev1.ProtocolTCP},
 						},
 					}},

--- a/pkg/controller/infinispan/resources/config/xsite.go
+++ b/pkg/controller/infinispan/resources/config/xsite.go
@@ -46,9 +46,10 @@ func ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *kube.Kubernetes, se
 	logger.Info("local site service", "service name", siteServiceName, "host", localSiteHost, "port", localSitePort)
 
 	xsite := &config.XSite{
-		Address: localSiteHost,
-		Name:    infinispan.Spec.Service.Sites.Local.Name,
-		Port:    localSitePort,
+		Address:   localSiteHost,
+		Name:      infinispan.Spec.Service.Sites.Local.Name,
+		Port:      localSitePort,
+		Transport: "tunnel",
 	}
 
 	for _, remoteLocation := range infinispan.GetRemoteSiteLocations() {

--- a/pkg/controller/infinispan/resources/service/service_controller.go
+++ b/pkg/controller/infinispan/resources/service/service_controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -402,8 +401,7 @@ func computeServiceExternal(ispn *ispnv1.Infinispan) *corev1.Service {
 
 // computeSiteService compute the XSite service
 func computeSiteService(ispn *ispnv1.Infinispan) *corev1.Service {
-	lsPodSelector := infinispan.PodLabels(ispn.Name)
-	lsPodSelector[consts.CoordinatorPodLabel] = strconv.FormatBool(true)
+	lsPodSelector := infinispan.TunnelPodLabels(ispn.Name)
 
 	exposeSpec := corev1.ServiceSpec{}
 	exposeConf := ispn.Spec.Service.Sites.Local.Expose

--- a/pkg/infinispan/configuration/configuration.go
+++ b/pkg/infinispan/configuration/configuration.go
@@ -80,10 +80,11 @@ type DNSPing struct {
 }
 
 type XSite struct {
-	Address string       `yaml:"address"`
-	Name    string       `yaml:"name"`
-	Port    int32        `yaml:"port"`
-	Backups []BackupSite `yaml:"backups"`
+	Address   string       `yaml:"address"`
+	Name      string       `yaml:"name"`
+	Port      int32        `yaml:"port"`
+	Transport string       `yaml:"transport"`
+	Backups   []BackupSite `yaml:"backups"`
 }
 
 type BackupSite struct {

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -59,9 +59,14 @@ type Parameters struct {
 
 // Launch launches operator
 func Launch(params Parameters) {
+	var portOffset int
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	flag.IntVar(&portOffset, "offset", 0, "Port offset for metrics listening ports")
 	flag.Parse()
+
+	metricsPort = metricsPort + int32(portOffset)
+	operatorMetricsPort = operatorMetricsPort + int32(portOffset)
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will

--- a/pkg/launcher/launcher.go
+++ b/pkg/launcher/launcher.go
@@ -59,14 +59,9 @@ type Parameters struct {
 
 // Launch launches operator
 func Launch(params Parameters) {
-	var portOffset int
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	flag.IntVar(&portOffset, "offset", 0, "Port offset for metrics listening ports")
 	flag.Parse()
-
-	metricsPort = metricsPort + int32(portOffset)
-	operatorMetricsPort = operatorMetricsPort + int32(portOffset)
 
 	// The logger instantiated here can be changed to any logger
 	// implementing the logr.Logger interface. This logger will


### PR DESCRIPTION
Adds support to use JGroups' TUNNEL protocol with GossipRouter pods.
It uses the JGroups JAR inside the server image to avoid depending on another image.

PR is open to get feedback sooner than later. No rush to integrate yet.

TODO:

- [ ] Create an entry point in the server image (avoid doing "java -jar ...")
- [ ] Handle server image upgrades (?)