### PR TITLE
Write logs and yaml to files on panic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,6 +186,8 @@ pipeline {
         }
 
         cleanup {
+            archiveArtifacts artifacts: '/tmp/infinispan-operator/**/*.yaml,/tmp/infinispan-operator/**/*.log', followSymlinks: false
+
             sh 'kind delete clusters --all'
             sh 'docker kill $(docker ps -q) || true'
             sh 'docker container prune -f'

--- a/test/e2e/infinispan/smoke_test.go
+++ b/test/e2e/infinispan/smoke_test.go
@@ -49,6 +49,8 @@ func TestBaseFunctionality(t *testing.T) {
 	verifyNoPVCs(assert, require, ispn)
 	verifyLabelsAndAnnotations(assert, require, ispn)
 	verifyDefaultAuthention(require, ispn)
+
+	panic("Temporary failure")
 }
 
 // Make sure no PVCs were created

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/url"
 	"os"
 	"reflect"
@@ -160,18 +161,25 @@ func (k TestKubernetes) CleanNamespaceAndLogWithPanic(t *testing.T, namespace st
 		specLabel["test-name"] = TestName(t)
 	}
 
-	// Print pod output if a panic has occurred
+	// Store pod output if a panic has occurred
 	testFailed := t != nil && t.Failed()
 	if panicVal != nil || testFailed {
-		k.PrintAllResources(namespace, &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
-		k.PrintAllResources(namespace, &corev1.PodList{}, map[string]string{"app": "infinispan-pod"})
-		k.PrintAllResources(namespace, &corev1.PodList{}, map[string]string{"app": "infinispan-batch-pod"})
-		k.PrintAllResources(namespace, &appsv1.StatefulSetList{}, map[string]string{})
-		k.PrintAllResources(namespace, &ispnv1.InfinispanList{}, map[string]string{})
-		k.PrintAllResources(namespace, &ispnv2.BackupList{}, map[string]string{})
-		k.PrintAllResources(namespace, &ispnv2.RestoreList{}, map[string]string{})
-		k.PrintAllResources(namespace, &ispnv2.BatchList{}, map[string]string{})
-		k.PrintAllResources(namespace, &ispnv2.CacheList{}, map[string]string{})
+		dir := os.TempDir() + "/infinispan-operator/" + TestName(t)
+		err := os.RemoveAll(dir)
+		LogError(err)
+
+		err = os.MkdirAll(dir, os.ModePerm)
+		LogError(err)
+
+		k.WriteAllResourcesToFile(dir, namespace, "Pod", &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
+		k.WriteAllResourcesToFile(dir, namespace, "Pod", &corev1.PodList{}, map[string]string{"app": "infinispan-pod"})
+		k.WriteAllResourcesToFile(dir, namespace, "Pod", &corev1.PodList{}, map[string]string{"app": "infinispan-batch-pod"})
+		k.WriteAllResourcesToFile(dir, namespace, "StatefulSet", &appsv1.StatefulSetList{}, map[string]string{})
+		k.WriteAllResourcesToFile(dir, namespace, "Infinispan", &ispnv1.InfinispanList{}, map[string]string{})
+		k.WriteAllResourcesToFile(dir, namespace, "Backup", &ispnv2.BackupList{}, map[string]string{})
+		k.WriteAllResourcesToFile(dir, namespace, "Restore", &ispnv2.RestoreList{}, map[string]string{})
+		k.WriteAllResourcesToFile(dir, namespace, "Batch", &ispnv2.BatchList{}, map[string]string{})
+		k.WriteAllResourcesToFile(dir, namespace, "Cache", &ispnv2.CacheList{}, map[string]string{})
 	}
 
 	if CleanupInfinispan == "TRUE" || panicVal == nil {
@@ -199,10 +207,9 @@ func (k TestKubernetes) CleanNamespaceAndLogWithPanic(t *testing.T, namespace st
 	}
 }
 
-func (k TestKubernetes) PrintAllResources(namespace string, list runtime.Object, set labels.Set) {
-	if err := k.Kubernetes.ResourcesList(namespace, set, list, context.TODO()); err != nil {
-		LogError(err)
-	}
+func (k TestKubernetes) WriteAllResourcesToFile(dir, namespace, suffix string, list runtime.Object, set labels.Set) {
+	err := k.Kubernetes.ResourcesList(namespace, set, list, context.TODO())
+	LogError(err)
 
 	unstructuredResource, err := runtime.DefaultUnstructuredConverter.ToUnstructured(list)
 	LogError(err)
@@ -213,14 +220,15 @@ func (k TestKubernetes) PrintAllResources(namespace string, list runtime.Object,
 		yaml_, err := yaml.Marshal(item)
 		LogError(err)
 		if strings.Contains(reflect.TypeOf(list).String(), "PodList") {
-			fmt.Println(strings.Repeat("-", 30))
 			log, err := k.Kubernetes.Logs(item.GetName(), namespace, context.TODO())
 			LogError(err)
-			fmt.Printf("%s", log)
+
+			err = ioutil.WriteFile(dir+"/"+item.GetName()+".log", []byte(log), 0666)
+			LogError(err)
 		}
 
-		fmt.Println(strings.Repeat("-", 30))
-		fmt.Println(string(yaml_))
+		err = ioutil.WriteFile(dir+"/"+item.GetName()+"-"+suffix+".yaml", []byte(string(yaml_)), 0666)
+		LogError(err)
 	}
 }
 

--- a/test/e2e/utils/olm.go
+++ b/test/e2e/utils/olm.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"testing"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
 
 	"github.com/infinispan/infinispan-operator/pkg/kubernetes"
 	"github.com/operator-framework/api/pkg/manifests"
@@ -40,13 +42,15 @@ func (k TestKubernetes) CleanupOLMTest(t *testing.T, subName, subNamespace, subP
 
 		testFailed := t != nil && t.Failed()
 		if panicVal != nil || testFailed {
-			k.PrintAllResources(subNamespace, &coreosv1.OperatorGroupList{}, map[string]string{})
-			k.PrintAllResources(subNamespace, &coreos.SubscriptionList{}, map[string]string{})
-			k.PrintAllResources(subNamespace, &coreos.ClusterServiceVersionList{}, map[string]string{})
+			dir := os.TempDir() + "/infinispan-operator/" + TestName(t)
+
+			k.WriteAllResourcesToFile(dir, subNamespace, "OperatorGroup", &coreosv1.OperatorGroupList{}, map[string]string{})
+			k.WriteAllResourcesToFile(dir, subNamespace, "Subscription", &coreos.SubscriptionList{}, map[string]string{})
+			k.WriteAllResourcesToFile(dir, subNamespace, "ClusterServiceVersion", &coreos.ClusterServiceVersionList{}, map[string]string{})
 			// Print 2.1.x Operator pod logs
-			k.PrintAllResources(subNamespace, &corev1.PodList{}, map[string]string{"name": "infinispan-operator"})
+			k.WriteAllResourcesToFile(dir, subNamespace, "Pod", &corev1.PodList{}, map[string]string{"name": "infinispan-operator"})
 			// Print latest Operator logs
-			k.PrintAllResources(subNamespace, &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
+			k.WriteAllResourcesToFile(dir, subNamespace, "Pod", &corev1.PodList{}, map[string]string{"app.kubernetes.io/name": "infinispan-operator"})
 		}
 
 		// Cleanup OLM resources


### PR DESCRIPTION
Store logs and yaml files in separate files in system tmp directory instead dumping them to stdout. Archive them after test execution.