### PR TITLE
Update CatalogSource scripts to be file based #1357

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ IMG ?= quay.io/infinispan/operator:latest
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
-CONTAINER_TOOL ?= docker
+export CONTAINER_TOOL ?= docker
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -214,7 +214,7 @@ bundle-push:
 	$(CONTAINER_TOOL) push $(BUNDLE_IMG)
 
 .PHONY: opm
-OPM = ./bin/opm
+export OPM = ./bin/opm
 opm: ## Download opm locally if necessary.
 ifeq (,$(wildcard $(OPM)))
 ifeq (,$(shell which opm 2>/dev/null))
@@ -222,7 +222,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.19.5/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.21.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else
@@ -230,12 +230,28 @@ OPM = $(shell which opm)
 endif
 endif
 
+.PHONY: jq
+export JQ = ./bin/jq
+jq: ## Download opm locally if necessary.
+ifeq (,$(wildcard $(JQ)))
+ifeq (,$(shell which jq 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(JQ)) ;\
+	curl -sSLo $(JQ) https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 ;\
+	chmod +x $(JQ) ;\
+	}
+else
+JQ = $(shell which jq)
+endif
+endif
+
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
-BUNDLE_IMGS ?= $(BUNDLE_IMG)
+export BUNDLE_IMGS ?= $(BUNDLE_IMG)
 
 # The image tag given to the resulting catalog image (e.g. make catalog-build CATALOG_IMG=example.com/operator-catalog:v0.2.0).
-CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
+export CATALOG_IMG ?= $(IMAGE_TAG_BASE)-catalog:v$(VERSION)
 
 # Set CATALOG_BASE_IMG to an existing catalog image tag to add $BUNDLE_IMGS to that image.
 ifneq ($(origin CATALOG_BASE_IMG), undefined)
@@ -246,8 +262,8 @@ endif
 ## https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 ## Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-catalog-build: opm ## Build a catalog image.
-	sudo $(OPM) index add --container-tool $(CONTAINER_TOOL) --mode replaces --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+catalog-build: opm jq ## Build a catalog image.
+	./scripts/create-olm-catalog.sh
 
 .PHONY: catalog-push
 ## Push the catalog image.

--- a/scripts/ci/install-catalog-source.sh
+++ b/scripts/ci/install-catalog-source.sh
@@ -14,21 +14,15 @@ BUNDLE_IMG_NAME=infinispan-operator-bundle
 export IMG=${IMG_REGISTRY}/infinispan-operator
 export BUNDLE_IMG=${IMG_REGISTRY}/${BUNDLE_IMG_NAME}:v${VERSION}
 export CATALOG_IMG=${IMG_REGISTRY}/infinispan-test-catalog
-export CATALOG_BASE_IMG=${CATALOG_BASE_IMG-"quay.io/operatorhubio/catalog:tmp_latest_sql"}
+export CATALOG_BASE_IMG=${CATALOG_BASE_IMG-"quay.io/operatorhubio/catalog:latest"}
 
 # Create the operator image
-make operator-build operator-push
+# make operator-build operator-push
 
 # Create the operator bundle image
-# We must capture the sha256 digest of the image for use with catalog-build later
-PUSH_OUTPUT=$(make bundle bundle-build bundle-push | tail -1)
-BUNDLE_IMG_DIGEST=$(echo "${PUSH_OUTPUT}" | awk '/:/ {print $3}')
+make bundle bundle-build bundle-push
 
-# Create the Catalog image
-# It's necessary to reference the image using sha256 digest when calling `make catalog-build`
-# If the sha isn't used, then the local tag is overwritten with a modified image that sets `bundle.channels.v1` to`alpha`
-# This doesn't occur if using an image that is not hosted on localhost:5000, i.e. quay.io.
-export BUNDLE_IMG=${IMG_REGISTRY}/${BUNDLE_IMG_NAME}@${BUNDLE_IMG_DIGEST}
+# Create the OLM catalog image
 make catalog-build catalog-push
 
 # Create the namespace and CatalogSource

--- a/scripts/create-olm-catalog.sh
+++ b/scripts/create-olm-catalog.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+CATALOG_DIR=infinispan-olm-catalog
+DOCKERFILE=${CATALOG_DIR}.Dockerfile
+CATALOG=${CATALOG_DIR}/catalog.json
+BUNDLE=${CATALOG_DIR}/bundle.json
+
+mkdir -p ${CATALOG_DIR}
+
+${OPM} render --use-http ${CATALOG_BASE_IMG} > ${CATALOG}
+${OPM} render --use-http ${BUNDLE_IMGS} > ${BUNDLE}
+
+default_channel=$(${JQ} 'select((.name=="infinispan") and (.schema=="olm.package"))' ${CATALOG} | ${JQ} -r .defaultChannel)
+channel_selector="(.package==\"infinispan\") and (.schema==\"olm.channel\") and (.name==\"${default_channel}\")"
+old_channel=$(${JQ} -r "select(${channel_selector})" ${CATALOG})
+old_channel_latest_bundle=$(echo $old_channel | ${JQ} -r '.entries[-1].name')
+
+bundle_name=$(${JQ} -r .name ${BUNDLE})
+new_channel=$(echo $old_channel | ${JQ} ".entries += [{\"name\":\"${bundle_name}\", \"replaces\":\"${old_channel_latest_bundle}\"}]")
+
+new_catalog=$(${JQ} -r "select(${channel_selector} | not)" ${CATALOG})
+echo ${new_channel} ${new_catalog} > ${CATALOG_DIR}/new_catalog.json
+
+# Remove the original catalog no longer required
+rm -f ${CATALOG}
+
+${OPM} validate ${CATALOG_DIR}
+${OPM} generate dockerfile ${CATALOG_DIR}
+${CONTAINER_TOOL} build -f ${DOCKERFILE} -t ${CATALOG_IMG} .
+
+rm -rf ${DOCKERFILE}


### PR DESCRIPTION
Requires a new version of `opm` in order for us to utilise the `--use-htttp` flag as our kind registry does not use https.

PR to add feature to `opm` binary: https://github.com/operator-framework/operator-registry/pull/909

Also, this PR should not be merged until the default `quay.io/operatorhubio/catalog` image is FBC based which is scheduled for th beginning of February.