### PR TITLE
Operand CVE upgrades always use RollingUpgrades regardless of source …

### DIFF
--- a/api/v1/infinispan_webhook.go
+++ b/api/v1/infinispan_webhook.go
@@ -166,7 +166,7 @@ func (i *Infinispan) ValidateUpdate(oldRuntimeObj runtime.Object) error {
 				detail := fmt.Sprintf("Version downgrading not supported. Existing='%s', Requested='%s'.", oldOperand.Ref(), operand.Ref())
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("spec").Child("version"), detail))
 			}
-		} else {
+		} else if operand.LT(oldOperand) {
 			if old.Status.HotRodRollingUpgradeStatus == nil {
 				detail := fmt.Sprintf("Version rollback only supported when a Hot Rolling Upgrade is in progress. Existing='%s', Requested='%s'.", oldOperand.Ref(), operand.Ref())
 				allErrs = append(allErrs, field.Forbidden(field.NewPath("spec").Child("version"), detail))

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
@@ -74,7 +74,7 @@ func AwaitWellFormedCondition(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	wellFormed := wellFormedCondition(i, ctx, podList)
 	if err := ctx.UpdateInfinispan(func() {
 		i.SetConditions(wellFormed)
-		if wellFormed.Status == metav1.ConditionTrue {
+		if i.GracefulShutdownUpgrades() && wellFormed.Status == metav1.ConditionTrue {
 			i.Status.Operand.Phase = ispnv1.OperandPhaseRunning
 		}
 	}); err != nil {

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
@@ -29,6 +29,7 @@ func InitialiseOperandVersion(i *ispnv1.Infinispan, ctx pipeline.Context) {
 				// Utilise the oldest Operand as this is the Operand provided by the Operator prior to Multi-Operand support
 				i.Spec.Version = operandRef
 				i.Status.Operand.Image = operand.Image
+				i.Status.Operand.Phase = ispnv1.OperandPhaseRunning
 				i.Status.Operand.Version = operandRef
 			}),
 		)
@@ -77,7 +78,7 @@ func UpgradeRequired(i *ispnv1.Infinispan, ctx pipeline.Context) bool {
 
 		// If the Operand is marked as a CVE base-image release, then we perform the upgrade as a StatefulSet rolling upgrade
 		// as the server components are not changed.
-		if requestedOperand.CVE {
+		if requestedOperand.CVE && installedOperand.UpstreamVersion.EQ(*requestedOperand.UpstreamVersion) {
 			return false
 		}
 		return !requestedOperand.EQ(installedOperand)

--- a/test/e2e/infinispan/upgrade_operand_test.go
+++ b/test/e2e/infinispan/upgrade_operand_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // TestOperandUpgrade tests that changes to spec.version results in the existing cluster being GracefulShutdown and
@@ -65,11 +66,17 @@ func TestOperandUpgrade(t *testing.T) {
 			container := kubernetes.GetContainer(provision.InfinispanContainer, &pod.Spec)
 			assert.Equal(t, operand.Image, container.Image)
 		}
+
+		// Ensure that the StatefulSet is on its first generation, i.e. a RollingUpgrade has not been performed
+		ss := appsv1.StatefulSet{}
+		tutils.ExpectNoError(testKube.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: ispn.Namespace, Name: ispn.GetStatefulSetName()}, &ss))
+		assert.EqualValues(t, 1, ss.Status.ObservedGeneration)
 	}
 }
 
-// TestOperandCVEUpgrade tests that Operands marked as CVE releases only execute a StatefulSet rolling upgrade
-func TestOperandCVEUpgrade(t *testing.T) {
+// TestOperandCVERollingUpgrade tests that Operands marked as CVE releases, with the same upstream version as the currently
+// installed operand, only result in a StatefulSet rolling upgrade
+func TestOperandCVERollingUpgrade(t *testing.T) {
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 	versionManager := tutils.VersionManager
 
@@ -101,4 +108,62 @@ func TestOperandCVEUpgrade(t *testing.T) {
 		})
 	}
 	genericTestForContainerUpdated(*spec, modifier, verifier)
+}
+
+// TestOperandCVEGracefulShutdown tests that Operands marked as a CVE release, but with a different upstream version to
+// the currently installed operand, result in a GracefulShutdown upgrade
+func TestOperandCVEGracefulShutdown(t *testing.T) {
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
+	versionManager := tutils.VersionManager
+	// Create Infinispan Cluster using the oldest Operand release
+	replicas := 1
+	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
+		i.Spec.Replicas = int32(replicas)
+		i.Spec.Version = versionManager.Operands[0].Ref()
+		// Ensure that FIPS is disabled when testing 13.0.x Operand
+		i.Spec.Container.CliExtraJvmOpts = "-Dcom.redhat.fips=false"
+		i.Spec.Container.ExtraJvmOpts = "-Dcom.redhat.fips=false"
+	})
+	testKube.CreateInfinispan(spec, tutils.Namespace)
+	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
+	ispn := testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)
+
+	cveOperand := versionManager.Latest()
+	if !cveOperand.CVE {
+		t.Errorf("Expected latest Operand release to have cve=true: %s", cveOperand)
+		return
+	}
+
+	tutils.ExpectNoError(
+		testKube.UpdateInfinispan(ispn, func() {
+			ispn.Spec.Version = cveOperand.Ref()
+		}),
+	)
+	testKube.WaitForInfinispanState(spec.Name, spec.Namespace, func(i *ispnv1.Infinispan) bool {
+		return !i.IsConditionTrue(ispnv1.ConditionWellFormed) &&
+			i.Status.Operand.Version == cveOperand.Ref() &&
+			i.Status.Operand.Image == cveOperand.Image &&
+			i.Status.Operand.Phase == ispnv1.OperandPhasePending
+	})
+
+	testKube.WaitForInfinispanState(spec.Name, spec.Namespace, func(i *ispnv1.Infinispan) bool {
+		return i.IsConditionTrue(ispnv1.ConditionWellFormed) &&
+			i.Status.Operand.Version == cveOperand.Ref() &&
+			i.Status.Operand.Image == cveOperand.Image &&
+			i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
+	})
+
+	// Ensure that the newly created cluster pods have the correct Operand image
+	podList := &corev1.PodList{}
+	tutils.ExpectNoError(testKube.Kubernetes.ResourcesList(tutils.Namespace, ispn.PodSelectorLabels(), podList, context.TODO()))
+	for _, pod := range podList.Items {
+		container := kubernetes.GetContainer(provision.InfinispanContainer, &pod.Spec)
+		assert.Equal(t, cveOperand.Image, container.Image)
+	}
+
+	// Ensure that the StatefulSet is on its first generation, i.e. a RollingUpgrade has not been performed
+	ss := appsv1.StatefulSet{}
+	tutils.ExpectNoError(testKube.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: ispn.Namespace, Name: ispn.GetStatefulSetName()}, &ss))
+	assert.EqualValues(t, 1, ss.Status.ObservedGeneration)
 }

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -63,6 +63,9 @@ func TestUpgrade(t *testing.T) {
 		i.Spec.Container.CliExtraJvmOpts = "-Dcom.redhat.fips=false"
 		i.Spec.Container.ExtraJvmOpts = "-Dcom.redhat.fips=false"
 	})
+	// Explicitly reset the Version so that it will be set by the Operator webhook
+	spec.Spec.Version = ""
+
 	testKube.CreateInfinispan(spec, tutils.Namespace)
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	testKube.WaitForInfinispanConditionWithTimeout(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -38,13 +38,16 @@ var VersionManager = func() *version.Manager {
 		// a real release, but the image tag must differ from the oldest Operand release so that we can ensure the
 		// Pod Image was correctly updated.
 		_ = os.Setenv(ispnv1.OperatorOperandVersionEnvVarName, `[{
+			"downstream-version": "0.1.0",
 			"upstream-version": "13.0.10",
 			"image": "quay.io/infinispan/server:13.0.10.Final"
 		},{
+			"downstream-version": "0.2.0-1",
 			"upstream-version": "14.0.0",
 			"image": "quay.io/infinispan/server:14.0.0.Final"
 		},{
-			"upstream-version": "14.0.1",
+			"downstream-version": "0.2.0-2",
+			"upstream-version": "14.0.0",
 			"image": "quay.io/infinispan/server:14.0",
 			"cve": true
 		}]`)


### PR DESCRIPTION
Resolves #1694