### PR TITLE
Update proc_creating_service_monitor

### DIFF
--- a/documentation/asciidoc/topics/proc_creating_service_monitor.adoc
+++ b/documentation/asciidoc/topics/proc_creating_service_monitor.adoc
@@ -11,7 +11,7 @@ Enable monitoring for user-defined projects on {ocp}.
 When the Operator detects an `Infinispan` CR with the monitoring annotation set to `true`, which is the default, {ispn_operator} does the following:
 
 * Creates a `ServiceMonitor` named `<cluster_name>-monitor`.
-* Adds `infinispan.org/monitoring: 'true'` annotation to your `Infinispan` CR  metadata, if the value is not already explicitly set:
+* Adds the `infinispan.org/monitoring: 'true'` annotation to your `Infinispan` CR  metadata, if the value is not already explicitly set:
 +
 [source,yaml,options="nowrap",subs=attributes+]
 ----


### PR DESCRIPTION
Update proc_creating_service_monitor.adoc in the section "the section "Creating a Prometheus service monitor"  which seems to be causing confusion to customers;
"that the user needs to create manually a ServiceMonitor CR and that Operator will see it then add the annotation in the Infinispan CR.
