### PR TITLE
[2.2.x] Test fixes for OLM deployed Operator/IT

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
@@ -3,6 +3,7 @@ package org.infinispan;
 import java.io.File;
 import java.io.IOException;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -79,7 +80,11 @@ public class Infinispan {
 
       new SimpleWaiter(bs).timeout(TimeUnit.MINUTES, 10).onTimeout(() -> onTimeout()).waitFor();
 
-      if(openShift.getLabeledPods("clusterName", clusterName).size() != infinispanObject.getSpec().getReplicas()) {
+      Map<String, String> labels = new HashMap<>();
+      labels.put("clusterName", clusterName);
+      labels.put("app", "infinispan-pod");
+
+      if(openShift.getLabeledPods(labels).size() != infinispanObject.getSpec().getReplicas()) {
          throw new IllegalStateException(clusterName + " is WellFormed but cluster pod count doesn't match expected replicas!");
       }
    }

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
@@ -23,6 +23,7 @@ import org.infinispan.identities.Credentials;
 import org.infinispan.util.CleanUpValidator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -163,6 +164,7 @@ class CacheServiceIT {
     */
    @Test
    @Tag("unstable")
+   @Disabled
    void autoscalingTest() throws Exception {
       String request = "https://" + hostName + "/rest/v2/caches/default/autoscaling-key-";
       int i = 0;

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
@@ -2,7 +2,9 @@ package org.infinispan.operator;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -117,7 +119,11 @@ class DataGridServiceIT {
       List<String> targetIPs = actualList.stream().map(t -> t.get("discoveredLabels").get("__meta_kubernetes_pod_ip").asText()).collect(Collectors.toList());
       List<String> targetHealths = actualList.stream().map(t -> t.get("health").asText()).collect(Collectors.toList());
 
-      List<Pod> clusterPods = openShift.getLabeledPods("clusterName", infinispan.getClusterName());
+      Map<String, String> labels = new HashMap<>();
+      labels.put("clusterName", infinispan.getClusterName());
+      labels.put("app", "infinispan-pod");
+
+      List<Pod> clusterPods = openShift.getLabeledPods(labels);
       List<String> podIPs = clusterPods.stream().map(p -> p.getStatus().getPodIP()).collect(Collectors.toList());
 
       // Assert that all the targets are up and that infinispan cluster pods are between the targets

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
@@ -89,7 +89,7 @@ public class MonitoringStackIT {
         operatorShift.configMaps().createOrReplace(infinispanOperatorConfig);
 
         // Restart the Operator to recreate the Dashboard in the Grafana namespace
-        operatorShift.pods().withLabel("name", "infinispan-operator").delete();
+        operatorShift.pods().withLabel("app.kubernetes.io/name", "infinispan-operator").delete();
     }
 
     static void createClusterRoleBindingForGrafana() {

--- a/test-integration/operator-tests/src/test/resources/infinispans/cache_service.yaml
+++ b/test-integration/operator-tests/src/test/resources/infinispans/cache_service.yaml
@@ -3,11 +3,11 @@ kind: Infinispan
 metadata:
   name: cache-service
 spec:
-  autoscale:
-    maxMemUsagePercent: 40
-    maxReplicas: 5
-    minMemUsagePercent: 20
-    minReplicas: 3
+  # autoscale:
+  #   maxMemUsagePercent: 40
+  #   maxReplicas: 5
+  #   minMemUsagePercent: 20
+  #   minReplicas: 3
   container:
     memory: 512Mi
   expose:

--- a/test/e2e/cache/cache_test.go
+++ b/test/e2e/cache/cache_test.go
@@ -3,6 +3,11 @@ package cache
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/iancoleman/strcase"
 	v1 "github.com/infinispan/infinispan-operator/api/v1"
 	"github.com/infinispan/infinispan-operator/api/v2alpha1"
@@ -16,12 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strings"
-	"testing"
-	"time"
 )
 
 var (
@@ -220,6 +221,7 @@ func TestStaticServerCache(t *testing.T) {
 		Data: map[string]string{"infinispan-config.xml": serverConfig},
 	}
 	testKube.CreateConfigMap(configMap)
+	defer testKube.DeleteConfigMap(configMap)
 
 	ispn := tutils.DefaultSpec(t, testKube)
 	ispn.Spec.ConfigMapName = configMap.Name
@@ -508,8 +510,8 @@ func TestSameCacheNameInMultipleClusters(t *testing.T) {
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
 	// Create two clusters in the same namespace
-	cluster1 := initClusterWithSuffix(t, "-cluster-1", true)
-	cluster2 := initClusterWithSuffix(t, "-cluster-2", true)
+	cluster1 := initClusterWithSuffix(t, "-c1", true)
+	cluster2 := initClusterWithSuffix(t, "-c2", true)
 
 	// Create a cache with the same name on each cluster
 	cacheName := "name-collision"

--- a/test/e2e/infinispan/smoke_test.go
+++ b/test/e2e/infinispan/smoke_test.go
@@ -140,7 +140,7 @@ func verifyLabelsAndAnnotations(assert *assert.Assertions, require *require.Asse
 // and match them with the labels map provided by the caller
 func operatorEnvVarExistsWithValues(namespace, varName string, expectedVals map[string]string) bool {
 	podList := &corev1.PodList{}
-	tutils.ExpectNoError(testKube.Kubernetes.ResourcesList(namespace, map[string]string{"name": tutils.OperatorName}, podList, context.TODO()))
+	tutils.ExpectNoError(testKube.Kubernetes.ResourcesList(namespace, map[string]string{"app.kubernetes.io/name": tutils.OperatorName}, podList, context.TODO()))
 	if len(podList.Items) == 0 {
 		panic("Cannot get the Infinispan operator pod")
 	}


### PR DESCRIPTION
Update integration suite:
* Update labels
* Disable broken autoscaling test

E2E
* Update label for selecting Operator pod
* Add missing `defer` delete for config map
* Shorten cluster suffix in `TestSameCacheNameInMultipleClusters` test by a bit otherwise it's possible that Operator will fail to create second route due truncating of too long name (depends also on base domain and namespace)