### PR TITLE
Change the default timestamp format in the operator logging

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,8 @@ spec:
           args:
             - operator
             - --leader-elect
+            - --zap-time-encoding
+            - rfc3339
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/config_listener.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/config_listener.go
@@ -189,6 +189,8 @@ func ConfigListener(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			i.Name,
 			"-zap-log-level",
 			string(i.Spec.ConfigListener.Logging.Level),
+			"-zap-time-encoding",
+			"rfc3339",
 		},
 		Env: []corev1.EnvVar{{Name: "INFINISPAN_OPERAND_VERSIONS", Value: operandVersions}},
 	}


### PR DESCRIPTION
Fixes #1962