### PR TITLE
[2.2.x] Update pods security contexts as required by k8s 1.24

### DIFF
--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
@@ -70,10 +70,17 @@ public class CustomLibsIT {
         vmb.withMountPath("/tmp/libs");
         vmb.withName("lib-pv-storage");
 
+        SecurityContextBuilder scb = new SecurityContextBuilder();
+        scb.withAllowPrivilegeEscalation(false);
+        scb.withCapabilities(new CapabilitiesBuilder().withDrop("ALL").build());
+        scb.withRunAsNonRoot(true);
+        scb.withSeccompProfile(new SeccompProfileBuilder().withType("RuntimeDefault").build());
+
         ContainerBuilder cb = new ContainerBuilder();
         cb.withName("lib-pv-container")
                 .withImage(serverImage)
                 .withVolumeMounts(vmb.build());
+        cb.withSecurityContext(scb.build());
 
         PodBuilder pod = new PodBuilder();
         pod.withNewMetadata()

--- a/test/e2e/backup-restore/backup_restore_test.go
+++ b/test/e2e/backup-restore/backup_restore_test.go
@@ -99,6 +99,18 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize, numEn
 						MountPath: "/etc/backups",
 					},
 				},
+				SecurityContext: &corev1.SecurityContext{
+					AllowPrivilegeEscalation: pointer.Bool(false),
+					Capabilities: &corev1.Capabilities{
+						Drop: []corev1.Capability{
+							"ALL",
+						},
+					},
+					RunAsNonRoot: pointer.Bool(true),
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: "RuntimeDefault",
+					},
+				},
 			}},
 			RestartPolicy: corev1.RestartPolicyNever,
 			Volumes: []corev1.Volume{

--- a/test/e2e/infinispan/dependencies_test.go
+++ b/test/e2e/infinispan/dependencies_test.go
@@ -141,9 +141,9 @@ func prepareWebServer() *corev1.ConfigMap {
 	webServerConfig.Namespace = tutils.Namespace
 	testKube.Create(webServerConfig)
 
-	webServerPodConfig := tutils.WebServerPod(tutils.WebServerName, tutils.Namespace, webServerConfig.Name, tutils.WebServerRootFolder, tutils.WebServerImageName)
-	tutils.ExpectNoError(controllerutil.SetControllerReference(webServerConfig, webServerPodConfig, tutils.Scheme))
-	testKube.Create(webServerPodConfig)
+	webServerDeploymentConfig := tutils.WebServerDeployment(tutils.WebServerName, tutils.Namespace, webServerConfig.Name, tutils.WebServerRootFolder, tutils.WebServerImageName)
+	tutils.ExpectNoError(controllerutil.SetControllerReference(webServerConfig, webServerDeploymentConfig, tutils.Scheme))
+	testKube.Create(webServerDeploymentConfig)
 
 	webServerService := tutils.WebServerService(tutils.WebServerName, tutils.Namespace)
 	tutils.ExpectNoError(controllerutil.SetControllerReference(webServerConfig, webServerService, tutils.Scheme))

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -16,10 +16,12 @@ import (
 	"github.com/infinispan/infinispan-operator/controllers/constants"
 	users "github.com/infinispan/infinispan-operator/pkg/infinispan/security"
 	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -142,55 +144,67 @@ func DefaultSpec(t *testing.T, testKube *TestKubernetes, initializer func(*ispnv
 	return infinispan
 }
 
-func WebServerPod(name, namespace, configName, mountPath, imageName string) *corev1.Pod {
-	return &corev1.Pod{
+func WebServerDeployment(name, namespace, configName, mountPath, imageName string) *appsv1.Deployment {
+	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Pod",
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Labels:    map[string]string{"app": name},
 		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "web-server",
-				Image: imageName,
-				Ports: []corev1.ContainerPort{{
-					ContainerPort: int32(WebServerPortNumber),
-					Name:          "web-port",
-					Protocol:      corev1.ProtocolTCP,
-				}},
-				VolumeMounts: []corev1.VolumeMount{{
-					MountPath: mountPath,
-					Name:      "data",
-				}},
-				ReadinessProbe: &corev1.Probe{
-					Handler: corev1.Handler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Scheme: corev1.URISchemeHTTP,
-							Path:   "/index.html",
-							Port:   intstr.FromInt(WebServerPortNumber),
-						},
-					},
-					InitialDelaySeconds: 5,
-					TimeoutSeconds:      60,
-					PeriodSeconds:       1,
-					SuccessThreshold:    1,
-					FailureThreshold:    5,
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": name},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   name,
+					Labels: map[string]string{"app": name},
 				},
-			}},
-			Volumes: []corev1.Volume{{
-				Name: "data",
-				VolumeSource: corev1.VolumeSource{
-					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{
-							Name: configName,
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:  "web-server",
+						Image: imageName,
+						Ports: []corev1.ContainerPort{{
+							ContainerPort: int32(WebServerPortNumber),
+							Name:          "web-port",
+							Protocol:      corev1.ProtocolTCP,
+						}},
+						VolumeMounts: []corev1.VolumeMount{{
+							MountPath: mountPath,
+							Name:      "data",
+						}},
+						ReadinessProbe: &corev1.Probe{
+							Handler: corev1.Handler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Scheme: corev1.URISchemeHTTP,
+									Path:   "/index.html",
+									Port:   intstr.FromInt(WebServerPortNumber),
+								},
+							},
+							InitialDelaySeconds: 5,
+							TimeoutSeconds:      60,
+							PeriodSeconds:       1,
+							SuccessThreshold:    1,
+							FailureThreshold:    5,
 						},
-					},
+					}},
+					Volumes: []corev1.Volume{{
+						Name: "data",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: configName,
+								},
+							},
+						},
+					}},
 				},
-			}},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Tests using custom pods are failing with incorrect SecurityContext configuration on k8s 1.24 and ocp 4.12:

```
kubernetes.go:206: pods "external-libs-web-server" is forbidden: violates PodSecurity "restricted:v1.24": allowPrivilegeEscalation != false (container "web-server" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "web-server" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "web-server" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "web-server" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```