### PR TITLE
[test-integration] Reflect recent (Infinispan|OpenShift|Java) releases

### DIFF
--- a/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
+++ b/test-integration/operator-tests/src/main/java/org/infinispan/Infinispan.java
@@ -77,7 +77,7 @@ public class Infinispan {
       BooleanSupplier bs = () -> {
          sync();
 
-         if (infinispanObject.getStatus() != null) {
+         if (infinispanObject.getStatus() != null && infinispanObject.getStatus().getConditions() != null) {
             List<Condition> conditions = infinispanObject.getStatus().getConditions();
             Condition wellFormed = conditions.stream().filter(c -> "WellFormed".equals(c.getType())).findFirst().orElse(null);
             return wellFormed != null && "True".equals(wellFormed.getStatus());

--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CacheServiceIT.java
@@ -130,9 +130,9 @@ class CacheServiceIT {
    void hotrodAuthTest() throws Exception {
       String encodedPass = URLEncoder.encode(pass, StandardCharsets.UTF_8.toString());
 
-      String authorizedGet = String.format("http://" + testServer.host() + "/hotrod/auth?username=%s&password=%s&servicename=%s&encrypted=%s", user, encodedPass, appName, "true");
-      String unauthorizedGet = String.format("http://" + testServer.host() + "/hotrod/auth?username=%s&password=%s&servicename=%s&encrypted=%s", user, "invalid", appName, "true");
-      String noAuthGet = String.format("http://" + testServer.host() + "/hotrod/auth?servicename=%s&encrypted=%s", appName, "true");
+      String authorizedGet = String.format("http://" + testServer.host() + "/hotrod/auth?username=%s&password=%s&servicename=%s&namespace=%s&encrypted=%s", user, encodedPass, appName, openShift.getNamespace(), "true");
+      String unauthorizedGet = String.format("http://" + testServer.host() + "/hotrod/auth?username=%s&password=%s&servicename=%s&namespace=%s&encrypted=%s", user, "invalid", appName, openShift.getNamespace(), "true");
+      String noAuthGet = String.format("http://" + testServer.host() + "/hotrod/auth?servicename=%s&namespace=%s&encrypted=%s", appName, openShift.getNamespace(), "true");
 
       Assertions.assertThat(Http.get(authorizedGet).execute().code()).isEqualTo(200);
       Assertions.assertThat(Http.get(unauthorizedGet).execute().code()).isEqualTo(401);

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -11,10 +11,10 @@
 
     <properties>
         <!-- Dependencies versions -->
-        <version.infinispan>14.0.0.Final</version.infinispan>
+        <version.infinispan>14.0.21.Final</version.infinispan>
         <version.fabric8>4.13.0</version.fabric8>
         <version.junit>5.7.0</version.junit>
-        <version.lombok>1.16.22</version.lombok>
+        <version.lombok>1.18.30</version.lombok>
         <version.logback>1.2.0</version.logback>
         <version.slf4j>1.7.30</version.slf4j>
         <version.verifier>1.5</version.verifier>

--- a/test-integration/test-server/pom.xml
+++ b/test-integration/test-server/pom.xml
@@ -11,7 +11,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <version.infinispan.hotrod>14.0.0.Final</version.infinispan.hotrod>
+        <version.infinispan.hotrod>14.0.21.Final</version.infinispan.hotrod>
         <version.jboss.servlet>1.0.2.Final</version.jboss.servlet>
         <version.maven.war>3.2.2</version.maven.war>
 

--- a/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/ClientCertificateAuthenticationServlet.java
+++ b/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/ClientCertificateAuthenticationServlet.java
@@ -31,6 +31,7 @@ public class ClientCertificateAuthenticationServlet extends HttpServlet {
                  .security().ssl().authentication().saslMechanism("EXTERNAL");
 
          builder.security().ssl()
+            .sniHostName(serviceName)
             .trustStoreFileName("/etc/test-server-cert-secret/truststore.p12")
             .trustStorePassword("password".toCharArray());
 

--- a/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/ClientCertificateValidationServlet.java
+++ b/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/ClientCertificateValidationServlet.java
@@ -36,6 +36,7 @@ public class ClientCertificateValidationServlet extends HttpServlet {
          }
 
          builder.security().ssl()
+                  .sniHostName(serviceName)
                   .trustStoreFileName("/etc/test-server-cert-secret/truststore.p12")
                   .trustStorePassword("password".toCharArray());
 

--- a/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/HotRodServlet.java
+++ b/test-integration/test-server/src/main/java/org/infinispan/operator/remote/auth/hotrod/HotRodServlet.java
@@ -27,6 +27,7 @@ public class HotRodServlet extends HttpServlet {
 
       try {
          String serviceName = request.getParameter("servicename");
+         String namespace = request.getParameter("namespace");
          String username = request.getParameter("username");
          String password = request.getParameter("password");
          String encrypted = request.getParameter("encrypted");
@@ -39,7 +40,7 @@ public class HotRodServlet extends HttpServlet {
          }
 
          if(encrypted != null) {
-            builder.security().ssl().trustStorePath("/etc/" + serviceName + "-cert-secret/tls.crt");
+            builder.security().ssl().sniHostName(serviceName + "." + namespace + ".svc").trustStorePath("/etc/" + serviceName + "-cert-secret/tls.crt");
          }
 
          RemoteCacheManager rcm = new RemoteCacheManager(builder.build());


### PR DESCRIPTION
Several fixes for the integration testsuite:
* Update Infinispan to 14.0.21.Final
  * Using `sniHostname` is now mandatory
*  Update Lombok to 1.18.30 (Required for Java 17 compatibility)
* Stabilize DataGridServiceIT#serviceMonitorTest by implementing condition waiter
  * Starting with OpenShift 4.13 it seems that Prometheus config reloader takes more time to (re)load service monitor config which results in test failure