### PR TITLE
E2E tests stabilizations

### DIFF
--- a/test/e2e/infinispan/jmx_test.go
+++ b/test/e2e/infinispan/jmx_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestJmxEnabled(t *testing.T) {
+	tutils.SkipForMajor(t, 13, "Enabling JMX in Infinispan 13 is not implemented.")
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
 	replicas := 1

--- a/test/e2e/infinispan/scaling_test.go
+++ b/test/e2e/infinispan/scaling_test.go
@@ -66,7 +66,8 @@ func TestGracefulShutdownWithTwoReplicas(t *testing.T) {
 	volatileKey := "volatileKey"
 	volatileValue := "volatileValue"
 
-	volatileCacheHelper.TestBasicUsage(volatileKey, volatileValue)
+	// Attempt to put entry right after the cluster went back online may result in EOF sometimes due to request not reaching the cluster
+	volatileCacheHelper.TestBasicUsageWithRetry(volatileKey, volatileValue, 5)
 
 	volatileCacheHelper.Delete()
 

--- a/test/e2e/infinispan/spec_update_test.go
+++ b/test/e2e/infinispan/spec_update_test.go
@@ -112,9 +112,7 @@ func TestUpdatePodTargetLabels(t *testing.T) {
 		ispn.ObjectMeta.Annotations = map[string]string{
 			ispnv1.PodTargetLabels: podLabel,
 		}
-		ispn.ObjectMeta.Labels = map[string]string{
-			podLabel: "value",
-		}
+		ispn.ObjectMeta.Labels[podLabel] = "value"
 	}
 	var verifier = func(ispn *ispnv1.Infinispan, ss *appsv1.StatefulSet) {
 		labels := ss.Spec.Template.ObjectMeta.Labels

--- a/test/e2e/utils/asserts.go
+++ b/test/e2e/utils/asserts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/blang/semver"
 	"k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -42,6 +43,16 @@ func SkipForMajor(t *testing.T, infinispanMajor uint64, message string) {
 	if OperandVersion != "" {
 		operand, _ := VersionManager().WithRef(OperandVersion)
 		if operand.UpstreamVersion.Major == infinispanMajor {
+			t.Skip(message)
+		}
+	}
+}
+
+func SkipPriorTo(t *testing.T, version, message string) {
+	if OperandVersion != "" {
+		operand_cur, _ := VersionManager().WithRef(OperandVersion)
+		version_min, _ := semver.Parse(version)
+		if operand_cur.UpstreamVersion.LE(version_min) {
 			t.Skip(message)
 		}
 	}

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -1055,7 +1055,7 @@ func (k TestKubernetes) WaitForValidBackupPhase(name, namespace string, phase is
 	ExpectNoError(err)
 }
 
-func (k TestKubernetes) WaitForValidRestorePhase(name, namespace string, phase ispnv2.RestorePhase) {
+func (k TestKubernetes) WaitForValidRestorePhase(name, namespace string, phase ispnv2.RestorePhase) error {
 	var restore *ispnv2.Restore
 	err := wait.Poll(10*time.Millisecond, TestTimeout, func() (bool, error) {
 		restore = k.GetRestore(name, namespace)
@@ -1067,7 +1067,7 @@ func (k TestKubernetes) WaitForValidRestorePhase(name, namespace string, phase i
 	if err != nil {
 		println(fmt.Sprintf("Expected Restore Phase %s, got %s:%s", phase, restore.Status.Phase, restore.Status.Reason))
 	}
-	ExpectNoError(err)
+	return err
 }
 
 // GetUsedNodePorts returns a set of NodePorts currently in use by the cluster


### PR DESCRIPTION
Fixes several E2E tests to reduce noise in the test results:
* **TestJmxEnabled**
  * Skip the test if the test is executed against Infinispan 13
* **TestUpdatePodTargetLabels**
  * The test removed the 'testname' labels used to clean up resources after the execution
* **BackupRestoreTests**
  * The test occasionally fails with ISPN-15173 when running against older Infinispan versions. Given the issue won't be fixed, just skip the test when the error with this message pops up
* **TestGracefulShutdownWithTwoReplicas**
  * It's possible for the test to fail the PUT request with EOF right after the cluster was brought back up. The issue randomly appears only when the test is executed as part of the whole testsuite. Debugging showed up that in the occasions the EOF happens the request does not reach the cluster which suggests that there is some race condition between routing network in the OpenShift and executing the request. Fixed by retrying the request.