### PR TITLE
[test-integration] Bump XTF to 0.23

### DIFF
--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -18,7 +18,7 @@
         <version.logback>1.2.0</version.logback>
         <version.slf4j>1.7.30</version.slf4j>
         <version.verifier>1.5</version.verifier>
-        <version.xtf>0.21</version.xtf>
+        <version.xtf>0.23</version.xtf>
 
         <!-- Plugin versions -->
         <version.maven.compiler>3.8.1</version.maven.compiler>


### PR DESCRIPTION
Required for testing on OCP4.8+