### PR TITLE
Stabilize upgrade tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6 // indirect
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/text v0.3.6
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/appengine v1.6.6 // indirect

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
 	"github.com/infinispan/infinispan-operator/api/v2alpha1"
@@ -96,6 +97,10 @@ func TestUpgrade(t *testing.T) {
 		testKube.WaitForSubscription(sub, func() bool {
 			return sub.Status.InstalledCSV == sub.Status.CurrentCSV
 		})
+		testKube.WaitForCSVSucceeded(sub)
+		// Operator does not start properly on the first attempt after the upgrade and is restarted
+		// https://github.com/infinispan/infinispan-operator/issues/1719
+		time.Sleep(time.Minute)
 
 		assertOperandImage := func(expectedImage string) {
 			pods := &corev1.PodList{}

--- a/test/e2e/utils/olm.go
+++ b/test/e2e/utils/olm.go
@@ -328,6 +328,15 @@ func (k TestKubernetes) WaitForSubscription(sub *coreos.Subscription, predicate 
 	ExpectNoError(err)
 }
 
+func (k TestKubernetes) WaitForCSVSucceeded(sub *coreos.Subscription) {
+
+	err := wait.Poll(ConditionPollPeriod, ConditionWaitTimeout, func() (done bool, err error) {
+		csv, _ := k.InstalledCSV(sub)
+		return csv.Status.Phase == "Succeeded", nil
+	})
+	ExpectNoError(err)
+}
+
 func retryOnConflict(update func() error) {
 	err := wait.Poll(DefaultPollPeriod, MaxWaitTimeout, func() (done bool, err error) {
 		err = update()


### PR DESCRIPTION
Fixes several timing issues present in upgrade tests:
* While Subscription already installed new CSV, old Operator is still running. Which leads to an unknown version issue (Old Operator isn't aware of new version available with new CSV until respun).
* Due to #1719 it's highly probable that update version requests hits Operator without running admission webhook, effectively failing the test
* Disable temporarily requirement for Infinispan CR to set Running after the upgrade till #1720 is fixed