### PR TITLE
[LPTOCPCI-419] Add a Dockerfile to execute integration tests in the Interop pipeline (main branch)

### DIFF
--- a/test-integration/Dockerfile
+++ b/test-integration/Dockerfile
@@ -1,0 +1,16 @@
+FROM maven:3.8-openjdk-11
+
+ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions --add-exports java.base/jdk.compiler=ALL-UNNAMED"
+
+# Copy the infinispan-operator repository in to /infinispan-operator
+RUN mkdir /infinispan-operator
+WORKDIR /infinispan-operator
+COPY . .
+
+# Add required permissions for OpenShift
+RUN chgrp -R 0 /infinispan-operator && \
+    chmod -R g=u /infinispan-operator
+
+WORKDIR /infinispan-operator/test-integration
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
This Dockerfile is required by the Interop pipeline. The Dockerfile will be built prior to test execution and used in the OpenShift CI platform for testing.

@Crumby @alanfx