### PR TITLE
[2.2.x] Write logs and yamls to files on panic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,6 +168,12 @@ pipeline {
                         junit testResults: 'test/reports/*.xml', skipPublishingChecks: true
                     }
                 }
+
+                stage('Archive artifacts') {
+                    steps {
+                        archiveArtifacts artifacts: '/tmp/infinispan-operator/*', followSymlinks: false
+                    }
+                }
             }
         }
     }

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -171,13 +171,15 @@ func cleanup(t *testing.T) {
 		}
 
 		if panicVal != nil {
-			testKube.PrintAllResources(subNamespace, &coreosv1.OperatorGroupList{}, map[string]string{})
-			testKube.PrintAllResources(subNamespace, &coreos.SubscriptionList{}, map[string]string{})
-			testKube.PrintAllResources(subNamespace, &coreos.ClusterServiceVersionList{}, map[string]string{})
+			dir := os.TempDir() + "/infinispan-operator/" + tutils.TestName(t)
+
+			testKube.PrintAllResources(dir, subNamespace, "OperatorGroup", &coreosv1.OperatorGroupList{}, map[string]string{})
+			testKube.PrintAllResources(dir, subNamespace, "Subscription", &coreos.SubscriptionList{}, map[string]string{})
+			testKube.PrintAllResources(dir, subNamespace, "ClusterServiceVersion", &coreos.ClusterServiceVersionList{}, map[string]string{})
 			// Print 2.1.x Operator pod logs
-			testKube.PrintAllResources(subNamespace, &corev1.PodList{}, map[string]string{"name": "infinispan-operator"})
+			testKube.PrintAllResources(dir, subNamespace, "Pod", &corev1.PodList{}, map[string]string{"name": "infinispan-operator"})
 			// Print latest Operator logs
-			testKube.PrintAllResources(subNamespace, &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
+			testKube.PrintAllResources(dir, subNamespace, "Pod", &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
 		}
 
 		// Cleanup OLM resources


### PR DESCRIPTION
Store logs and yaml files in separate files in system tmp directory instead dumping them to stdout. Archive them after test execution.