### PR TITLE
Use statefulSet name instead of version to label pods

### DIFF
--- a/api/v1/types_util.go
+++ b/api/v1/types_util.go
@@ -522,8 +522,8 @@ func (ispn *Infinispan) AddLabelsForPods(uMap map[string]string) {
 	addLabelsFor(ispn, PodTargetLabels, uMap)
 }
 
-func (ispn *Infinispan) AddVersionLabelForPods(uMap map[string]string) {
-	uMap[consts.VersionPodLabel] = strings.Split(consts.DefaultImageName, ":")[1]
+func (ispn *Infinispan) AddStatefulSetLabelForPods(uMap map[string]string) {
+	uMap[consts.StatefulSetPodLabel] = ispn.Name
 }
 
 // AddLabelsForServices adds to the user maps the labels defined for services and ingresses/routes in the infinispan CR. New values override old ones in map.

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -36,7 +36,7 @@ var (
 	SystemPodLabels = map[string]bool{
 		appsv1.StatefulSetPodNameLabel:  true,
 		appsv1.StatefulSetRevisionLabel: true,
-		VersionPodLabel:                 true,
+		StatefulSetPodLabel:             true,
 	}
 )
 
@@ -57,7 +57,7 @@ const (
 	InfinispanUserPort       = 11222
 	CrossSitePort            = 7900
 	CrossSitePortName        = "xsite"
-	VersionPodLabel          = "app.kubernetes.io/version"
+	StatefulSetPodLabel      = "app.kubernetes.io/created-by"
 	StaticCrossSiteUriSchema = "infinispan+xsite"
 	// DefaultCacheManagerName default cache manager name used for cross site
 	DefaultCacheManagerName                 = "default"

--- a/controllers/infinispan_controller.go
+++ b/controllers/infinispan_controller.go
@@ -1021,7 +1021,7 @@ func (r *infinispanRequest) statefulSetForInfinispan(adminSecret, userSecret, ke
 	labelsForPod := PodLabels(ispn.Name)
 	ispn.AddOperatorLabelsForPods(labelsForPod)
 	ispn.AddLabelsForPods(labelsForPod)
-	ispn.AddVersionLabelForPods(labelsForPod)
+	ispn.AddStatefulSetLabelForPods(labelsForPod)
 
 	pvcs := &corev1.PersistentVolumeClaimList{}
 	err := r.kubernetes.ResourcesList(ispn.Namespace, LabelsResource(ispn.Name, ""), pvcs, r.ctx)
@@ -1487,7 +1487,7 @@ func (r *infinispanRequest) reconcileContainerConf(statefulSet *appsv1.StatefulS
 			labelsForPod := PodLabels(ispn.Name)
 			ispn.AddOperatorLabelsForPods(labelsForPod)
 			ispn.AddLabelsForPods(labelsForPod)
-			ispn.AddVersionLabelForPods(labelsForPod)
+			ispn.AddStatefulSetLabelForPods(labelsForPod)
 			statefulSet.Spec.Template.Labels = labelsForPod
 		}
 		err := r.Client.Update(r.ctx, statefulSet)


### PR DESCRIPTION
Some deloyments use image name as a SHA string and it overflows the maximum label size.