### PR TITLE
Skip particular XSite tests under certain conditions

### DIFF
--- a/test/e2e/utils/asserts.go
+++ b/test/e2e/utils/asserts.go
@@ -46,3 +46,15 @@ func SkipForMajor(t *testing.T, infinispanMajor uint64, message string) {
 		}
 	}
 }
+
+func SkipForAWS(t *testing.T, message string) {
+	if Infrastructure == "AWS" {
+		t.Skip(message)
+	}
+}
+
+func SkipForOpenShift(t *testing.T, message string) {
+	if Platform == "OpenShift" {
+		t.Skip(message)
+	}
+}

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -37,6 +37,9 @@ var (
 	SuiteMode, _      = strconv.ParseBool(constants.GetEnvWithDefault("SUITE_MODE", "false"))
 	ExposeServiceType = constants.GetEnvWithDefault("EXPOSE_SERVICE_TYPE", string(ispnv1.ExposeTypeNodePort))
 
+	Infrastructure = os.Getenv("TESTING_INFRASTRUCTURE")
+	Platform       = os.Getenv("TESTING_PLATFORM")
+
 	WebServerName       = "external-libs-web-server"
 	WebServerImageName  = "quay.io/openshift-scale/nginx"
 	WebServerRootFolder = "/usr/share/nginx/html"


### PR DESCRIPTION
Introduces environment variables specifying platform and infrastructure test are being executed against so the tests can be skipped in such case and changes `TestSingleGossipRouter` xsite schema type to OpenShift for the ability to run the test against the OpenShift

