### PR TITLE
fix indentation in the cacheCR example #1696

### DIFF
--- a/documentation/asciidoc/topics/yaml/cache_yaml.yaml
+++ b/documentation/asciidoc/topics/yaml/cache_yaml.yaml
@@ -3,15 +3,14 @@ kind: Cache
 metadata:
   name: mycachedefinition
 spec:
-  clusterName:
-    example_crd_name: ~
+  clusterName: infinispan
   name: myYAMLcache
   template: |-
-      distributedCache:
-        mode: "SYNC"
-        owners: "2"
-        statistics: "true"
-        encoding:
-          mediaType: "application/x-protostream"
-        persistence:
-          fileStore: ~
+    distributedCache:
+      mode: "SYNC"
+      owners: "2"
+      statistics: "true"
+      encoding:
+        mediaType: "application/x-protostream"
+      persistence:
+        fileStore: ~


### PR DESCRIPTION
Needs backport to 2.2.x
Fixes errors in indentation that were discovered during QE review
Issue #1696 