### PR TITLE
Separate admin port into a different service

### DIFF
--- a/build/upgrade-test-local.sh
+++ b/build/upgrade-test-local.sh
@@ -56,6 +56,7 @@ if git checkout "${FROM_UPGRADE_VERSION}"; then
     export DEFAULT_IMAGE=$(sed -n '/name: DEFAULT_IMAGE/ {n;p}' "${TO_OPERATOR_DEPLOY_FILE}" | awk -F '"' '{print $2}')
   else
     export DEFAULT_IMAGE="${TO_OPERATOR_IMAGE}"
+    export EXPECTED_IMAGE="${TO_OPERATOR_IMAGE}"
   fi
 
   if ! "${TO_TEST_SCRIPT_FILE}" "${KUBECONFIG}"; then

--- a/pkg/apis/infinispan/v1/types_util.go
+++ b/pkg/apis/infinispan/v1/types_util.go
@@ -262,6 +262,10 @@ func (ispn *Infinispan) GetServiceName() string {
 	return ispn.Name
 }
 
+func (ispn *Infinispan) GetAdminServiceName() string {
+	return fmt.Sprintf("%s-admin", ispn.Name)
+}
+
 func (ispn *Infinispan) GetPingServiceName() string {
 	return fmt.Sprintf("%s-ping", ispn.Name)
 }

--- a/pkg/controller/infinispan/infinispan_controller.go
+++ b/pkg/controller/infinispan/infinispan_controller.go
@@ -650,6 +650,17 @@ func (r *ReconcileInfinispan) destroyResources(infinispan *infinispanv1.Infinisp
 	err = r.client.Delete(context.TODO(),
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
+				Name:      infinispan.GetAdminServiceName(),
+				Namespace: infinispan.Namespace,
+			},
+		})
+	if err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+
+	err = r.client.Delete(context.TODO(),
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      infinispan.GetServiceExternalName(),
 				Namespace: infinispan.Namespace,
 			},

--- a/pkg/controller/infinispan/resources/secret/secret_controller.go
+++ b/pkg/controller/infinispan/resources/secret/secret_controller.go
@@ -250,7 +250,7 @@ func (s secretResource) reconcileAdminSecret() error {
 }
 
 func (s secretResource) addCliProperties(secret *corev1.Secret, password string) {
-	service := s.infinispan.GetServiceName()
+	service := s.infinispan.GetAdminServiceName()
 	url := fmt.Sprintf("http://%s:%s@%s:%d", consts.DefaultOperatorUser, url.QueryEscape(password), service, consts.InfinispanAdminPort)
 	properties := fmt.Sprintf("autoconnect-url=%s", url)
 	secret.Data[consts.CliPropertiesFilename] = []byte(properties)

--- a/test/e2e/batch/batch_helper.go
+++ b/test/e2e/batch/batch_helper.go
@@ -1,0 +1,57 @@
+package batch
+
+import (
+	"fmt"
+	v2 "github.com/infinispan/infinispan-operator/pkg/apis/infinispan/v2alpha1"
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"time"
+)
+
+type BatchHelper struct {
+	testKube *tutils.TestKubernetes
+}
+
+func NewBatchHelper(testKube *tutils.TestKubernetes) *BatchHelper {
+	return &BatchHelper{
+		testKube: testKube,
+	}
+}
+
+func (b BatchHelper) CreateBatch(name, cluster string, config, configMap *string) *v2.Batch {
+	batch := &v2.Batch{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infinispan.org/v2alpha1",
+			Kind:       "Batch",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tutils.Namespace,
+		},
+		Spec: v2.BatchSpec{
+			Cluster:   cluster,
+			Config:    config,
+			ConfigMap: configMap,
+		},
+	}
+	batch.Labels = map[string]string{"test-name": name}
+	b.testKube.Create(batch)
+	return batch
+}
+
+func (b BatchHelper) WaitForValidBatchPhase(name string, phase v2.BatchPhase) *v2.Batch {
+	var batch *v2.Batch
+	err := wait.Poll(10*time.Millisecond, tutils.TestTimeout, func() (bool, error) {
+		batch = b.testKube.GetBatch(name, tutils.Namespace)
+		if batch.Status.Phase == v2.BatchFailed && phase != v2.BatchFailed {
+			return true, fmt.Errorf("Batch failed. Reason: %s", batch.Status.Reason)
+		}
+		return phase == batch.Status.Phase, nil
+	})
+	if err != nil {
+		println(fmt.Sprintf("Expected Batch Phase %s, got %s:%s", phase, batch.Status.Phase, batch.Status.Reason))
+	}
+	tutils.ExpectNoError(err)
+	return batch
+}

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -566,6 +566,24 @@ func (k TestKubernetes) GetSchemaForRest(ispn *ispnv1.Infinispan) string {
 	return curr.GetEndpointScheme()
 }
 
+func (k TestKubernetes) GetAdminServicePorts(namespace, name string) []v1.ServicePort {
+	return k.getPorts(namespace, fmt.Sprintf("%s-admin", name))
+}
+
+func (k TestKubernetes) GetServicePorts(namespace, name string) []v1.ServicePort {
+	return k.getPorts(namespace, name)
+}
+
+func (k TestKubernetes) getPorts(namespace, name string) []v1.ServicePort {
+	key := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	service := &corev1.Service{}
+	ExpectNoError(k.Kubernetes.Client.Get(context.TODO(), key, service))
+	return service.Spec.Ports
+}
+
 func debugPods(required int, pods []v1.Pod) {
 	log.Info("pod list incomplete", "required", required, "pod list size", len(pods))
 	for _, pod := range pods {


### PR DESCRIPTION
Motivation: so that redirection of services during rolling upgrades can be done only for the "user facing" service and not for admin services, that needs to be associated with the cluster for monitoring purposes