### PR TITLE
Add support for cross-site communication using Openshift Routes

### DIFF
--- a/api/v1/infinispan_types.go
+++ b/api/v1/infinispan_types.go
@@ -220,7 +220,7 @@ const (
 )
 
 // CrossSiteExposeType describe different exposition methods for Infinispan Cross-Site service
-// +kubebuilder:validation:Enum=NodePort;LoadBalancer;ClusterIP
+// +kubebuilder:validation:Enum=NodePort;LoadBalancer;ClusterIP;Route
 type CrossSiteExposeType string
 
 const (
@@ -236,6 +236,9 @@ const (
 	// CrossSiteExposeTypeClusterIP means an internal 'ClusterIP'
 	// service will be created without external exposition
 	CrossSiteExposeTypeClusterIP = CrossSiteExposeType(corev1.ServiceTypeClusterIP)
+
+	// CrossSiteExposeTypeRoute route
+	CrossSiteExposeTypeRoute = "Route"
 )
 
 // CrossSiteSchemeType specifies the supported url scheme's allowed in InfinispanSiteLocationSpec.URL
@@ -271,6 +274,9 @@ type CrossSiteExposeSpec struct {
 	NodePort int32 `json:"nodePort,omitempty"`
 	// +optional
 	Port int32 `json:"port,omitempty"`
+	// RouteHostName optionally, specifies a custom hostname to be used by Openshift Route.
+	// +optional
+	RouteHostName string `json:"routeHostName,omitempty"`
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 }

--- a/api/v1/types_util.go
+++ b/api/v1/types_util.go
@@ -47,6 +47,7 @@ const (
 	ServiceMonitoringAnnotation string = "infinispan.org/monitoring"
 
 	SiteServiceNameTemplate = "%v-site"
+	SiteRouteNameSuffix     = "-route-site"
 	SiteServiceFQNTemplate  = "%s.%s.svc.cluster.local"
 
 	GossipRouterDeploymentNameTemplate = "%s-tunnel"
@@ -284,6 +285,10 @@ func (ispn *Infinispan) HasSites() bool {
 	return ispn.IsDataGrid() && ispn.Spec.Service.Sites != nil
 }
 
+func (ispn *Infinispan) GetCrossSiteExposeType() CrossSiteExposeType {
+	return ispn.Spec.Service.Sites.Local.Expose.Type
+}
+
 // GetRemoteSiteLocations returns remote site locations
 func (ispn *Infinispan) GetRemoteSiteLocations() (remoteLocations map[string]InfinispanSiteLocationSpec) {
 	remoteLocations = make(map[string]InfinispanSiteLocationSpec)
@@ -323,6 +328,26 @@ func (ispn *Infinispan) GetSiteServiceName() string {
 
 func (ispn *Infinispan) GetRemoteSiteServiceName(locationName string) string {
 	return fmt.Sprintf(SiteServiceNameTemplate, ispn.GetRemoteSiteClusterName(locationName))
+}
+
+// GetSiteRouteName returns the local Route name for cross-site replication
+func (ispn *Infinispan) GetSiteRouteName() string {
+	name := ispn.Name
+	maxNameLength := MaxRouteObjectNameLength - len(SiteRouteNameSuffix)
+	if len(name) >= maxNameLength {
+		name = name[0 : maxNameLength-1]
+	}
+	return name + SiteRouteNameSuffix
+}
+
+// GetRemoteSiteRouteName return the remote Route name for cross-site replication
+func (ispn *Infinispan) GetRemoteSiteRouteName(locationName string) string {
+	name := ispn.GetRemoteSiteClusterName(locationName)
+	maxNameLength := MaxRouteObjectNameLength - len(SiteRouteNameSuffix)
+	if len(name) >= maxNameLength {
+		name = name[0 : maxNameLength-1]
+	}
+	return name + SiteRouteNameSuffix
 }
 
 func (ispn *Infinispan) GetRemoteSiteServiceFQN(locationName string) string {

--- a/config/crd/bases/infinispan.org_infinispans.yaml
+++ b/config/crd/bases/infinispan.org_infinispans.yaml
@@ -921,6 +921,10 @@ spec:
                               port:
                                 format: int32
                                 type: integer
+                              routeHostName:
+                                description: RouteHostName optionally, specifies a
+                                  custom hostname to be used by Openshift Route.
+                                type: string
                               type:
                                 description: Type specifies different exposition methods
                                   for data grid
@@ -928,6 +932,7 @@ spec:
                                 - NodePort
                                 - LoadBalancer
                                 - ClusterIP
+                                - Route
                                 type: string
                             required:
                             - type

--- a/controllers/infinispan_service_controller.go
+++ b/controllers/infinispan_service_controller.go
@@ -142,8 +142,24 @@ func (reconciler *ServiceReconciler) Reconcile(ctx context.Context, request reco
 	}
 
 	if s.infinispan.HasSites() {
-		if err := s.reconcileResource(computeSiteService(s.infinispan)); err != nil {
-			return reconcile.Result{}, err
+		switch s.infinispan.GetCrossSiteExposeType() {
+		case ispnv1.CrossSiteExposeTypeClusterIP, ispnv1.CrossSiteExposeTypeNodePort, ispnv1.CrossSiteExposeTypeLoadBalancer:
+			// just a single external service
+			if err := s.reconcileResource(computeSiteService(s.infinispan, s.infinispan.GetCrossSiteExposeType())); err != nil {
+				return reconcile.Result{}, err
+			}
+		case ispnv1.CrossSiteExposeTypeRoute:
+			if s.isTypeSupported(consts.ExternalTypeRoute) {
+				// create internal service
+				if err := s.reconcileResource(computeSiteService(s.infinispan, ispnv1.CrossSiteExposeTypeClusterIP)); err != nil {
+					return reconcile.Result{}, err
+				}
+				if err := s.reconcileResource(computeSiteRoute(s.infinispan)); err != nil {
+					return reconcile.Result{}, err
+				}
+			} else {
+				return reconcile.Result{}, fmt.Errorf("route cross-site expose type is not supported")
+			}
 		}
 	} else {
 		siteService := &corev1.Service{
@@ -480,14 +496,14 @@ func computeServiceExternal(ispn *ispnv1.Infinispan) *corev1.Service {
 }
 
 // computeSiteService compute the XSite service
-func computeSiteService(ispn *ispnv1.Infinispan) *corev1.Service {
+func computeSiteService(ispn *ispnv1.Infinispan, exposeType ispnv1.CrossSiteExposeType) *corev1.Service {
 	lsPodSelector := GossipRouterPodLabels(ispn.Name)
 
 	exposeSpec := corev1.ServiceSpec{}
 	exposeConf := ispn.Spec.Service.Sites.Local.Expose
 	exposeSpec.Selector = lsPodSelector
 
-	switch exposeConf.Type {
+	switch exposeType {
 	case ispnv1.CrossSiteExposeTypeNodePort:
 		exposeSpec.Type = corev1.ServiceTypeNodePort
 		exposeSpec.Ports = []corev1.ServicePort{
@@ -542,6 +558,39 @@ func computeSiteService(ispn *ispnv1.Infinispan) *corev1.Service {
 	ispn.AddOperatorLabelsForServices(siteService.Labels)
 	ispn.AddLabelsForServices(siteService.Labels)
 	return &siteService
+}
+
+func computeSiteRoute(ispn *ispnv1.Infinispan) *routev1.Route {
+	host := strings.TrimSpace(ispn.Spec.Service.Sites.Local.Expose.RouteHostName)
+	route := routev1.Route{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "route.openshift.io/v1",
+			Kind:       "Route",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ispn.GetSiteRouteName(),
+			Namespace: ispn.Namespace,
+			Labels:    LabelsResource(ispn.Name, "infinispan-route-xsite"),
+		},
+		Spec: routev1.RouteSpec{
+			Host: host,
+			Port: &routev1.RoutePort{
+				TargetPort: intstr.IntOrString{IntVal: consts.CrossSitePort},
+			},
+			To: routev1.RouteTargetReference{
+				Kind: "Service",
+				Name: ispn.GetSiteServiceName(),
+			},
+			TLS: &routev1.TLSConfig{
+				Termination: routev1.TLSTerminationPassthrough,
+			},
+		},
+	}
+
+	// This way CR labels will override operator labels with same name
+	ispn.AddOperatorLabelsForServices(route.Labels)
+	ispn.AddLabelsForServices(route.Labels)
+	return &route
 }
 
 // computeRoute compute the Route object

--- a/controllers/xsite_config.go
+++ b/controllers/xsite_config.go
@@ -12,7 +12,9 @@ import (
 	consts "github.com/infinispan/infinispan-operator/controllers/constants"
 	config "github.com/infinispan/infinispan-operator/pkg/infinispan/configuration/server"
 	kube "github.com/infinispan/infinispan-operator/pkg/kubernetes"
+	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
@@ -61,15 +63,22 @@ func ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *kube.Kubernetes, se
 	// add local site first
 	appendBackupSite(infinispan.Spec.Service.Sites.Local.Name, siteServiceName, localPort, xsite)
 
+	err = searchRemoteSites(infinispan, kubernetes, xsite, logger, eventRec, ctx)
+
+	logger.Info("x-site configured", "configuration", xsite)
+	return xsite, err
+}
+
+func searchRemoteSites(infinispan *ispnv1.Infinispan, kubernetes *kube.Kubernetes, xsite *config.XSite, logger logr.Logger, eventRec record.EventRecorder, ctx context.Context) error {
 	for _, remoteLocation := range infinispan.GetRemoteSiteLocations() {
 		backupSiteURL, err := url.Parse(remoteLocation.URL)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if backupSiteURL.Scheme == "" || (backupSiteURL.Scheme == consts.StaticCrossSiteUriSchema && backupSiteURL.Hostname() == "") {
 			// No static location provided. Try to resolve internal cluster service
 			if infinispan.GetRemoteSiteClusterName(remoteLocation.Name) == infinispan.Name && infinispan.GetRemoteSiteNamespace(remoteLocation.Name) == infinispan.Namespace {
-				return nil, fmt.Errorf("unable to link the cross-site service with itself. clusterName '%s' or namespace '%s' for remote location '%s' should be different from the original cluster name or namespace",
+				return fmt.Errorf("unable to link the cross-site service with itself. clusterName '%s' or namespace '%s' for remote location '%s' should be different from the original cluster name or namespace",
 					infinispan.GetRemoteSiteClusterName(remoteLocation.Name), infinispan.GetRemoteSiteNamespace(remoteLocation.Name), remoteLocation.Name)
 			}
 			// Add cross-site FQN service name inside the same k8s cluster
@@ -80,13 +89,11 @@ func ComputeXSite(infinispan *ispnv1.Infinispan, kubernetes *kube.Kubernetes, se
 		} else {
 			// lookup remote service via kubernetes API
 			if err = appendRemoteLocation(ctx, infinispan, &remoteLocation, kubernetes, logger, eventRec, xsite); err != nil {
-				return nil, err
+				return err
 			}
 		}
 	}
-
-	logger.Info("x-site configured", "configuration", xsite)
-	return xsite, nil
+	return nil
 }
 
 func appendRemoteLocation(ctx context.Context, infinispan *ispnv1.Infinispan, remoteLocation *ispnv1.InfinispanSiteLocationSpec, kubernetes *kube.Kubernetes,
@@ -111,18 +118,40 @@ func appendRemoteLocation(ctx context.Context, infinispan *ispnv1.Infinispan, re
 func appendKubernetesRemoteLocation(ctx context.Context, infinispan *ispnv1.Infinispan, remoteLocationName string, remoteKubernetes *kube.Kubernetes, logger logr.Logger, eventRec record.EventRecorder, xsite *config.XSite) error {
 	remoteNamespace := infinispan.GetRemoteSiteNamespace(remoteLocationName)
 	remoteServiceName := infinispan.GetRemoteSiteServiceName(remoteLocationName)
+	remoteRouteName := infinispan.GetRemoteSiteRouteName(remoteLocationName)
 
+	var host string
+	var port int32
+	var err error
+
+	// Try to find the service first
 	siteService := &corev1.Service{}
-	err := remoteKubernetes.Client.Get(ctx, types.NamespacedName{Name: remoteServiceName, Namespace: remoteNamespace}, siteService)
+	err = remoteKubernetes.Client.Get(ctx, types.NamespacedName{Name: remoteServiceName, Namespace: remoteNamespace}, siteService)
 	if err != nil {
 		logger.Error(err, "could not get x-site service in remote cluster", "site service name", remoteServiceName, "site namespace", remoteNamespace)
-		return err
+		if !errors.IsNotFound(err) {
+			// another error
+			return err
+		}
 	}
 
-	host, port, err := getCrossSiteServiceHostPort(siteService, remoteKubernetes, logger, eventRec, "XSiteRemoteServiceUnsupported", ctx)
-	if err != nil {
-		logger.Error(err, "error retrieving remote x-site service information")
-		return err
+	// service found
+	if err == nil {
+		host, port, err = getCrossSiteServiceHostPort(siteService, remoteKubernetes, logger, eventRec, "XSiteRemoteServiceUnsupported", ctx)
+		if err != nil {
+			logger.Error(err, "error retrieving remote x-site service information")
+			return err
+		}
+	} else {
+		// Try searching for the Route
+		siteRoute := &routev1.Route{}
+		err = remoteKubernetes.Client.Get(ctx, types.NamespacedName{Name: remoteRouteName, Namespace: remoteNamespace}, siteRoute)
+		if err != nil {
+			logger.Error(err, "could not get x-site Route in remote cluster", "site route name", remoteRouteName, "site namespace", remoteNamespace)
+			return err
+		}
+		host = siteRoute.Spec.Host
+		port = 443 // TLS port
 	}
 
 	if host == "" {
@@ -131,7 +160,7 @@ func appendKubernetesRemoteLocation(ctx context.Context, infinispan *ispnv1.Infi
 		return fmt.Errorf(msg)
 	}
 
-	logger.Info("remote site service", "service name", remoteServiceName, "host", host, "port", port)
+	logger.Info("remote site service", "host", host, "port", port)
 	appendBackupSite(remoteLocationName, host, port, xsite)
 	return nil
 }


### PR DESCRIPTION
Enable Openshift Route for cross-site communication. 

Currently, I'm unable to add tests for CI. :/ 