### PR TITLE
[LPTOCPCI-558] Update Permissions Within Interop Dockerfile - main branch

### DIFF
--- a/test-integration/Dockerfile
+++ b/test-integration/Dockerfile
@@ -7,9 +7,17 @@ RUN mkdir /infinispan-operator
 WORKDIR /infinispan-operator
 COPY . .
 
+# Create required directories
+RUN mkdir /.m2 && mkdir /.kube/
+
 # Add required permissions for OpenShift
 RUN chgrp -R 0 /infinispan-operator && \
-    chmod -R g=u /infinispan-operator
+    chmod -R g=u /infinispan-operator && \
+    chgrp -R 0 /.m2 && \
+    chmod -R g=u /.m2 && \
+    chgrp -R 0 /.kube && \
+    chmod -R g=u /.kube
+
 
 WORKDIR /infinispan-operator/test-integration
 


### PR DESCRIPTION
This pull requests fixes some permissions within the Interop Dockerfile that are required for the Dockerfile to run correctly inside of an OpenShift CI pod.