### PR TITLE
Clean up events after test execution

### DIFF
--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
@@ -84,6 +84,8 @@ class CacheServiceIT {
       testServer.delete();
 
       new CleanUpValidator(openShift, appName).withExposedRoute().withDefaultCredentials().withOpenShiftCerts().withServiceMonitor().validate();
+
+      openShift.events().delete();
    }
 
    /**

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/ClientAuthenticationIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/ClientAuthenticationIT.java
@@ -83,6 +83,7 @@ class ClientAuthenticationIT {
       }
 
       openShift.secrets().withLabel("test", "ClientAuthenticationIT").delete();
+      openShift.events().delete();
    }
 
    @Test

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/ClientValidationIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/ClientValidationIT.java
@@ -94,6 +94,7 @@ class ClientValidationIT {
       }
 
       openShift.secrets().withLabel("test", "ClientAuthenticationIT").delete();
+      openShift.events().delete();
    }
 
    @Test

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
@@ -46,6 +46,7 @@ public class CustomLibsIT {
 
         openShift.pods().withLabel("app", "infinispan-libs").delete();
         openShift.persistentVolumeClaims().withLabel("app", "infinispan-libs").delete();
+        openShift.events().delete();
     }
 
     @Test

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/DataGridServiceIT.java
@@ -98,6 +98,7 @@ class DataGridServiceIT {
       new CleanUpValidator(openShift, appName).withExposedRoute().withServiceMonitor().validate();
 
       openShift.secrets().withLabel("test", "DataGridServiceIT").delete();
+      openShift.events().delete();
    }
 
    /**

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/DevSetupIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/DevSetupIT.java
@@ -62,6 +62,8 @@ class DevSetupIT {
       testServer.delete();
 
       new CleanUpValidator(openShift, appName).withExposedRoute().validate();
+
+      openShift.events().delete();
    }
 
    /**

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/installation/MonitoringStackIT.java
@@ -105,6 +105,7 @@ public class MonitoringStackIT {
         infinispan.delete();
         grafanaShift.projects().withName(grafanaNamespace).delete();
         operatorShift.configMaps().withName("infinispan-operator-config").delete();
+        clusterShift.events().delete();
     }
 
     /**

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -202,6 +202,12 @@ func (k TestKubernetes) CleanNamespaceAndLogWithPanic(t *testing.T, namespace st
 		k.WaitForPods(0, 3*SinglePodTimeout, &client.ListOptions{Namespace: namespace, LabelSelector: labels.SelectorFromSet(map[string]string{"app": "infinispan-pod", "infinispan_cr": specLabel["test-name"]})}, nil)
 		k.WaitForPods(0, 3*SinglePodTimeout, &client.ListOptions{Namespace: namespace, LabelSelector: labels.SelectorFromSet(map[string]string{"app": "infinispan-batch-pod"})}, nil)
 		k.WaitForPods(0, 3*SinglePodTimeout, &client.ListOptions{Namespace: namespace, LabelSelector: labels.SelectorFromSet(map[string]string{"app": "infinispan-router-pod"})}, nil)
+
+		// Remove the events otherwise we are storing the events for unrelated tests in case of failure
+		optsEvents := []client.DeleteAllOfOption{
+			client.InNamespace(namespace),
+		}
+		ExpectMaybeNotFound(k.Kubernetes.Client.DeleteAllOf(ctx, &corev1.Event{}, optsEvents...))
 	}
 
 	if t != nil && panicVal != nil {


### PR DESCRIPTION
Events in the testing namespace are not cleaned up upon test execution. This may results in unrelated events being reported in case of other test failure.