### PR TITLE
OOM failover test fix

### DIFF
--- a/test/e2e/infinispan/failover_test.go
+++ b/test/e2e/infinispan/failover_test.go
@@ -64,7 +64,7 @@ func TestPodDegradationAfterOOM(t *testing.T) {
 			if containerStatuses.LastTerminationState.Terminated != nil {
 				terminatedPod := containerStatuses.LastTerminationState.Terminated
 
-				if terminatedPod.Reason == "OOMKilled" {
+				if terminatedPod.Reason == "OOMKilled" || terminatedPod.ExitCode == 137 {
 					hasOOMhappened = true
 					fmt.Printf("ExitCode='%d' Reason='%s' Message='%s'\n", terminatedPod.ExitCode, terminatedPod.Reason, terminatedPod.Message)
 					break out


### PR DESCRIPTION
`TestPodDegradationAfterOOM` on OpenShift 4.15 no longer seems to fail with `OOMKilled` but rather provides exit code 137 which indicates it was abruptly terminated by external signal.