### PR TITLE
Update README and add help target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,98 +30,130 @@ else
 GOBIN=$(shell go env GOBIN)
 endif
 
-all: manager
+.DEFAULT_GOAL := help
 
+help:
+	@awk '/^#/{c=substr($$0,3);next}c&&/^[[:alpha:]][[:alnum:]_-]+:/{print substr($$1,1,index($$1,":")),c}1{c=0}' $(MAKEFILE_LIST) | column -s: -t
+
+
+.PHONY: lint
+## Invoke linter to promote Go lang best practices.
 lint: golangci-lint
 	$(GOLANGCI_LINT) run --enable errorlint
 	$(GOLANGCI_LINT) run --disable-all --enable bodyclose --skip-dirs test
 
+.PHONY: unit-test
+## Execute unit tests
 unit-test: manager
 	go test ./api/... -v
 	go test ./controllers/... -v
 
+.PHONY: test
+## Execute end to end (e2e) tests on running clusters.
 test: manager manifests
 	scripts/run-tests.sh main
 
+.PHONY: multinamespace-test
+## Execute end to end (e2e) tests in multinamespace mode
 multinamespace-test: manager manifests
 	scripts/run-tests.sh multinamespace
 
+.PHONY: backuprestore-test
+## Execute end to end (e2e) tests for Backup/Restore CR's
 backuprestore-test: manager manifests
 	scripts/run-tests.sh backup-restore
 
+.PHONY: batch-test
+## Execute end to end (e2e) tests for Batch CR's
 batch-test: manager manifests
 	scripts/run-tests.sh batch
-	
-# Build manager binary
+
+.PHONY: manager
+## Build manager binary
 manager: generate fmt vet
 	go build -o bin/manager main.go
 
-# Run against the configured Kubernetes cluster in ~/.kube/config
+.PHONY: run
+## Run the operator against the configured Kubernetes cluster in ~/.kube/config
 run: manager manifests
 	OSDK_FORCE_RUN_MODE=local go run ./main.go
 
-# Install CRDs into a cluster
+.PHONY: install
+## Install CRDs into a cluster
 install: manifests kustomize
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
 
-# Uninstall CRDs from a cluster
+.PHONY: uninstall
+## Uninstall CRDs from a cluster
 uninstall: manifests kustomize
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
-# Deploy controller in the configured Kubernetes cluster in ~/.kube/config
+.PHONY: deploy
+## Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	cd config/default && $(KUSTOMIZE) edit set namespace $(DEPLOYMENT_NAMESPACE)
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
-# UnDeploy controller from the configured Kubernetes cluster in ~/.kube/config
+.PHONY: undeploy
+## Undeploy controller from the configured Kubernetes cluster in ~/.kube/config
 undeploy:
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
-# Generate manifests e.g. CRD, RBAC etc.
+.PHONY: manifests
+## Generate manifests locally e.g. CRD, RBAC etc.
 manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
-# Run go fmt against code
+.PHONY: fmt
+## Run go fmt against code
 fmt:
 	go fmt ./...
 
-# Run go vet against code
+.PHONY: vet
+## Inspects the source code for suspicious constructs.
 vet:
 	go vet ./...
 
-# Generate code
+.PHONY: generate
+## Generate code
 generate: controller-gen rice
 	$(CONTROLLER_GEN) object paths="./..."
 # Generate rice-box files and fix timestamp value
 	$(RICE) embed-go -i controllers/dependencies.go -i controllers/grafana.go
 	find . -type f -name 'rice-box.go' -exec sed -i "s|time.Unix(.*, 0)|time.Unix(1620137619, 0)|" {} \;
 
-
-# Build the docker image
+.PHONY: docker-build
+## Build the docker image
 docker-build: manager
 	docker build -t $(IMG) .
 
-# Push the docker image
+.PHONY: docker-push
+## Push the docker image
 docker-push:
 	docker push $(IMG)
 
-# Download Rice locally if necessary
 RICE = $(shell pwd)/bin/rice
+.PHONY: rice
+## Download Rice locally if necessary
 rice:
 	$(call go-get-tool,$(RICE),github.com/GeertJohan/go.rice/rice@v1.0.2)
 
-# Download controller-gen locally if necessary
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
+.PHONY: controller-gen
+## Download controller-gen locally if necessary
 controller-gen:
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1)
 
-# Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize
+.PHONY: kustomize
+## Download kustomize locally if necessary
 kustomize:
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+.PHONY: golanci-lint
+## Download golanci-lint locally if necessary
 golangci-lint:
 	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.39.0)
 
@@ -139,20 +171,20 @@ rm -rf $$TMP_DIR ;\
 }
 endef
 
-# Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle
+## Generate bundle manifests and metadata, then validate generated files.
 bundle: manifests kustomize
 	operator-sdk generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 
-# Build the bundle image.
 .PHONY: bundle-build
+## Build the bundle image.
 bundle-build:
 	docker build --build-arg VERSION=$(VERSION) -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
-# Push the bundle image.
 .PHONY: bundle-push
+## Push the bundle image.
 bundle-push:
 	docker push $(BUNDLE_IMG)

--- a/README.md
+++ b/README.md
@@ -28,12 +28,15 @@ To create a docker container and push to a remote repository execute:
 ## Running the Operator
 
 ### Locally
+The following commands will generate and install the CRDs to the local cluster before starting the operator. To only execute the operator, simply omit the `install` target.
+
 To watch all namespaces:
 
-`make run`
+`make install run`
 
 To watch specific namespaces:
-`make run WATCH_NAMESPACE=namespace1,namespace2`
+
+`make install run WATCH_NAMESPACE=namespace1,namespace2`
 
 ### On K8s
 To deploy the operator to the cluster you're currently connected to, execute:
@@ -63,10 +66,25 @@ make bundle-build bundle-push VERSION=<latest-version> IMG=<operator-image> BUND
 
 ## Go Integration Tests
 
-`make test`
-`make batch-test`
-`make multinamespace-test`
-`make backuprestore-test`
+The different categories of integration tests can be executed with the following commands:
+
+- `make test`
+- `make batch-test`
+- `make multinamespace-test`
+- `make backuprestore-test`
+
+The target cluster should be specified by exporting or explicitly providing `KUBECONFIG`, e.g. `make test KUBECONFIG=/path/to/admin.kubeconfig`.
+
+### Env Variables
+The followin variables can be exported or provided as part of the `make *test` call.
+
+| Variable              | Purpose                                                                              |
+|-----------------------|--------------------------------------------------------------------------------------|
+| `TEST_NAME`           | Specify a single test to run                                                         |
+| `TESTING_NAMESPACE`   | Specify the namespace/project for running test                                       |
+| `RUN_LOCAL_OPERATOR`  | Specify whether run operator locally or use the predefined installation              |
+| `EXPOSE_SERVICE_TYPE` | Specify expose service type. `NodePort \| LoadBalancer \| Route`.                    |
+| `PARALLEL_COUNT`      | Specify parallel test running count. Default is one, i.e. no parallel tests enabled. |
 
 ### Xsite
 Cross-Site tests require you to create two k8s Kind clusters or utilize already prepared OKD clusters:


### PR DESCRIPTION
`make` or `make help`:

```
lint                   Invoke linter to promote Go lang best practices.
unit-test              Execute unit tests
test                   Execute end to end (e2e) tests on running clusters.
multinamespace-test    Execute end to end (e2e) tests in multinamespace mode
backuprestore-test     Execute end to end (e2e) tests for Backup/Restore CR's
batch-test             Execute end to end (e2e) tests for Batch CR's
manager                Build manager binary
run                    Run the operator against the configured Kubernetes cluster in ~/.kube/config
install                Install CRDs into a cluster
uninstall              Uninstall CRDs from a cluster
deploy                 Deploy controller in the configured Kubernetes cluster in ~/.kube/config
undeploy               Undeploy controller from the configured Kubernetes cluster in ~/.kube/config
manifests              Generate manifests locally e.g. CRD, RBAC etc.
fmt                    Run go fmt against code
vet                    Inspects the source code for suspicious constructs.
generate               Generate code
docker-build           Build the docker image
docker-push            Push the docker image
rice                   Download Rice locally if necessary
controller-gen         Download controller-gen locally if necessary
kustomize              Download kustomize locally if necessary
golangci-lint          Download golanci-lint locally if necessary
bundle                 Generate bundle manifests and metadata, then validate generated files.
bundle-build           Build the bundle image.
bundle-push            Push the bundle image.
```