### PR TITLE
2.2.x:[test-integraiont] CI fixes, Grafana enablement on OCP4.9

### DIFF
--- a/test-integration/global-test.properties
+++ b/test-integration/global-test.properties
@@ -1,1 +1,1 @@
-xtf.testserver.image=registry.access.redhat.com/jboss-webserver-3/webserver31-tomcat8-openshift:1.3
+xtf.testserver.image=registry.redhat.io/jboss-webserver-5/webserver55-openjdk11-tomcat9-openshift-rhel8:1.0

--- a/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
@@ -72,7 +72,7 @@ public class Infinispan {
          }
       };
 
-      new SimpleWaiter(bs).timeout(TimeUnit.MINUTES, 3).waitFor();
+      new SimpleWaiter(bs).timeout(TimeUnit.MINUTES, 5).waitFor();
 
       if(openShift.getLabeledPods("clusterName", clusterName).size() != infinispanObject.getSpec().getReplicas()) {
          throw new IllegalStateException(clusterName + " is WellFormed but cluster pod count doesn't match expected replicas!");

--- a/test-integration/operator-tests/src/test/resources/monitoring/grafana_sub.yaml
+++ b/test-integration/operator-tests/src/test/resources/monitoring/grafana_sub.yaml
@@ -3,7 +3,7 @@ kind: Subscription
 metadata:
   name: grafana-operator
 spec:
-  channel: alpha
+  channel: v4
   installPlanApproval: Automatic
   name: grafana-operator
   source: community-operators


### PR DESCRIPTION
* Fixes CI failures with HotRod client cert authentication
* Enables Grafana deployment on OCP4.9