### PR TITLE
Utilise Operatorhub sqlite catalog image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ endif
 .PHONY: catalog-build
 ## Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool $(CONTAINER_TOOL) --mode replaces --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	sudo $(OPM) index add --container-tool $(CONTAINER_TOOL) --mode replaces --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 .PHONY: catalog-push
 ## Push the catalog image.

--- a/scripts/ci/install-catalog-source.sh
+++ b/scripts/ci/install-catalog-source.sh
@@ -14,7 +14,7 @@ BUNDLE_IMG_NAME=infinispan-operator-bundle
 export IMG=${IMG_REGISTRY}/infinispan-operator
 export BUNDLE_IMG=${IMG_REGISTRY}/${BUNDLE_IMG_NAME}:v${VERSION}
 export CATALOG_IMG=${IMG_REGISTRY}/infinispan-test-catalog
-export CATALOG_BASE_IMG=${CATALOG_BASE_IMG-"quay.io/operatorhubio/catalog_tmp"}
+export CATALOG_BASE_IMG=${CATALOG_BASE_IMG-"quay.io/operatorhubio/catalog:tmp_latest_sql"}
 
 # Create the operator image
 make operator-build operator-push


### PR DESCRIPTION
This image will be available until April, then we must utilise the FBC format images. https://github.com/infinispan/infinispan-operator/pull/1375 converts our repo to use FBC, however it requires a new OPM release containing https://github.com/operator-framework/operator-registry/pull/909 before it can be merged.