### PR TITLE
[E2E] Clean-up ConfigMap in TestBatchConfigMap

### DIFF
--- a/test/e2e/batch/batch_test.go
+++ b/test/e2e/batch/batch_test.go
@@ -75,9 +75,8 @@ func TestBatchConfigMap(t *testing.T) {
 		},
 	}
 
-	if err := testKube.Kubernetes.Client.Create(ctx, configMap); err != nil {
-		panic(fmt.Errorf("Unable to create ConfigMap: %w", err))
-	}
+	testKube.CreateConfigMap(configMap)
+	defer testKube.DeleteConfigMap(configMap)
 
 	batch := helper.CreateBatch(name, name, nil, &configMapName)
 

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -656,6 +656,18 @@ func (k TestKubernetes) DeleteSecret(secret *v1.Secret) {
 	ExpectMaybeNotFound(err)
 }
 
+// CreateConfigMap creates a ConfigMap
+func (k TestKubernetes) CreateConfigMap(configMap *v1.ConfigMap) {
+	err := k.Kubernetes.Client.Create(context.TODO(), configMap)
+	ExpectNoError(err)
+}
+
+// DeleteConfigMap deletes a ConfigMap
+func (k TestKubernetes) DeleteConfigMap(configMap *v1.ConfigMap) {
+	err := k.Kubernetes.Client.Delete(context.TODO(), configMap, DeleteOpts...)
+	ExpectMaybeNotFound(err)
+}
+
 // RunOperator runs an operator on a Kubernetes cluster
 func (k TestKubernetes) RunOperator(namespace, crdsPath string) chan struct{} {
 	k.installCRD(crdsPath + "infinispan.org_infinispans.yaml")


### PR DESCRIPTION
Make `TestBatchConfigMap` clean-up `ConfigMap` after it's executed otherwise second run of the test will fail on already existing `ConfigMap`.