### PR TITLE
ServiceMonitor is using incorrect matchLabels to target pods #1686

### DIFF
--- a/pkg/reconcile/pipeline/infinispan/handler/provision/service_monitor.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/service_monitor.go
@@ -63,7 +63,7 @@ func ServiceMonitor(i *iv1.Infinispan, ctx pipeline.Context) {
 				},
 			},
 			Selector: metav1.LabelSelector{
-				MatchLabels: i.ServiceSelectorLabels(),
+				MatchLabels: i.Labels("infinispan-service-admin"),
 			},
 			NamespaceSelector: monitoringv1.NamespaceSelector{
 				MatchNames: []string{i.Namespace},


### PR DESCRIPTION
Resolves #1686 