### PR TITLE
marks service monitor labels as community only

### DIFF
--- a/documentation/asciidoc/stories/assembly_monitoring.adoc
+++ b/documentation/asciidoc/stories/assembly_monitoring.adoc
@@ -17,7 +17,12 @@ See the link:{link_prometheus_operator} documentation.
 
 include::{topics}/proc_creating_service_monitor.adoc[leveloffset=+1]
 include::{topics}/proc_disabling_service_monitor.adoc[leveloffset=+2]
+
+//Community only
+ifdef::community[]
 include::{topics}/proc_configuring_service_monitor_target_labels.adoc[leveloffset=+2]
+endif::community[]
+
 //Downstream content
 ifdef::downstream[]
 include::{topics}/proc_installing_grafana_operator.adoc[leveloffset=+1]


### PR DESCRIPTION
This content should be available only in the community