### PR TITLE
Was experiencing permission issue for the operator to list storageclasses

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -27,4 +27,5 @@ rules:
     - storageclasses
   verbs:
     - get
+    - list
     - watch

--- a/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/infinispan-operator.clusterserviceversion.yaml
@@ -503,6 +503,7 @@ spec:
                 - storageclasses
               verbs:
                 - get
+                - list
                 - watch
     strategy: deployment
   installModes:

--- a/deploy/operator-install.yaml
+++ b/deploy/operator-install.yaml
@@ -207,6 +207,7 @@ rules:
     - storageclasses
   verbs:
     - get
+    - list
     - watch
 
 ---


### PR DESCRIPTION
> E0804 14:44:26.874977       1 reflector.go:123] go/pkg/mod/k8s.io/client-go@v0.0.0-20191016111102-bec269661e48/tools/cache/reflector.go:96: Failed to list *v1.StorageClass: storageclasses.storage.k8s.io is forbidden: User "system:serviceaccount:operators:infinispan-operator" cannot list resource "storageclasses" in API group "storage.k8s.io" at the cluster scope

Adding the list permission for the operator to query storageclasses fixes this for me.

Running: infinispan-operator.v2.1.5 via olm