### PR TITLE
Enable xsite tests with downstream operator installed globally on OCP

### DIFF
--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -30,6 +30,7 @@ var (
 	MultiNamespace    = strings.ToLower(constants.GetEnvWithDefault("TESTING_MULTINAMESPACE", "namespace-for-testing-1,namespace-for-testing-2"))
 	OperatorNamespace = strings.ToLower(constants.GetEnvWithDefault("TESTING_OPERATOR_NAMESPACE", ""))
 	OperatorName      = "infinispan-operator"
+	OperatorSAName    = strings.ToLower(constants.GetEnvWithDefault("OPERATOR_SA_NAME", "infinispan-operator-controller-manager"))
 	RunLocalOperator  = strings.ToUpper(constants.GetEnvWithDefault("RUN_LOCAL_OPERATOR", "true"))
 	RunSaOperator     = strings.ToUpper(constants.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	CleanupInfinispan = strings.ToUpper(constants.GetEnvWithDefault("CLEANUP_INFINISPAN_ON_FINISH", "true"))


### PR DESCRIPTION
Includes several enhancements for xsite test in order to enable their execution against downstream Operator
* Operator SA name differs between upstream/downstream
* Cluster name referred by Context in KUBECONFIG file may have different name then the Context itself
* Operator may be installed globally