### PR TITLE
Skip tests based on Infinispan server version

### DIFF
--- a/test/e2e/infinispan/credential_store_test.go
+++ b/test/e2e/infinispan/credential_store_test.go
@@ -44,6 +44,8 @@ var config = `
 `
 
 func TestCredentialStoreEntries(t *testing.T) {
+	tutils.SkipForMajor(t, 13, "Credential store is not available in Infinispan 13.")
+
 	t.Parallel()
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 

--- a/test/e2e/infinispan/dependencies_test.go
+++ b/test/e2e/infinispan/dependencies_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestExternalDependenciesHttp(t *testing.T) {
+	tutils.SkipForMajor(t, 13, "Downloading artifacts dependencies via url is broken with Infinispan 13.")
+
 	if os.Getenv("NO_NGINX") != "" {
 		t.Skip("Skipping test, no Nginx available.")
 	}

--- a/test/e2e/utils/asserts.go
+++ b/test/e2e/utils/asserts.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"testing"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 )
@@ -34,5 +35,14 @@ func ExpectNotFound(err error) {
 
 	if !errors.IsNotFound(err) {
 		panic(fmt.Errorf("unexpected error: %w", err))
+	}
+}
+
+func SkipForMajor(t *testing.T, infinispanMajor uint64, message string) {
+	if OperandVersion != "" {
+		operand, _ := VersionManager().WithRef(OperandVersion)
+		if operand.UpstreamVersion.Major == infinispanMajor {
+			t.Skip(message)
+		}
 	}
 }


### PR DESCRIPTION
Some features may not work or be broken with older Infinispan versions. In such cases there is no point in running those tests with those versions.