### PR TITLE
[2.2.x] Sidecar compatiblity

### DIFF
--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -40,6 +40,7 @@ var (
 )
 
 const (
+	InfinispanContainer = "infinispan"
 	// DefaultOperatorUser users to access the cluster rest API
 	DefaultOperatorUser = "operator"
 	// DefaultDeveloperUser users to access the cluster rest API

--- a/controllers/infinispan_controller.go
+++ b/controllers/infinispan_controller.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	InfinispanContainer          = consts.InfinispanContainer
 	DataMountPath                = consts.ServerRoot + "/data"
 	OperatorConfMountPath        = consts.ServerRoot + "/conf/operator"
 	DataMountVolume              = "data-volume"
@@ -1207,7 +1208,7 @@ func (r *infinispanRequest) statefulSetForInfinispan(adminSecret, userSecret, ke
 					Affinity: ispn.Spec.Affinity,
 					Containers: []corev1.Container{{
 						Image: ispn.ImageName(),
-						Name:  "infinispan",
+						Name:  InfinispanContainer,
 						Env: PodEnv(ispn, &[]corev1.EnvVar{
 							{Name: "CONFIG_HASH", Value: hash.HashString(configMap.Data[consts.ServerConfigFilename])},
 							{Name: "ADMIN_IDENTITIES_HASH", Value: hash.HashByte(adminSecret.Data[consts.ServerIdentitiesFilename])},

--- a/controllers/pods.go
+++ b/controllers/pods.go
@@ -157,7 +157,7 @@ func AddVolumeForUserAuthentication(i *infinispanv1.Infinispan, spec *corev1.Pod
 		},
 	})
 
-	vm := &spec.Containers[0].VolumeMounts
+	vm := &GetContainer(InfinispanContainer, spec).VolumeMounts
 	*vm = append(*vm, corev1.VolumeMount{
 		Name:      IdentitiesVolumeName,
 		MountPath: consts.ServerUserIdentitiesRoot,
@@ -213,7 +213,7 @@ func AddSecretVolume(secretName, volumeName, mountPath string, spec *corev1.PodS
 	}
 
 	index := -1
-	volumeMounts := &spec.Containers[0].VolumeMounts
+	volumeMounts := &GetContainer(InfinispanContainer, spec).VolumeMounts
 	for i, vm := range *volumeMounts {
 		if vm.Name == volumeName {
 			index = i
@@ -226,4 +226,13 @@ func AddSecretVolume(secretName, volumeName, mountPath string, spec *corev1.PodS
 	} else {
 		(*volumeMounts)[index] = volumeMount
 	}
+}
+
+func GetContainer(name string, spec *corev1.PodSpec) *corev1.Container {
+	for i, c := range spec.Containers {
+		if c.Name == name {
+			return &spec.Containers[i]
+		}
+	}
+	return nil
 }

--- a/controllers/zero_controller.go
+++ b/controllers/zero_controller.go
@@ -325,7 +325,7 @@ func (z *zeroCapacityController) zeroPodSpec(name, namespace string, podSecurity
 			SecurityContext: podSecurityCtx,
 			Containers: []corev1.Container{{
 				Image: ispn.ImageName(),
-				Name:  name,
+				Name:  InfinispanContainer,
 				//				Env:   PodEnv(ispn, nil),
 				Env:            PodEnv(ispn, &[]corev1.EnvVar{{Name: "IDENTITIES_BATCH", Value: consts.ServerOperatorSecurity + "/" + consts.ServerIdentitiesCliFilename}}),
 				LivenessProbe:  PodLivenessProbe(),

--- a/pkg/infinispan/client/http/curl/curl.go
+++ b/pkg/infinispan/client/http/curl/curl.go
@@ -100,6 +100,7 @@ func (c *CurlClient) executeCurlNoAuth(httpURL, headers, args, podName string) (
 func (c *CurlClient) exec(cmd, podName string) (bytes.Buffer, string, error) {
 	return c.Kubernetes.ExecWithOptions(
 		kube.ExecOptions{
+			Container: consts.InfinispanContainer,
 			Command:   []string{"bash", "-c", cmd},
 			PodName:   podName,
 			Namespace: c.config.Namespace,

--- a/pkg/infinispan/cluster.go
+++ b/pkg/infinispan/cluster.go
@@ -244,7 +244,7 @@ func (c Cluster) CreateCacheWithTemplateName(cacheName, templateName, podName st
 
 func (c Cluster) GetMemoryLimitBytes(podName string) (uint64, error) {
 	command := []string{"cat", "/sys/fs/cgroup/memory/memory.limit_in_bytes"}
-	execOptions := kube.ExecOptions{Command: command, PodName: podName, Namespace: c.Namespace}
+	execOptions := kube.ExecOptions{Container: consts.InfinispanContainer, Command: command, PodName: podName, Namespace: c.Namespace}
 	execOut, execErr, err := c.Kubernetes.ExecWithOptions(execOptions)
 
 	if err != nil {
@@ -262,7 +262,7 @@ func (c Cluster) GetMemoryLimitBytes(podName string) (uint64, error) {
 
 func (c Cluster) GetMaxMemoryUnboundedBytes(podName string) (uint64, error) {
 	command := []string{"cat", "/proc/meminfo"}
-	execOptions := kube.ExecOptions{Command: command, PodName: podName, Namespace: c.Namespace}
+	execOptions := kube.ExecOptions{Container: consts.InfinispanContainer, Command: command, PodName: podName, Namespace: c.Namespace}
 	execOut, execErr, err := c.Kubernetes.ExecWithOptions(execOptions)
 
 	if err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -103,6 +103,7 @@ func (k Kubernetes) GetSecret(secretName, namespace string, ctx context.Context)
 
 // ExecOptions specify execution options
 type ExecOptions struct {
+	Container string
 	Command   []string
 	Namespace string
 	PodName   string
@@ -118,11 +119,12 @@ func (k Kubernetes) ExecWithOptions(options ExecOptions) (bytes.Buffer, string, 
 		Namespace(options.Namespace).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Command: options.Command,
-			Stdin:   false,
-			Stdout:  true,
-			Stderr:  true,
-			TTY:     false,
+			Container: options.Container,
+			Command:   options.Command,
+			Stdin:     false,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
 		}, scheme.ParameterCodec)
 	var execOut, execErr bytes.Buffer
 	// Create an executor


### PR DESCRIPTION
The approach here is slightly different to the upstream PR where the http/curl abstractions have changed. To avoid updating the `Cluster` interface I have simply hard coded all `curl.go` executions to use the Infinispan container.