### PR TITLE
updated Dockerfile to run IDE debug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM registry.access.redhat.com/ubi9/go-toolset:1.17.7 AS build
 ARG OPERATOR_VERSION
+ARG SKAFFOLD_GO_GCFLAGS
 WORKDIR /workspace
 USER root
 # Copy the Go Modules manifests
@@ -18,8 +19,11 @@ COPY pkg/ pkg/
 
 RUN GOPROXY="https://proxy.golang.org,direct" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on \
     go build -a -o /bin/infinispan-operator \
-    -ldflags="-X 'github.com/infinispan/infinispan-operator/launcher.Version=${OPERATOR_VERSION}'" main.go
+    -ldflags="-X 'github.com/infinispan/infinispan-operator/launcher.Version=${OPERATOR_VERSION}'" -gcflags="${SKAFFOLD_GO_GCFLAGS}" main.go
 
 FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=build /bin/infinispan-operator /usr/local/bin/infinispan-operator
-ENTRYPOINT [ "infinispan-operator" ]
+# Define GOTRACEBACK to mark this container as using the Go language runtime
+# for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
+ENV GOTRACEBACK=single
+ENTRYPOINT [ "/usr/local/bin/infinispan-operator" ]


### PR DESCRIPTION
allows IDE debugging of remote pod with: skaffold,delve,vscode.

More info https://skaffold.dev/docs/workflows/debug/#go-runtime-go-protocols-dlv

A working config for vscode is:
```
            {
                "name": "Kubernetes: Run/Debug",
                "type": "cloudcode.kubernetes",
                "request": "launch",
                "skaffoldConfig": "${workspaceFolder}/skaffold.yaml",
                "watch": true,
                "cleanUp": true,
                "portForward": true,
                "imageRegistry": "localhost:5000",
                "debug": [
                    {
                        "image": "operator",
                        "containerName": "manager",
                        "sourceFileMap": {
                            "${workspaceFolder}": "/workspace"
                        }
                    }
                ]
            }
```