### PR TITLE
Fixes JDG-6584 wrong tls secret

### DIFF
--- a/api/v1/infinispan_types.go
+++ b/api/v1/infinispan_types.go
@@ -508,6 +508,7 @@ const (
 	ConditionWellFormed          ConditionType = "WellFormed"
 	ConditionCrossSiteViewFormed ConditionType = "CrossSiteViewFormed"
 	ConditionGossipRouterReady   ConditionType = "GossipRouterReady"
+	ConditionTLSSecretValid      ConditionType = "TLSSecretValid"
 )
 
 // InfinispanCondition define a condition of the cluster

--- a/api/v1/types_util.go
+++ b/api/v1/types_util.go
@@ -219,6 +219,10 @@ func (ispn *Infinispan) IsConditionTrue(name ConditionType) bool {
 	return ispn.GetCondition(name).Status == metav1.ConditionTrue
 }
 
+func (ispn *Infinispan) IsConditionFalse(name ConditionType) bool {
+	return ispn.GetCondition(name).Status == metav1.ConditionFalse
+}
+
 func (ispn *Infinispan) IsUpgradeCondition() bool {
 	return ispn.IsConditionTrue(ConditionUpgrade)
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/configure/tls.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/configure/tls.go
@@ -54,7 +54,7 @@ func Keystore(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			_ = ctx.UpdateInfinispan(func() {
 				i.SetCondition(ispnv1.ConditionTLSSecretValid, metav1.ConditionFalse, errMsg)
 			})
-			ctx.Requeue(fmt.Errorf(errMsg))
+			ctx.Requeue(nil)
 			return
 		}
 	}

--- a/pkg/reconcile/pipeline/infinispan/handler/configure/tls.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/configure/tls.go
@@ -50,7 +50,7 @@ func Keystore(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			keystore.Path = consts.ServerOperatorSecurity + "/" + EncryptPemKeystoreName
 			keystore.PemFile = append(keystoreSecret.Data["tls.key"], keystoreSecret.Data["tls.crt"]...)
 		} else {
-			errMsg := fmt.Sprintf("Failed to setup TLS keystore from secret %s", keystoreSecret.Name)
+			errMsg := fmt.Sprintf("Failed to setup TLS. Secret %s must contain a keystore.p12 or a tls.key/tls.crt pair", keystoreSecret.Name)
 			_ = ctx.UpdateInfinispan(func() {
 				i.SetCondition(ispnv1.ConditionTLSSecretValid, metav1.ConditionFalse, errMsg)
 			})

--- a/test/e2e/infinispan/encryption_test.go
+++ b/test/e2e/infinispan/encryption_test.go
@@ -60,7 +60,9 @@ func TestTLSConditionWithBadKeystore(t *testing.T) {
 	// Create secret
 	serverName := tutils.GetServerName(spec)
 	keystore, _ := tutils.CreateKeystore(serverName)
-	secret := tutils.EncryptionBadSecretKeystore(spec.Name, tutils.Namespace, keystore)
+	secret := tutils.EncryptionSecretKeystore(spec.Name, tutils.Namespace, keystore)
+	// Corrupt secret
+	delete(secret.Data, "keystore.p12")
 	testKube.CreateSecret(secret)
 	defer testKube.DeleteSecret(secret)
 

--- a/test/e2e/infinispan/encryption_test.go
+++ b/test/e2e/infinispan/encryption_test.go
@@ -37,12 +37,38 @@ func TestTLSWithExistingKeystore(t *testing.T) {
 
 	// Register it
 	testKube.CreateInfinispan(spec, tutils.Namespace)
+	testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionTLSSecretValid)
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)
 
 	// Ensure that we can connect to the endpoint with TLS
 	client_ := tutils.HTTPSClientForCluster(spec, tlsConfig, testKube)
 	checkRestConnection(client_)
+}
+
+func TestTLSConditionWithBadKeystore(t *testing.T) {
+	t.Parallel()
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
+	// Create a resource without passing any config
+	replicas := 2
+	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
+		i.Spec.Replicas = int32(replicas)
+		i.Spec.Security = ispnv1.InfinispanSecurity{
+			EndpointEncryption: tutils.EndpointEncryption(i.Name),
+		}
+	})
+
+	// Create secret
+	serverName := tutils.GetServerName(spec)
+	keystore, _ := tutils.CreateKeystore(serverName)
+	secret := tutils.EncryptionBadSecretKeystore(spec.Name, tutils.Namespace, keystore)
+	testKube.CreateSecret(secret)
+	defer testKube.DeleteSecret(secret)
+
+	// Register it
+	testKube.CreateInfinispan(spec, tutils.Namespace)
+	testKube.WaitForInfinispanConditionFalse(spec.Name, spec.Namespace, ispnv1.ConditionTLSSecretValid)
 }
 
 func checkRestConnection(client tutils.HTTPClient) {

--- a/test/e2e/infinispan/encryption_test.go
+++ b/test/e2e/infinispan/encryption_test.go
@@ -51,9 +51,7 @@ func TestTLSConditionWithBadKeystore(t *testing.T) {
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
 	// Create a resource without passing any config
-	replicas := 2
 	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
-		i.Spec.Replicas = int32(replicas)
 		i.Spec.Security = ispnv1.InfinispanSecurity{
 			EndpointEncryption: tutils.EndpointEncryption(i.Name),
 		}

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -113,6 +113,14 @@ func EncryptionSecretKeystore(name, namespace string, keystore []byte) *corev1.S
 	return s
 }
 
+func EncryptionBadSecretKeystore(name, namespace string, keystore []byte) *corev1.Secret {
+	s := keystoreSecret(name, namespace)
+	s.StringData["alias"] = "server"
+	s.StringData["password"] = KeystorePassword
+	s.Data["badname.p12"] = keystore
+	return s
+}
+
 func EncryptionSecretClientCert(name, namespace string, caCert, clientCert []byte) *corev1.Secret {
 	s := truststoreSecret(name, namespace)
 	s.Data["trust.ca"] = caCert

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -113,14 +113,6 @@ func EncryptionSecretKeystore(name, namespace string, keystore []byte) *corev1.S
 	return s
 }
 
-func EncryptionBadSecretKeystore(name, namespace string, keystore []byte) *corev1.Secret {
-	s := keystoreSecret(name, namespace)
-	s.StringData["alias"] = "server"
-	s.StringData["password"] = KeystorePassword
-	s.Data["badname.p12"] = keystore
-	return s
-}
-
 func EncryptionSecretClientCert(name, namespace string, caCert, clientCert []byte) *corev1.Secret {
 	s := truststoreSecret(name, namespace)
 	s.Data["trust.ca"] = caCert

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -638,16 +638,7 @@ func (k TestKubernetes) WaitForPods(required int, timeout time.Duration, listOps
 	return podList
 }
 
-func (k TestKubernetes) WaitForInfinispanConditionWithTimeout(name, namespace string, condition ispnv1.ConditionType, timeout time.Duration, value ...string) *ispnv1.Infinispan {
-	if len(value) > 0 && value[0] == string(metav1.ConditionFalse) {
-		return k.WaitForInfinispanStateWithTimeout(name, namespace, timeout, func(i *ispnv1.Infinispan) bool {
-			if i.IsConditionFalse(condition) {
-				log.Info("infinispan condition met", "condition", condition, "status", metav1.ConditionTrue)
-				return true
-			}
-			return false
-		})
-	}
+func (k TestKubernetes) WaitForInfinispanConditionWithTimeout(name, namespace string, condition ispnv1.ConditionType, timeout time.Duration) *ispnv1.Infinispan {
 	return k.WaitForInfinispanStateWithTimeout(name, namespace, timeout, func(i *ispnv1.Infinispan) bool {
 		if i.IsConditionTrue(condition) {
 			log.Info("infinispan condition met", "condition", condition, "status", metav1.ConditionTrue)
@@ -682,7 +673,13 @@ func (k TestKubernetes) WaitForInfinispanCondition(name, namespace string, condi
 }
 
 func (k TestKubernetes) WaitForInfinispanConditionFalse(name, namespace string, condition ispnv1.ConditionType) *ispnv1.Infinispan {
-	return k.WaitForInfinispanConditionWithTimeout(name, namespace, condition, ConditionWaitTimeout, string(metav1.ConditionFalse))
+	return k.WaitForInfinispanStateWithTimeout(name, namespace, ConditionWaitTimeout, func(i *ispnv1.Infinispan) bool {
+		if i.IsConditionFalse(condition) {
+			log.Info("infinispan condition met", "condition", condition, "status", metav1.ConditionFalse)
+			return true
+		}
+		return false
+	})
 }
 
 func (k TestKubernetes) GetSchemaForRest(ispn *ispnv1.Infinispan) string {


### PR DESCRIPTION
In case it's not possible to create a keystore for the user provided `spec.security.endpointEncryption.certSecretName` deployment is halted and a failure status condition (`TLSSecretValid`) is added to the Infinispan CR.

Fixes JDG-6584