### PR TITLE
OperatorCA lookup for k8s 1.22

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -164,9 +164,9 @@ func SetConfigDefaults(config *rest.Config) *rest.Config {
 // ServiceCAsCRDResourceExists returns true if the platform
 // has the servicecas.operator.openshift.io custom resource deployed
 // Used to check if serviceca operator is serving TLS certificates
-func (k Kubernetes) hasServiceCAsCRDResource() bool {
+func (k Kubernetes) hasServiceCAsCRDResource(version string) bool {
 	// Using an ad-hoc path
-	req := k.RestClient.Get().AbsPath("apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/servicecas.operator.openshift.io")
+	req := k.RestClient.Get().AbsPath("apis/apiextensions.k8s.io/" + version + "/customresourcedefinitions/servicecas.operator.openshift.io")
 	result := req.Do()
 	var status int
 	result.StatusCode(&status)
@@ -176,7 +176,7 @@ func (k Kubernetes) hasServiceCAsCRDResource() bool {
 // GetServingCertsMode returns a label that identify the kind of serving
 // certs service is available. Returns 'openshift.io' for service-ca on openshift
 func (k Kubernetes) GetServingCertsMode() string {
-	if k.hasServiceCAsCRDResource() {
+	if k.hasServiceCAsCRDResource("v1beta1") || k.hasServiceCAsCRDResource("v1") {
 		return "openshift.io"
 
 		// Code to check if other modes of serving TLS cert service is available


### PR DESCRIPTION
starting with k8s 1.22 operatorCA is exposed only as extensions v1