### PR TITLE
Do not panic on test failure

### DIFF
--- a/test/e2e/backup-restore/backup_restore_test.go
+++ b/test/e2e/backup-restore/backup_restore_test.go
@@ -24,7 +24,7 @@ import (
 
 var testKube = tutils.NewTestKubernetes(os.Getenv("TESTING_CONTEXT"))
 
-type clusterSpec func(name, namespace string, clusterSize int) *v1.Infinispan
+type clusterSpec func(t *testing.T, name, namespace string, clusterSize int) *v1.Infinispan
 
 func TestMain(m *testing.M) {
 	tutils.RunOperator(m, testKube)
@@ -39,13 +39,14 @@ func TestBackupRestoreNoAuth(t *testing.T) {
 }
 
 func TestBackupRestoreTransformations(t *testing.T) {
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
 	// Create a resource without passing any config
 	clusterName := strcase.ToKebab(t.Name())
 	namespace := tutils.Namespace
 
-	infinispan := datagridService(clusterName, namespace, 1)
+	infinispan := datagridService(t, clusterName, namespace, 1)
 	testKube.Create(infinispan)
-	defer testKube.CleanNamespaceAndLogOnPanic(namespace, nil)
 	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, infinispan.Name, tutils.Namespace)
 	testKube.WaitForInfinispanCondition(infinispan.Name, namespace, v1.ConditionWellFormed)
 
@@ -58,6 +59,7 @@ func TestBackupRestoreTransformations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupName,
 			Namespace: namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v2.BackupSpec{
 			Cluster: clusterName,
@@ -89,6 +91,7 @@ func TestBackupRestoreTransformations(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      restoreName,
 			Namespace: namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v2.RestoreSpec{
 			Backup:  backupName,
@@ -113,6 +116,8 @@ func TestBackupRestoreTransformations(t *testing.T) {
 }
 
 func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
 	// Create a resource without passing any config
 	name := strcase.ToKebab(t.Name())
 	namespace := tutils.Namespace
@@ -120,9 +125,8 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
 
 	// 1. Create initial source cluster
 	sourceCluster := name + "-source"
-	infinispan := clusterSpec(sourceCluster, namespace, clusterSize)
+	infinispan := clusterSpec(t, sourceCluster, namespace, clusterSize)
 	testKube.Create(infinispan)
-	defer testKube.CleanNamespaceAndLogOnPanic(namespace, nil)
 	testKube.WaitForInfinispanPods(clusterSize, tutils.SinglePodTimeout, infinispan.Name, tutils.Namespace)
 	testKube.WaitForInfinispanCondition(sourceCluster, namespace, v1.ConditionWellFormed)
 
@@ -150,6 +154,7 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      backupName,
 			Namespace: namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v2.BackupSpec{
 			Cluster: sourceCluster,
@@ -169,6 +174,7 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "verify-backup-pod",
 			Namespace: namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{
@@ -216,7 +222,7 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
 
 	// 5. Create a new cluster to restore the backup to
 	targetCluster := name + "-target"
-	infinispan = clusterSpec(targetCluster, namespace, clusterSize)
+	infinispan = clusterSpec(t, targetCluster, namespace, clusterSize)
 	testKube.Create(infinispan)
 
 	testKube.WaitForInfinispanPods(clusterSize, tutils.SinglePodTimeout, infinispan.Name, tutils.Namespace)
@@ -232,6 +238,7 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize int) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      restoreName,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v2.RestoreSpec{
 			Cluster: targetCluster,
@@ -284,27 +291,27 @@ func waitForValidRestorePhase(name, namespace string, phase v2.RestorePhase) {
 	tutils.ExpectNoError(err)
 }
 
-func datagridServiceNoAuth(name, namespace string, replicas int) *v1.Infinispan {
-	infinispan := datagridService(name, namespace, replicas)
+func datagridServiceNoAuth(t *testing.T, name, namespace string, replicas int) *v1.Infinispan {
+	infinispan := datagridService(t, name, namespace, replicas)
 	infinispan.Spec.Security.EndpointAuthentication = pointer.BoolPtr(false)
 	return infinispan
 }
 
-func datagridService(name, namespace string, replicas int) *v1.Infinispan {
-	infinispan := cacheService(name, namespace, replicas)
+func datagridService(t *testing.T, name, namespace string, replicas int) *v1.Infinispan {
+	infinispan := cacheService(t, name, namespace, replicas)
 	infinispan.Spec.Service = v1.InfinispanServiceSpec{
 		Type: v1.ServiceTypeDataGrid,
 	}
 	return infinispan
 }
 
-func cacheService(name, namespace string, replicas int) *v1.Infinispan {
-	tutils.DefaultSpec(testKube)
+func cacheService(t *testing.T, name, namespace string, replicas int) *v1.Infinispan {
 	return &v1.Infinispan{
 		TypeMeta: tutils.InfinispanTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v1.InfinispanSpec{
 			Replicas: int32(replicas),

--- a/test/e2e/batch/batch_helper.go
+++ b/test/e2e/batch/batch_helper.go
@@ -2,6 +2,7 @@ package batch
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	v2 "github.com/infinispan/infinispan-operator/api/v2alpha1"
@@ -20,7 +21,7 @@ func NewBatchHelper(testKube *tutils.TestKubernetes) *BatchHelper {
 	}
 }
 
-func (b BatchHelper) CreateBatch(name, cluster string, config, configMap *string) *v2.Batch {
+func (b BatchHelper) CreateBatch(t *testing.T, name, cluster string, config, configMap *string) *v2.Batch {
 	batch := &v2.Batch{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "infinispan.org/v2alpha1",
@@ -29,6 +30,7 @@ func (b BatchHelper) CreateBatch(name, cluster string, config, configMap *string
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: tutils.Namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: v2.BatchSpec{
 			Cluster:   cluster,
@@ -36,7 +38,6 @@ func (b BatchHelper) CreateBatch(name, cluster string, config, configMap *string
 			ConfigMap: configMap,
 		},
 	}
-	batch.Labels = map[string]string{"test-name": name}
 	b.testKube.Create(batch)
 	return batch
 }

--- a/test/e2e/batch/batch_test.go
+++ b/test/e2e/batch/batch_test.go
@@ -34,16 +34,16 @@ func TestMain(m *testing.M) {
 
 func TestBatchInlineConfig(t *testing.T) {
 	t.Parallel()
-	name := strcase.ToKebab(t.Name())
-	infinispan := createCluster(name)
-	defer testKube.CleanNamespaceAndLogOnPanic(tutils.Namespace, infinispan.Labels)
-	testBatchInlineConfig(infinispan)
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
+	infinispan := createCluster(t)
+	testBatchInlineConfig(t, infinispan)
 }
 
-func testBatchInlineConfig(infinispan *v1.Infinispan) {
+func testBatchInlineConfig(t *testing.T, infinispan *v1.Infinispan) {
 	name := infinispan.Name
 	batchScript := batchString()
-	batch := helper.CreateBatch(name, name, &batchScript, nil)
+	batch := helper.CreateBatch(t, name, name, &batchScript, nil)
 
 	helper.WaitForValidBatchPhase(name, v2.BatchSucceeded)
 
@@ -57,11 +57,11 @@ func testBatchInlineConfig(infinispan *v1.Infinispan) {
 
 func TestBatchConfigMap(t *testing.T) {
 	t.Parallel()
-	name := strcase.ToKebab(t.Name())
-	infinispan := createCluster(name)
-	defer testKube.CleanNamespaceAndLogOnPanic(tutils.Namespace, infinispan.Labels)
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
-	configMapName := name + "-cm"
+	infinispan := createCluster(t)
+
+	configMapName := infinispan.Name + "-cm"
 	configMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      configMapName,
@@ -75,11 +75,11 @@ func TestBatchConfigMap(t *testing.T) {
 	testKube.CreateConfigMap(configMap)
 	defer testKube.DeleteConfigMap(configMap)
 
-	batch := helper.CreateBatch(name, name, nil, &configMapName)
+	batch := helper.CreateBatch(t, infinispan.Name, infinispan.Name, nil, &configMapName)
 
-	helper.WaitForValidBatchPhase(name, v2.BatchSucceeded)
+	helper.WaitForValidBatchPhase(infinispan.Name, v2.BatchSucceeded)
 	testKube.DeleteBatch(batch)
-	waitForK8sResourceCleanup(name)
+	waitForK8sResourceCleanup(infinispan.Name)
 
 	httpClient := tutils.HTTPClientForCluster(infinispan, testKube)
 	ispn := ispnClient.New(httpClient)
@@ -90,7 +90,7 @@ func TestBatchConfigMap(t *testing.T) {
 func TestBatchNoConfigOrConfigMap(t *testing.T) {
 	t.Parallel()
 	name := strcase.ToKebab(t.Name())
-	helper.CreateBatch(name, "doesn't exist", nil, nil)
+	helper.CreateBatch(t, name, "doesn't exist", nil, nil)
 
 	batch := helper.WaitForValidBatchPhase(name, v2.BatchFailed)
 	if batch.Status.Reason != "'Spec.config' OR 'spec.ConfigMap' must be configured" {
@@ -103,7 +103,7 @@ func TestBatchNoConfigOrConfigMap(t *testing.T) {
 func TestBatchConfigAndConfigMap(t *testing.T) {
 	t.Parallel()
 	name := strcase.ToKebab(t.Name())
-	helper.CreateBatch(name, "doesn't exist", pointer.StringPtr("Config"), pointer.StringPtr("ConfigMap"))
+	helper.CreateBatch(t, name, "doesn't exist", pointer.StringPtr("Config"), pointer.StringPtr("ConfigMap"))
 
 	batch := helper.WaitForValidBatchPhase(name, v2.BatchFailed)
 	if batch.Status.Reason != "at most one of ['Spec.config', 'spec.ConfigMap'] must be configured" {
@@ -115,16 +115,16 @@ func TestBatchConfigAndConfigMap(t *testing.T) {
 
 func TestBatchFail(t *testing.T) {
 	t.Parallel()
-	name := strcase.ToKebab(t.Name())
-	infinispan := createCluster(name)
-	defer testKube.CleanNamespaceAndLogOnPanic(tutils.Namespace, infinispan.Labels)
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
+	infinispan := createCluster(t)
 
 	batchScript := "SOME INVALID BATCH CMD!"
-	batch := helper.CreateBatch(name, name, &batchScript, nil)
+	batch := helper.CreateBatch(t, infinispan.Name, infinispan.Name, &batchScript, nil)
 
-	helper.WaitForValidBatchPhase(name, v2.BatchFailed)
+	helper.WaitForValidBatchPhase(infinispan.Name, v2.BatchFailed)
 	testKube.DeleteBatch(batch)
-	waitForK8sResourceCleanup(name)
+	waitForK8sResourceCleanup(infinispan.Name)
 }
 
 func batchString() string {
@@ -133,10 +133,8 @@ func batchString() string {
 	return strings.ReplaceAll(batchScript, "\t", "")
 }
 
-func createCluster(name string) *v1.Infinispan {
-	infinispan := tutils.DefaultSpec(testKube)
-	infinispan.Name = name
-	infinispan.Labels = map[string]string{"test-name": name}
+func createCluster(t *testing.T) *v1.Infinispan {
+	infinispan := tutils.DefaultSpec(t, testKube)
 	testKube.Create(infinispan)
 	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, infinispan.Name, tutils.Namespace)
 	return infinispan

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -88,7 +88,8 @@ func TestMain(t *testing.M) {
 }
 
 func TestRollingUpgrade(t *testing.T) {
-	defer testKube.CleanNamespaceAndLogOnPanic(tutils.Namespace, nil)
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
 	initialize()
 	// TODO This should always trigger a rolling upgrade since the operator uses aliases by default. Make it an environment variable to test upgrade from different versions
 	go runOperatorNewProcess("quay.io/infinispan/server")
@@ -98,6 +99,7 @@ func TestRollingUpgrade(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: tutils.Namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: ispnv1.InfinispanSpec{
 			Replicas: int32(numPods),

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -8,7 +8,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
 
+	"github.com/iancoleman/strcase"
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
 	"github.com/infinispan/infinispan-operator/controllers/constants"
 	users "github.com/infinispan/infinispan-operator/pkg/infinispan/security"
@@ -109,12 +111,13 @@ var MinimalSpec = ispnv1.Infinispan{
 	},
 }
 
-func DefaultSpec(testKube *TestKubernetes) *ispnv1.Infinispan {
+func DefaultSpec(t *testing.T, testKube *TestKubernetes) *ispnv1.Infinispan {
 	return &ispnv1.Infinispan{
 		TypeMeta: InfinispanTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      DefaultClusterName,
+			Name:      strcase.ToKebab(t.Name()),
 			Namespace: Namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
 		},
 		Spec: ispnv1.InfinispanSpec{
 			Service: ispnv1.InfinispanServiceSpec{

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -149,12 +149,14 @@ func (k TestKubernetes) NewNamespace(namespace string) {
 	ExpectNoError(err)
 }
 
-func (k TestKubernetes) CleanNamespaceAndLogOnPanic(namespace string, specLabel map[string]string) {
+func (k TestKubernetes) CleanNamespaceAndLogOnPanic(t *testing.T, namespace string) {
 	panicVal := recover()
-	k.CleanNamespaceAndLogWithPanic(namespace, specLabel, panicVal)
+	k.CleanNamespaceAndLogWithPanic(t, namespace, panicVal)
 }
 
-func (k TestKubernetes) CleanNamespaceAndLogWithPanic(namespace string, specLabel map[string]string, panicVal interface{}) {
+func (k TestKubernetes) CleanNamespaceAndLogWithPanic(t *testing.T, namespace string, panicVal interface{}) {
+	specLabel := map[string]string{"test-name": t.Name()}
+
 	// Print pod output if a panic has occurred
 	if panicVal != nil {
 		k.PrintAllResources(namespace, &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
@@ -171,15 +173,9 @@ func (k TestKubernetes) CleanNamespaceAndLogWithPanic(namespace string, specLabe
 	if CleanupInfinispan == "TRUE" || panicVal == nil {
 		var opts []client.DeleteAllOfOption
 		ctx := context.TODO()
-		if specLabel != nil {
-			opts = []client.DeleteAllOfOption{
-				client.InNamespace(namespace),
-				client.MatchingLabels(specLabel),
-			}
-		} else {
-			opts = []client.DeleteAllOfOption{
-				client.InNamespace(namespace),
-			}
+		opts = []client.DeleteAllOfOption{
+			client.InNamespace(namespace),
+			client.MatchingLabels(specLabel),
 		}
 
 		ExpectMaybeNotFound(k.Kubernetes.Client.DeleteAllOf(ctx, &ispnv2.Batch{}, opts...))
@@ -193,8 +189,8 @@ func (k TestKubernetes) CleanNamespaceAndLogWithPanic(namespace string, specLabe
 	}
 
 	if panicVal != nil {
-		// Throw the recovered panic values so the tests fail as expected
-		panic(panicVal)
+		// Fail the test and pass the panic value to the output if panic occurred
+		t.Fatal(fmt.Printf("panicVal: %v\n", panicVal))
 	}
 }
 

--- a/test/e2e/xsite/xsite_test.go
+++ b/test/e2e/xsite/xsite_test.go
@@ -281,6 +281,9 @@ func testCrossSiteView(t *testing.T, isMultiCluster bool, schemeType ispnv1.Cros
 		}
 	}
 
+	defer tesKubes["xsite1"].kube.CleanNamespaceAndLogOnPanic(t, tesKubes["xsite1"].namespace)
+	defer tesKubes["xsite2"].kube.CleanNamespaceAndLogOnPanic(t, tesKubes["xsite2"].namespace)
+
 	if tlsMode == DefaultTLS {
 		transport, router, trust := tutils.CreateDefaultCrossSiteKeyAndTrustStore()
 
@@ -364,9 +367,6 @@ func testCrossSiteView(t *testing.T, isMultiCluster bool, schemeType ispnv1.Cros
 
 	tesKubes["xsite1"].kube.CreateInfinispan(&tesKubes["xsite1"].crossSite, tesKubes["xsite1"].namespace)
 	tesKubes["xsite2"].kube.CreateInfinispan(&tesKubes["xsite2"].crossSite, tesKubes["xsite2"].namespace)
-
-	defer tesKubes["xsite1"].kube.CleanNamespaceAndLogOnPanic(tesKubes["xsite1"].namespace, tesKubes["xsite1"].crossSite.Labels)
-	defer tesKubes["xsite2"].kube.CleanNamespaceAndLogOnPanic(tesKubes["xsite2"].namespace, tesKubes["xsite2"].crossSite.Labels)
 
 	tesKubes["xsite1"].kube.WaitForInfinispanPods(int(podsPerSite), tutils.SinglePodTimeout, tesKubes["xsite1"].crossSite.Name, tesKubes["xsite1"].namespace)
 	tesKubes["xsite2"].kube.WaitForInfinispanPods(int(podsPerSite), tutils.SinglePodTimeout, tesKubes["xsite2"].crossSite.Name, tesKubes["xsite2"].namespace)


### PR DESCRIPTION
Resolves #1217 by catching up panic code and changing test state to fail by calling `t.Fatal()` in general `CleanNamespaceAndLogOnPanic` function. Other test changes introduced:
* `DefaultsSpec` now accepts `t *testing.T` and generates Infinispan name and labels based on that (duplicity reduction)
* All owned CRDs are now expected to be labeled with `"test-name": t.Name()` so they can be properly caught up by clean up function (consistency)
* `testKube.CleanNamespaceAndLogOnPanic` is hooked up rather at the begging of test code