### PR TITLE
[2.2.x] Graceful Shutdown Refactoring #1154

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ generate: controller-gen rice
 .PHONY: operator-build
 ## Build the operator image
 operator-build: manager
-	$(CONTAINER_TOOL) build -t $(IMG) .
+	$(CONTAINER_TOOL) build --build-arg VERSION=$(VERSION) -t $(IMG) .
 
 .PHONY: operator-push
 ## Push the operator image

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -100,15 +100,16 @@ const (
 	ServerOperatorSecurity              = ServerSecurityRoot + "/conf/operator-security"
 	ServerRoot                          = "/opt/infinispan/server"
 
-	ServerHTTPBasePath         = "rest/v2"
-	ServerHTTPCacheManagerPath = ServerHTTPBasePath + "/cache-managers/" + DefaultCacheManagerName
-	ServerHTTPHealthPath       = ServerHTTPCacheManagerPath + "/health"
-	ServerHTTPServerStop       = ServerHTTPBasePath + "/server?action=stop"
-	ServerHTTPClusterStop      = ServerHTTPBasePath + "/cluster?action=stop"
-	ServerHTTPHealthStatusPath = ServerHTTPHealthPath + "/status"
-	ServerHTTPLoggersPath      = ServerHTTPBasePath + "/logging/loggers"
-	ServerHTTPModifyLoggerPath = ServerHTTPLoggersPath + "/%s?level=%s"
-	ServerHTTPXSitePath        = ServerHTTPCacheManagerPath + "/x-site/backups"
+	ServerHTTPBasePath          = "rest/v2"
+	ServerHTTPCacheManagerPath  = ServerHTTPBasePath + "/cache-managers/" + DefaultCacheManagerName
+	ServerHTTPHealthPath        = ServerHTTPCacheManagerPath + "/health"
+	ServerHTTPServerStop        = ServerHTTPBasePath + "/server?action=stop"
+	ServerHTTPClusterStop       = ServerHTTPBasePath + "/cluster?action=stop"
+	ServerHTTPContainerShutdown = ServerHTTPBasePath + "/container?action=shutdown"
+	ServerHTTPHealthStatusPath  = ServerHTTPHealthPath + "/status"
+	ServerHTTPLoggersPath       = ServerHTTPBasePath + "/logging/loggers"
+	ServerHTTPModifyLoggerPath  = ServerHTTPLoggersPath + "/%s?level=%s"
+	ServerHTTPXSitePath         = ServerHTTPCacheManagerPath + "/x-site/backups"
 
 	EncryptTruststoreKey         = "truststore.p12"
 	EncryptTruststorePasswordKey = "truststore-password"
@@ -138,6 +139,8 @@ const (
 	DefaultLongWaitOnCreateResource = 60 * time.Second
 	//DefaultWaitClusterNotWellFormed wait delay until cluster is not well formed
 	DefaultWaitClusterNotWellFormed = 15 * time.Second
+	// DefaultWaitPodsNotReady wait delay until cluster pods are ready
+	DefaultWaitClusterPodsNotReady = 2 * time.Second
 )
 
 const (

--- a/scripts/ci/install-catalog-source.sh
+++ b/scripts/ci/install-catalog-source.sh
@@ -33,6 +33,7 @@ make catalog-build catalog-push
 
 # Create the namespace and CatalogSource
 kubectl create namespace ${TESTING_NAMESPACE} || true
+kubectl delete CatalogSource test-catalog -n ${TESTING_NAMESPACE} || true
 cat <<EOF | kubectl apply -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -74,7 +74,10 @@ func TestUpgrade(t *testing.T) {
 	}
 
 	defer cleanup(labels)
-	testKube.CreateOperatorGroup(subName, tutils.Namespace, tutils.Namespace)
+	// Create OperatorGroup only if Subscription is created in non-global namespace
+	if subNamespace != "openshift-operators" && subNamespace != "operators" {
+		testKube.CreateOperatorGroup(subName, subNamespace, subNamespace)
+	}
 	testKube.CreateSubscription(sub)
 
 	// Approve the initial startingCSV InstallPlan
@@ -259,7 +262,7 @@ func populateCache(cacheName, host string, numEntries int, infinispan *ispnv1.In
 
 	headers := map[string]string{"Content-Type": "application/json"}
 	url := fmt.Sprintf("%s/rest/v2/caches/%s", host, cacheName)
-	config := `{"distributed-cache":{"mode":"SYNC", "persistence":{"file-store":{}}}}`
+	config := `{"distributed-cache":{"mode":"SYNC", "encoding": {"media-type": "application/json"}, "persistence":{"file-store":{"fetch-state":true}}, "statistics":true}}`
 	post(url, config, http.StatusOK, headers)
 
 	for i := 0; i < numEntries; i++ {

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -114,6 +114,7 @@ func TestUpgrade(t *testing.T) {
 
 	// Approve InstallPlans and verify cluster state on each upgrade until the most recent CSV has been reached
 	for testKube.Subscription(sub); sub.Status.InstalledCSV != targetChannel.CurrentCSVName; {
+		fmt.Printf("Installed csv: %s, Current CSV: %s", sub.Status.InstalledCSV, targetChannel.CurrentCSVName)
 		testKube.WaitForSubscriptionState(coreos.SubscriptionStateUpgradePending, sub)
 		testKube.ApproveInstallPlan(sub)
 


### PR DESCRIPTION
No longer explicitly delete pods on GracefulShutdown, instead scale the StatefulSet once all of the caches have been shutdown on the server.