### PR TITLE
update labels on operator restart. Fixes #JDG-5931 JDG-5936

### DIFF
--- a/pkg/reconcile/pipeline/infinispan/handler/provision/statefulsets.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/statefulsets.go
@@ -65,6 +65,8 @@ func ClusterStatefulSet(i *ispnv1.Infinispan, ctx pipeline.Context) {
 
 func ClusterStatefulSetSpec(statefulSetName string, i *ispnv1.Infinispan, ctx pipeline.Context) (*appsv1.StatefulSet, error) {
 	labelsForPod := i.PodLabels()
+	labelsForSelector := i.PodSelectorLabels()
+	labelsForSelector[consts.StatefulSetPodLabel] = statefulSetName
 	labelsForPod[consts.StatefulSetPodLabel] = statefulSetName
 
 	configFiles := ctx.ConfigFiles()
@@ -89,7 +91,7 @@ func ClusterStatefulSetSpec(statefulSetName string, i *ispnv1.Infinispan, ctx pi
 		Spec: appsv1.StatefulSetSpec{
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{Type: appsv1.RollingUpdateStatefulSetStrategyType},
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labelsForPod,
+				MatchLabels: labelsForSelector,
 			},
 			Replicas: &i.Spec.Replicas,
 			Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
see #1780 
currently labels are updated only if PreliminaryCheckCondition==false.
This prevents labels update on operator restart.
Also selector template in statefulset has been changed to allow label update.

Label are merged in the Infinispan CR (using ApplyOperatorMeta) while are replaced in Statefulset and Pod.
replace= all the old keys are lost
merge= updated affects only label present in the new label map

I would prefer to use merge approach also for Statefulset and Pod, since I don't like the idea to delete user labels.
wdyt @ryanemerson ?