### PR TITLE
[test-integration] CustomLibsIT Multi-Attach error fix

### DIFF
--- a/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
+++ b/test-integration/operator-tests/src/test/java/org/infinispan/operator/CustomLibsIT.java
@@ -35,6 +35,7 @@ public class CustomLibsIT {
 
         buildLibs();
         uploadLibs();
+        deletePod();
 
         infinispan.deploy();
         infinispan.waitFor();
@@ -44,7 +45,6 @@ public class CustomLibsIT {
     static void undeploy() throws Exception {
         infinispan.delete();
 
-        openShift.pods().withLabel("app", "infinispan-libs").delete();
         openShift.persistentVolumeClaims().withLabel("app", "infinispan-libs").delete();
         openShift.events().delete();
     }
@@ -121,5 +121,9 @@ public class CustomLibsIT {
         File file = new File("src/test/resources/libs/custom-filter/target/custom-filter-1.0.jar");
 
         openShift.pods().withName("infinispan-libs").file("/tmp/libs/custom-filter-1.0.jar").upload(file.toPath());
+    }
+
+    private static void deletePod() {
+        openShift.pods().withLabel("app", "infinispan-libs").delete();
     }
 }


### PR DESCRIPTION
Mounting a PV with ReadWriteOnce access mode is not possible from multiple k8s nodes. In the context of test it may cause an issue if the uploading pod is taking most of the space on the node not allowing for Infinispan node to be scheduled on the same node and result in Multi-Attach error as a result.

**Fix:** Delete the pod created to upload the libs for the cluster after the upload is complete.