### PR TITLE
Remove leftover IT resources upon finished execution

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/TestServer.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/TestServer.java
@@ -53,6 +53,12 @@ public class TestServer {
       testApp.buildApplication().deploy();
    }
 
+   public void delete() {
+      openShift.deploymentConfigs().withLabel("app", name).delete();
+      openShift.services().withLabel("app", name).delete();
+      openShift.routes().withLabel("app", name).delete();
+   }
+
    public String host() {
       return openShift.generateHostname(name);
    }
@@ -66,10 +72,10 @@ public class TestServer {
       ManagedBuildReference mbr = bm.getBuildReference(build);
 
       ApplicationBuilder appBuilder = new ApplicationBuilder(name);
-      appBuilder.deploymentConfig().onConfigurationChange().onImageChange();
+      appBuilder.deploymentConfig().addLabel("app", name).onConfigurationChange().onImageChange();
       appBuilder.deploymentConfig().podTemplate().container().fromImage(mbr.getNamespace(), mbr.getStreamName()).port(8080);
-      appBuilder.service().port(8080);
-      appBuilder.route();
+      appBuilder.service().addLabel("app", name).port(8080);
+      appBuilder.route().addLabel("app", name);
 
       return appBuilder;
    }

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
@@ -81,6 +81,7 @@ class CacheServiceIT {
    @AfterAll
    static void undeploy() throws IOException {
       infinispan.delete();
+      testServer.delete();
 
       new CleanUpValidator(openShift, appName).withExposedRoute().withDefaultCredentials().withOpenShiftCerts().withServiceMonitor().validate();
    }

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
@@ -42,7 +42,6 @@ import cz.xtf.core.waiting.Waiters;
 import cz.xtf.junit5.annotations.CleanBeforeAll;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * Compared to MinimalSetupIT this set of tests are running
@@ -50,7 +49,6 @@ import lombok.extern.slf4j.Slf4j;
  *
  * Check datagrid_service.yaml Infinispan CR in test resources for input configuration.
  */
-@Slf4j
 @CleanBeforeAll
 class DataGridServiceIT {
    private static final OpenShift openShift = OpenShifts.master();
@@ -69,11 +67,11 @@ class DataGridServiceIT {
 
       certs = KeystoreGenerator.generateCerts(hostName, new String[]{appName});
 
-      Secret encryptionSecret = new SecretBuilder("encryption-secret")
+      Secret encryptionSecret = new SecretBuilder("encryption-secret").addLabel("test", "DataGridServiceIT")
             .addData("keystore.p12", certs.keystore)
             .addData("alias", hostName.getBytes())
             .addData("password", "password".getBytes()).build();
-      Secret authSecret = new SecretBuilder("connect-secret")
+      Secret authSecret = new SecretBuilder("connect-secret").addLabel("test", "DataGridServiceIT")
             .addData("identities.yaml", Paths.get("src/test/resources/secrets/identities.yaml")).build();
 
       openShift.secrets().create(encryptionSecret);
@@ -98,6 +96,8 @@ class DataGridServiceIT {
       infinispan.delete();
 
       new CleanUpValidator(openShift, appName).withExposedRoute().withServiceMonitor().validate();
+
+      openShift.secrets().withLabel("test", "DataGridServiceIT").delete();
    }
 
    /**

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/DevSetupIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/DevSetupIT.java
@@ -22,14 +22,12 @@ import cz.xtf.core.openshift.OpenShift;
 import cz.xtf.core.openshift.OpenShifts;
 import cz.xtf.junit5.annotations.CleanBeforeAll;
 import io.fabric8.kubernetes.api.model.Pod;
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * DevSetupIT tests deployment setup for development purposes with disabled security and monitoring features
  *
  * Check dev_setup.yaml Infinispan CR in test resources for input configuration.
  */
-@Slf4j
 @CleanBeforeAll
 class DevSetupIT {
    private static final OpenShift openShift = OpenShifts.master();
@@ -61,6 +59,7 @@ class DevSetupIT {
    @AfterAll
    static void undeploy() throws IOException {
       infinispan.delete();
+      testServer.delete();
 
       new CleanUpValidator(openShift, appName).withExposedRoute().validate();
    }


### PR DESCRIPTION
Update integration test so they remove all the leftover resources after the execution. Leaving some of them can end up in other tests instability due to lack of k8s cluster resources.