### PR TITLE
Indexed HotRod Rolling Upgrades fail when cache name is sorted before ___protobuf_metadata cache

### DIFF
--- a/pkg/infinispan/client/api/infinispan.go
+++ b/pkg/infinispan/client/api/infinispan.go
@@ -15,6 +15,8 @@ type Infinispan interface {
 	Container() Container
 	Logging() Logging
 	Metrics() Metrics
+	ProtobufMetadataCacheName() string
+	ScriptCacheName() string
 	Server() Server
 }
 

--- a/pkg/infinispan/client/v13/infinispan_v13.go
+++ b/pkg/infinispan/client/v13/infinispan_v13.go
@@ -39,6 +39,14 @@ func (i *infinispan) Metrics() api.Metrics {
 	return &metrics{i.HttpClient}
 }
 
+func (i *infinispan) ProtobufMetadataCacheName() string {
+	return "___protobuf_metadata"
+}
+
+func (i *infinispan) ScriptCacheName() string {
+	return "___script_cache"
+}
+
 func (i *infinispan) Server() api.Server {
 	return &server{i.HttpClient}
 }

--- a/pkg/infinispan/client/v14/infinispan_v14.go
+++ b/pkg/infinispan/client/v14/infinispan_v14.go
@@ -41,6 +41,14 @@ func (i *infinispan) Metrics() api.Metrics {
 	return i.ispn13.Metrics()
 }
 
+func (i *infinispan) ProtobufMetadataCacheName() string {
+	return i.ispn13.ProtobufMetadataCacheName()
+}
+
+func (i *infinispan) ScriptCacheName() string {
+	return i.ispn13.ScriptCacheName()
+}
+
 func (i *infinispan) Server() api.Server {
 	return i.ispn13.Server()
 }

--- a/pkg/infinispan/version/version.go
+++ b/pkg/infinispan/version/version.go
@@ -56,6 +56,13 @@ func (o Operand) EQ(other Operand) bool {
 	return o.UpstreamVersion.EQ(*other.UpstreamVersion)
 }
 
+func (o Operand) GTE(other Operand) bool {
+	if o.DownstreamVersion != nil {
+		return o.DownstreamVersion.GTE(*other.DownstreamVersion)
+	}
+	return o.UpstreamVersion.GTE(*other.UpstreamVersion)
+}
+
 func (o Operand) LT(other Operand) bool {
 	if o.DownstreamVersion != nil {
 		return o.DownstreamVersion.LT(*other.DownstreamVersion)


### PR DESCRIPTION
This requires https://github.com/infinispan/infinispan/pull/11921and a new Infinispan image release before it can be merged.