### PR TITLE
rename include to fix docs build #1881

### DIFF
--- a/documentation/asciidoc/stories/assembly_creating_services.adoc
+++ b/documentation/asciidoc/stories/assembly_creating_services.adoc
@@ -17,7 +17,7 @@ include::{topics}/proc_allocating_storage.adoc[leveloffset=+1]
 include::{topics}/ref_persistent_cache_store.adoc[leveloffset=+2]
 include::{topics}/proc_allocating_cpu_memory.adoc[leveloffset=+1]
 include::{topics}/proc_setting_jvm_options.adoc[leveloffset=+1]
-include::{topics}/proc_setting_priority.adoc[leveloffset=+1]
+include::{topics}/proc_configuring_pod_priority.adoc[leveloffset=+1]
 
 // Downstream content
 ifdef::downstream[]


### PR DESCRIPTION
follow up on #1881 
Apologies for the noise @ryanemerson but I forgot to rename the include 