### PR TITLE
Deprecate Infinispan 13.0.10 Operand for removal in 2.4.3.CSV

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -54,7 +54,8 @@ spec:
                 [
                   {
                     "upstream-version": "13.0.10",
-                    "image": "quay.io/infinispan/server:13.0.10.Final"
+                    "image": "quay.io/infinispan/server:13.0.10.Final",
+                    "deprecated": true
                   },
                   {
                     "upstream-version": "14.0.1",


### PR DESCRIPTION
@rigazilla I realised that we still have 13.0.10 in our list of Operands, I have marked this as deprecated so that we can remove this in the release after next. The 13.0.10 server is no longer supported and no security updates are provided, so we should not longer bundle this with the Operator #2075.