### PR TITLE
[2.2.x] Create OpenShift interop testsuite

### DIFF
--- a/test-integration/operator-tests/pom.xml
+++ b/test-integration/operator-tests/pom.xml
@@ -84,6 +84,16 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.maven.surefire}</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.maven.surefire}</version>
                 <configuration>
@@ -101,4 +111,13 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>interop</id>
+            <properties>
+                <excludedGroups>unstable</excludedGroups>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
@@ -23,6 +23,7 @@ import org.infinispan.identities.Credentials;
 import org.infinispan.util.CleanUpValidator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import cz.xtf.client.Http;
@@ -161,6 +162,7 @@ class CacheServiceIT {
     * Verifies autoscaling feature of default cache.
     */
    @Test
+   @Tag("unstable")
    void autoscalingTest() throws Exception {
       String request = "https://" + hostName + "/rest/v2/caches/default/autoscaling-key-";
       int i = 0;

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
@@ -1,11 +1,9 @@
 package org.infinispan.operator.installation;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import cz.xtf.core.openshift.*;
 import cz.xtf.core.waiting.SimpleWaiter;
-import cz.xtf.core.waiting.Waiters;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.rbac.*;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -14,22 +12,19 @@ import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroup;
 import io.fabric8.openshift.api.model.operatorhub.v1.OperatorGroupBuilder;
 import io.fabric8.openshift.api.model.operatorhub.v1alpha1.Subscription;
 import lombok.extern.slf4j.Slf4j;
-import org.assertj.core.api.Assertions;
 import org.infinispan.Infinispan;
 import org.infinispan.Infinispans;
 import org.infinispan.crd.GrafanaContextProvider;
 import org.infinispan.crd.GrafanaDashboardContextProvider;
 import org.infinispan.crd.GrafanaDataSourceContextProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 /**
  * Tests Infinispan operator integration with Monitoring stack.
@@ -38,6 +33,7 @@ import java.util.stream.StreamSupport;
  * Prerequisites: Enabled user workload monitoring.
  */
 @Slf4j
+@Tag("unstable")
 public class MonitoringStackIT {
     private static final CustomResourceDefinitionContext gcp = new GrafanaContextProvider().getContext();
     private static final CustomResourceDefinitionContext gdcp = new GrafanaDashboardContextProvider().getContext();
@@ -45,12 +41,10 @@ public class MonitoringStackIT {
 
     private static final String grafanaNamespace = "grafana";
     private static final String operatorNamespace = "openshift-operators";
-    private static final String monitoringNamespace = "openshift-user-workload-monitoring";
 
     private static final OpenShift clusterShift = OpenShifts.master();
     private static final OpenShift grafanaShift = OpenShifts.master(grafanaNamespace);
     private static final OpenShift operatorShift = OpenShifts.master(operatorNamespace);
-    private static final OpenShift monitoringShift = OpenShifts.master(monitoringNamespace);
 
     private static final OpenShiftWaiters grafanaWaiter = OpenShiftWaiters.get(grafanaShift, () -> false);
 
@@ -110,32 +104,6 @@ public class MonitoringStackIT {
                 .build();
         crb.getSubjects().add(subject);
         grafanaShift.rbac().clusterRoleBindings().createOrReplace(crb);
-    }
-
-    /**
-     * Retrieves targets from Prometheus instance and verifies that Infinispan pods are up and healthy.
-     */
-    @Test
-    void serviceMonitorTest() throws IOException {
-        // Give Prometheus some time to reload the config and make the first scrape
-        Waiters.sleep(TimeUnit.SECONDS, 60);
-
-        // Check ServiceMonitor targets
-        Pod prometheus = monitoringShift.getAnyPod("prometheus", "user-workload");
-        PodShell shell = new PodShell(monitoringShift, prometheus, "prometheus");
-        String targets = shell.executeWithBash("curl http://localhost:9090/api/v1/targets?state=active").getOutput();
-        JsonNode activeTargets = new ObjectMapper().readTree(targets).get("data").get("activeTargets");
-
-        List<JsonNode> actualList = StreamSupport.stream(activeTargets.spliterator(), false).collect(Collectors.toList());
-        List<String> targetIPs = actualList.stream().map(t -> t.get("discoveredLabels").get("__meta_kubernetes_pod_ip").asText()).collect(Collectors.toList());
-        List<String> targetHealths = actualList.stream().map(t -> t.get("health").asText()).collect(Collectors.toList());
-
-        List<Pod> clusterPods = clusterShift.getLabeledPods("clusterName", infinispan.getClusterName());
-        List<String> podIPs = clusterPods.stream().map(p -> p.getStatus().getPodIP()).collect(Collectors.toList());
-
-        // Assert that all the targets are up and that infinispan cluster pods are between the targets
-        Assertions.assertThat(targetHealths).allMatch("up"::equals);
-        Assertions.assertThat(targetIPs).containsAll(podIPs);
     }
 
     /**

--- a/test-integration/operator-tests/src/test/resources/infinispans/cache_service.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/cache_service.yaml
@@ -8,6 +8,8 @@ spec:
     maxReplicas: 5
     minMemUsagePercent: 20
     minReplicas: 3
+  container:
+    memory: 512Mi
   expose:
     type: Route
   service:

--- a/test-integration/operator-tests/src/test/resources/infinispans/client_authentication.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/client_authentication.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   service:
     type: DataGrid
+    container:
+      ephemeralStorage: true
   expose:
     type: Route
   replicas: 1

--- a/test-integration/operator-tests/src/test/resources/infinispans/client_validation.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/client_validation.yaml
@@ -7,6 +7,8 @@ metadata:
 spec:
   service:
     type: DataGrid
+    container:
+      ephemeralStorage: true
   expose:
     type: Route
   replicas: 1

--- a/test/e2e/backup-restore/suite_test.go
+++ b/test/e2e/backup-restore/suite_test.go
@@ -1,0 +1,18 @@
+package backup_restore
+
+import (
+	"testing"
+
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+)
+
+// Executes tests that have potential to find regression in new OpenShift versions
+func TestOpenShiftIntegration(t *testing.T) {
+	// Prevent execution unless explicitly configured
+	if !tutils.SuiteMode {
+		t.SkipNow()
+	}
+
+	// Smoke tests
+	t.Run("TestBackupRestore", TestBackupRestore)
+}

--- a/test/e2e/batch/batch_helper.go
+++ b/test/e2e/batch/batch_helper.go
@@ -22,6 +22,7 @@ func NewBatchHelper(testKube *tutils.TestKubernetes) *BatchHelper {
 }
 
 func (b BatchHelper) CreateBatch(t *testing.T, name, cluster string, config, configMap *string) *v2.Batch {
+	testName := tutils.TestName(t)
 	batch := &v2.Batch{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "infinispan.org/v2alpha1",
@@ -30,7 +31,7 @@ func (b BatchHelper) CreateBatch(t *testing.T, name, cluster string, config, con
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: tutils.Namespace,
-			Labels:    map[string]string{"test-name": t.Name()},
+			Labels:    map[string]string{"test-name": testName},
 		},
 		Spec: v2.BatchSpec{
 			Cluster:   cluster,

--- a/test/e2e/batch/batch_test.go
+++ b/test/e2e/batch/batch_test.go
@@ -89,7 +89,7 @@ func TestBatchConfigMap(t *testing.T) {
 
 func TestBatchNoConfigOrConfigMap(t *testing.T) {
 	t.Parallel()
-	name := strcase.ToKebab(t.Name())
+	name := strcase.ToKebab(tutils.TestName(t))
 	helper.CreateBatch(t, name, "doesn't exist", nil, nil)
 
 	batch := helper.WaitForValidBatchPhase(name, v2.BatchFailed)
@@ -102,7 +102,7 @@ func TestBatchNoConfigOrConfigMap(t *testing.T) {
 
 func TestBatchConfigAndConfigMap(t *testing.T) {
 	t.Parallel()
-	name := strcase.ToKebab(t.Name())
+	name := strcase.ToKebab(tutils.TestName(t))
 	helper.CreateBatch(t, name, "doesn't exist", pointer.StringPtr("Config"), pointer.StringPtr("ConfigMap"))
 
 	batch := helper.WaitForValidBatchPhase(name, v2.BatchFailed)

--- a/test/e2e/batch/suite_test.go
+++ b/test/e2e/batch/suite_test.go
@@ -1,0 +1,19 @@
+package batch
+
+import (
+	"testing"
+
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+)
+
+// Executes tests that have potential to find regression in new OpenShift versions
+func TestOpenShiftIntegration(t *testing.T) {
+	// Prevent execution unless explicitly configured
+	if !tutils.SuiteMode {
+		t.SkipNow()
+	}
+
+	// Smoke tests
+	t.Run("TestBatchInlineConfig", TestBatchInlineConfig)
+	t.Run("TestBatchConfigMap", TestBatchConfigMap)
+}

--- a/test/e2e/cache/cache_test.go
+++ b/test/e2e/cache/cache_test.go
@@ -160,7 +160,7 @@ func TestStaticServerCache(t *testing.T) {
 	t.Parallel()
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
-	name := strcase.ToKebab(t.Name())
+	name := strcase.ToKebab(tutils.TestName(t))
 	cacheName := "static-cache"
 
 	// Create cluster using custom config containing a static cache

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -99,7 +99,7 @@ func TestRollingUpgrade(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterName,
 			Namespace: tutils.Namespace,
-			Labels:    map[string]string{"test-name": t.Name()},
+			Labels:    map[string]string{"test-name": tutils.TestName(t)},
 		},
 		Spec: ispnv1.InfinispanSpec{
 			Replicas: int32(numPods),

--- a/test/e2e/infinispan/authentication_test.go
+++ b/test/e2e/infinispan/authentication_test.go
@@ -151,7 +151,6 @@ func TestAuthenticationDisabled(t *testing.T) {
 	spec.Spec.Security.EndpointAuthentication = pointer.BoolPtr(false)
 
 	// Create the cluster
-	spec.Labels = map[string]string{"test-name": t.Name()}
 	testKube.CreateInfinispan(spec, tutils.Namespace)
 	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)

--- a/test/e2e/infinispan/suite_test.go
+++ b/test/e2e/infinispan/suite_test.go
@@ -1,0 +1,34 @@
+package infinispan
+
+import (
+	"testing"
+
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+)
+
+// Executes tests that have potential to find regression in new OpenShift versions
+func TestOpenShiftIntegration(t *testing.T) {
+	// Prevent execution unless explicitly configured
+	if !tutils.SuiteMode {
+		t.SkipNow()
+	}
+
+	// Smoke tests
+	t.Run("TestBaseFunctionality", TestBaseFunctionality)
+	t.Run("TestExplicitCredentials", TestExplicitCredentials)
+	t.Run("TestAuthorizationWithCustomRoles", TestAuthorizationWithCustomRoles)
+
+	// Init container
+	t.Run("TestExternalDependenciesHttp", TestExternalDependenciesHttp)
+
+	// Scaling/Updates - cooperation of Operator and StatefulSets
+	t.Run("TestGracefulShutdownWithTwoReplicas", TestGracefulShutdownWithTwoReplicas)
+	t.Run("TestUserCustomConfigUpdateOnChange", TestUserCustomConfigUpdateOnChange)
+	t.Run("TestContainerCPUUpdateWithTwoReplicas", TestContainerCPUUpdateWithTwoReplicas)
+
+	// Validate that request with tls certificates are correctly passing through HaProxy
+	t.Run("TestClientCertValidateWithAuthorization", TestClientCertValidateWithAuthorization)
+	t.Run("TestClientCertAuthenticateWithAuthorization", TestClientCertAuthenticateWithAuthorization)
+	t.Run("TestClientCertGeneratedTruststoreAuthenticate", TestClientCertGeneratedTruststoreAuthenticate)
+	t.Run("TestClientCertGeneratedTruststoreValidate", TestClientCertGeneratedTruststoreValidate)
+}

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -101,13 +102,19 @@ func encryptionSecret(name, namespace string) *corev1.Secret {
 	}
 }
 
+func TestName(t *testing.T) string {
+	return regexp.MustCompile(".*/").ReplaceAllString(t.Name(), "")
+}
+
 func DefaultSpec(t *testing.T, testKube *TestKubernetes) *ispnv1.Infinispan {
+	testName := TestName(t)
+
 	return &ispnv1.Infinispan{
 		TypeMeta: InfinispanTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      strcase.ToKebab(t.Name()),
+			Name:      strcase.ToKebab(testName),
 			Namespace: Namespace,
-			Labels:    map[string]string{"test-name": t.Name()},
+			Labels:    map[string]string{"test-name": testName},
 		},
 		Spec: ispnv1.InfinispanSpec{
 			Service: ispnv1.InfinispanServiceSpec{

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -34,6 +35,7 @@ var (
 	RunLocalOperator  = strings.ToUpper(constants.GetEnvWithDefault("RUN_LOCAL_OPERATOR", "true"))
 	RunSaOperator     = strings.ToUpper(constants.GetEnvWithDefault("RUN_SA_OPERATOR", "false"))
 	CleanupInfinispan = strings.ToUpper(constants.GetEnvWithDefault("CLEANUP_INFINISPAN_ON_FINISH", "true"))
+	SuiteMode, _      = strconv.ParseBool(constants.GetEnvWithDefault("SUITE_MODE", "false"))
 	ExposeServiceType = constants.GetEnvWithDefault("EXPOSE_SERVICE_TYPE", string(ispnv1.ExposeTypeNodePort))
 
 	WebServerName       = "external-libs-web-server"

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -155,7 +155,8 @@ func (k TestKubernetes) CleanNamespaceAndLogOnPanic(t *testing.T, namespace stri
 }
 
 func (k TestKubernetes) CleanNamespaceAndLogWithPanic(t *testing.T, namespace string, panicVal interface{}) {
-	specLabel := map[string]string{"test-name": t.Name()}
+	testName := TestName(t)
+	specLabel := map[string]string{"test-name": testName}
 
 	// Print pod output if a panic has occurred
 	if panicVal != nil {

--- a/test/e2e/xsite/suite_test.go
+++ b/test/e2e/xsite/suite_test.go
@@ -1,0 +1,18 @@
+package xsite
+
+import (
+	"testing"
+
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+)
+
+// Executes tests that have potential to find regression in new OpenShift versions
+func TestOpenShiftIntegration(t *testing.T) {
+	// Prevent execution unless explicitly configured
+	if !tutils.SuiteMode {
+		t.SkipNow()
+	}
+
+	// Smoke tests
+	t.Run("TestDefaultTLSInternalMultiPod", TestDefaultTLSInternalMultiPod)
+}

--- a/test/e2e/xsite/xsite_test.go
+++ b/test/e2e/xsite/xsite_test.go
@@ -237,6 +237,7 @@ func TestDefaultTLSOpenshiftRoute(t *testing.T) {
 }
 
 func testCrossSiteView(t *testing.T, isMultiCluster bool, schemeType ispnv1.CrossSiteSchemeType, exposeType ispnv1.CrossSiteExposeType, exposePort, podsPerSite int32, tlsMode TLSMode, tlsProtocol *ispnv1.TLSProtocol) {
+	testName := tutils.TestName(t)
 	tesKubes := map[string]*crossSiteKubernetes{"xsite1": {}, "xsite2": {}}
 	clientConfig := clientcmd.GetConfigFromFileOrDie(kube.FindKubeConfig())
 
@@ -271,14 +272,14 @@ func testCrossSiteView(t *testing.T, isMultiCluster bool, schemeType ispnv1.Cros
 			defer tesKubes["xsite1"].kube.DeleteSecret(crossSiteTokenSecret("xsite2", tesKubes["xsite1"].namespace, []byte("")))
 			defer tesKubes["xsite2"].kube.DeleteSecret(crossSiteTokenSecret("xsite1", tesKubes["xsite2"].namespace, []byte("")))
 		}
-		tesKubes["xsite1"].crossSite = *crossSiteSpec(strcase.ToKebab(t.Name()), podsPerSite, "xsite1", "xsite2", tesKubes["xsite2"].namespace, exposeType, exposePort)
-		tesKubes["xsite2"].crossSite = *crossSiteSpec(strcase.ToKebab(t.Name()), podsPerSite, "xsite2", "xsite1", tesKubes["xsite1"].namespace, exposeType, exposePort)
+		tesKubes["xsite1"].crossSite = *crossSiteSpec(strcase.ToKebab(testName), podsPerSite, "xsite1", "xsite2", tesKubes["xsite2"].namespace, exposeType, exposePort)
+		tesKubes["xsite2"].crossSite = *crossSiteSpec(strcase.ToKebab(testName), podsPerSite, "xsite2", "xsite1", tesKubes["xsite1"].namespace, exposeType, exposePort)
 
 		tesKubes["xsite1"].crossSite.Spec.Service.Sites.Locations[0].URL = fmt.Sprintf("%s://%s", schemeType, tesKubes["xsite2"].apiServer)
 		tesKubes["xsite2"].crossSite.Spec.Service.Sites.Locations[0].URL = fmt.Sprintf("%s://%s", schemeType, tesKubes["xsite1"].apiServer)
 	} else {
-		tesKubes["xsite1"].crossSite = *crossSiteSpec(strcase.ToKebab(t.Name()), podsPerSite, "xsite1", "xsite2", "", exposeType, exposePort)
-		tesKubes["xsite2"].crossSite = *crossSiteSpec(strcase.ToKebab(t.Name()), podsPerSite, "xsite2", "xsite1", "", exposeType, exposePort)
+		tesKubes["xsite1"].crossSite = *crossSiteSpec(strcase.ToKebab(testName), podsPerSite, "xsite1", "xsite2", "", exposeType, exposePort)
+		tesKubes["xsite2"].crossSite = *crossSiteSpec(strcase.ToKebab(testName), podsPerSite, "xsite2", "xsite1", "", exposeType, exposePort)
 		for _, testKube := range tesKubes {
 			testKube.context = clientConfig.CurrentContext
 			testKube.namespace = fmt.Sprintf("%s-%s", tutils.Namespace, "xsite2")
@@ -381,8 +382,8 @@ func testCrossSiteView(t *testing.T, isMultiCluster bool, schemeType ispnv1.Cros
 		}
 	}
 
-	tesKubes["xsite1"].crossSite.Labels = map[string]string{"test-name": t.Name()}
-	tesKubes["xsite2"].crossSite.Labels = map[string]string{"test-name": t.Name()}
+	tesKubes["xsite1"].crossSite.Labels = map[string]string{"test-name": testName}
+	tesKubes["xsite2"].crossSite.Labels = map[string]string{"test-name": testName}
 
 	tesKubes["xsite1"].kube.CreateInfinispan(&tesKubes["xsite1"].crossSite, tesKubes["xsite1"].namespace)
 	tesKubes["xsite2"].kube.CreateInfinispan(&tesKubes["xsite2"].crossSite, tesKubes["xsite2"].namespace)


### PR DESCRIPTION
Resolves #1381.

Intergration tests:
* Create `interop` profile which excludes unstable tests or tests that are irrelevant for certification with new OpenShift versions
* Move `serviceMonitorTest` under DataGridServiceIT (the test should be executed but Grafana integration itself is irrelevant)

GoLang tests:
* Create `suites_test.go` in each package which lists and call the tests that should be executed as part of the testsuite
* Tests can be executed as `go test ./test/e2e/{package} -run TestOpenShiftIntegration`
  * ${package} could theoretically be * and it would correctly list all the tests in all packages but `upgrade_test.go` fails on var init unless it's correct `test-calatog` exists
* Code generating name and labels for K8s resources was updated to crop prefix