### PR TITLE
Split core testsuite so that all Cache CR tests belong in test/e2e/cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,6 +75,12 @@ pipeline {
                     }
                 }
 
+                stage('Cache') {
+                    steps {
+                        sh "make cache-test PARALLEL_COUNT=2"
+                    }
+                }
+
                 stage('Batch') {
                     steps {
                         sh 'make batch-test PARALLEL_COUNT=2'

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ unit-test: manager
 test: manager manifests
 	scripts/run-tests.sh main
 
+.PHONY: cache-test
+## Execute end to end (e2e) tests for Cache CRs
+cache-test: manager manifests
+	scripts/run-tests.sh cache
+
 .PHONY: multinamespace-test
 ## Execute end to end (e2e) tests in multinamespace mode
 multinamespace-test: manager manifests

--- a/test/e2e/cache/cache_test.go
+++ b/test/e2e/cache/cache_test.go
@@ -1,0 +1,73 @@
+package cache
+
+import (
+	"os"
+	"testing"
+
+	"github.com/iancoleman/strcase"
+	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
+	"github.com/infinispan/infinispan-operator/api/v2alpha1"
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var testKube = tutils.NewTestKubernetes(os.Getenv("TESTING_CONTEXT"))
+
+func TestMain(m *testing.M) {
+	tutils.RunOperator(m, testKube)
+}
+
+func TestCacheCR(t *testing.T) {
+	t.Parallel()
+	spec := tutils.DefaultSpec(testKube)
+	name := strcase.ToKebab(t.Name())
+	spec.Name = name
+	spec.Labels = map[string]string{"test-name": t.Name()}
+	testKube.CreateInfinispan(spec, tutils.Namespace)
+	defer testKube.CleanNamespaceAndLogOnPanic(tutils.Namespace, spec.Labels)
+	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
+	ispn := testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)
+
+	//Test for CacheCR with Templatename
+
+	cacheCRTemplateName := createCacheWithCR("cache-with-static-template", spec.Namespace, name)
+	cacheCRTemplateName.Spec.TemplateName = "org.infinispan.DIST_SYNC"
+	testCacheWithCR(ispn, cacheCRTemplateName)
+
+	//Test for CacheCR with TemplateXML
+
+	cacheCRTemplateXML := createCacheWithCR("cache-with-xml-template", spec.Namespace, name)
+	cacheCRTemplateXML.Spec.Template = "<infinispan><cache-container><distributed-cache name=\"cache-with-xml-template\" mode=\"SYNC\"><persistence><file-store/></persistence></distributed-cache></cache-container></infinispan>"
+	testCacheWithCR(ispn, cacheCRTemplateXML)
+}
+
+func testCacheWithCR(ispn *ispnv1.Infinispan, cache *v2alpha1.Cache) {
+	key := "testkey"
+	value := "test-operator"
+	testKube.Create(cache)
+	hostAddr, client := tutils.HTTPClientAndHost(ispn, testKube)
+	condition := v2alpha1.CacheCondition{
+		Type:   "Ready",
+		Status: "True",
+	}
+	testKube.WaitForCacheCondition(cache.Spec.Name, cache.Namespace, condition)
+	tutils.WaitForCacheToBeCreated(cache.Spec.Name, hostAddr, client)
+	tutils.TestBasicCacheUsage(key, value, cache.Spec.Name, hostAddr, client)
+	defer testKube.DeleteCache(cache)
+}
+func createCacheWithCR(cacheName string, nameSpace string, clusterName string) *v2alpha1.Cache {
+	return &v2alpha1.Cache{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infinispan.org/v2alpha1",
+			Kind:       "Cache",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cacheName,
+			Namespace: nameSpace,
+		},
+		Spec: v2alpha1.CacheSpec{
+			ClusterName: clusterName,
+			Name:        cacheName,
+		},
+	}
+}

--- a/test/e2e/utils/cache.go
+++ b/test/e2e/utils/cache.go
@@ -1,0 +1,107 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+func CacheURL(cacheName, hostAddr string) string {
+	return fmt.Sprintf("%v/rest/v2/caches/%s", hostAddr, cacheName)
+}
+
+func CreateCache(cacheName, hostAddr string, flags string, client HTTPClient) *http.Response {
+	httpURL := CacheURL(cacheName, hostAddr)
+	headers := map[string]string{}
+	if flags != "" {
+		headers["Flags"] = flags
+	}
+	resp, err := client.Post(httpURL, "", headers)
+	ExpectNoError(err)
+	return resp
+}
+
+func CreateCacheAndValidate(cacheName, hostAddr string, flags string, client HTTPClient) {
+	resp := CreateCache(cacheName, hostAddr, flags, client)
+	defer CloseHttpResponse(resp)
+	if resp.StatusCode != http.StatusOK {
+		panic(HttpError{resp.StatusCode})
+	}
+}
+
+func CreateCacheWithXMLTemplate(cacheName, hostAddr, template string, client HTTPClient) {
+	httpURL := CacheURL(cacheName, hostAddr)
+	fmt.Printf("Create cache: %v\n", httpURL)
+	headers := map[string]string{
+		"Content-Type": "application/xml;charset=UTF-8",
+	}
+	resp, err := client.Post(httpURL, template, headers)
+	defer CloseHttpResponse(resp)
+	ExpectNoError(err)
+	// Accept all the 2xx success codes
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		ThrowHTTPError(resp)
+	}
+}
+
+func TestBasicCacheUsage(key, value, cacheName, hostAddr string, client HTTPClient) {
+	keyURL := fmt.Sprintf("%v/%v", CacheURL(cacheName, hostAddr), key)
+	PutViaRoute(keyURL, value, client)
+	actual := GetViaRoute(keyURL, client)
+
+	if actual != value {
+		panic(fmt.Errorf("unexpected actual returned: %v (value %v)", actual, value))
+	}
+}
+
+func PutViaRoute(url, value string, client HTTPClient) {
+	headers := map[string]string{
+		"Content-Type": "text/plain",
+	}
+	resp, err := client.Post(url, value, headers)
+	defer CloseHttpResponse(resp)
+	ExpectNoError(err)
+	if resp.StatusCode != http.StatusNoContent {
+		ThrowHTTPError(resp)
+	}
+}
+
+func DeleteCache(cacheName, hostAddr string, client HTTPClient) {
+	httpURL := CacheURL(cacheName, hostAddr)
+	resp, err := client.Delete(httpURL, nil)
+	ExpectNoError(err)
+
+	if resp.StatusCode != http.StatusOK {
+		panic(HttpError{resp.StatusCode})
+	}
+}
+
+func GetViaRoute(url string, client HTTPClient) string {
+	resp, err := client.Get(url, nil)
+	ExpectNoError(err)
+	defer func(Body io.ReadCloser) {
+		ExpectNoError(Body.Close())
+	}(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		ThrowHTTPError(resp)
+	}
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	ExpectNoError(err)
+	return string(bodyBytes)
+}
+
+func WaitForCacheToBeCreated(cacheName, hostAddr string, client HTTPClient) {
+	err := wait.Poll(DefaultPollPeriod, MaxWaitTimeout, func() (done bool, err error) {
+		httpURL := CacheURL(cacheName, hostAddr)
+		fmt.Printf("Waiting for cache to be created")
+		resp, err := client.Get(httpURL, nil)
+		if err != nil {
+			return false, err
+		}
+		return resp.StatusCode == http.StatusOK, nil
+	})
+	ExpectNoError(err)
+}

--- a/test/e2e/utils/httpClient.go
+++ b/test/e2e/utils/httpClient.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -43,6 +44,19 @@ type httpClientConfig struct {
 	protocol string
 	auth     authType
 	quiet    bool
+}
+
+type HttpError struct {
+	Status int
+}
+
+func (e *HttpError) Error() string {
+	return fmt.Sprintf("unexpected response %v", e.Status)
+}
+
+func ThrowHTTPError(resp *http.Response) {
+	errorBytes, _ := ioutil.ReadAll(resp.Body)
+	panic(fmt.Errorf("unexpected HTTP status code (%d): %s", resp.StatusCode, string(errorBytes)))
 }
 
 // NewHTTPClient return a new HTTPClient


### PR DESCRIPTION
This is required by the Cache reconciliation work https://github.com/infinispan/infinispan-operator/issues/747. Creating as an initial PR to reduce the size of the final PR.