### PR TITLE
Avoid spec.autoscale to be set. Fixes #2079

### DIFF
--- a/api/v1/infinispan_webhook.go
+++ b/api/v1/infinispan_webhook.go
@@ -288,6 +288,12 @@ func (i *Infinispan) validate() error {
 		allErrs = append(allErrs, err)
 	}
 
+	if i.Spec.Autoscale != nil {
+		msg := "Autoscale is no longer supported. Please remove spec.autoscale field."
+		err := field.Forbidden(field.NewPath("spec").Child("autoscale"), msg)
+		allErrs = append(allErrs, err)
+	}
+
 	if i.IsEncryptionEnabled() {
 		e := i.Spec.Security.EndpointEncryption
 		if e.CertSecretName == "" {

--- a/api/v1/infinispan_webhook_test.go
+++ b/api/v1/infinispan_webhook_test.go
@@ -71,6 +71,22 @@ var _ = Describe("Infinispan Webhooks", func() {
 			expectInvalidErrStatus(err, statusDetailCause{"FieldValueForbidden", "spec.service.type", "CacheService is no longer supported."})
 		})
 
+		It("Should return an error if spec.autoscale is enabled", func() {
+
+			failed := &Infinispan{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+				Spec: InfinispanSpec{
+					Replicas:  1,
+					Autoscale: &Autoscale{MaxReplicas: 3},
+				},
+			}
+			err := k8sClient.Create(ctx, failed)
+			expectInvalidErrStatus(err, statusDetailCause{"FieldValueForbidden", "spec.autoscale", "Autoscale is no longer supported."})
+		})
+
 		It("Should initiate DataGrid defaults", func() {
 
 			created := &Infinispan{

--- a/controllers/constants/constants.go
+++ b/controllers/constants/constants.go
@@ -113,8 +113,6 @@ const (
 )
 
 const (
-	// DefaultMinimumAutoscalePollPeriod minimum period for autoscaler polling loop
-	DefaultMinimumAutoscalePollPeriod = 5 * time.Second
 	//DefaultWaitOnCluster delay for the Infinispan cluster wait if it not created while Cache creation
 	DefaultWaitOnCluster = 10 * time.Second
 	// DefaultWaitOnCreateResource delay for wait until resource (Secret, ConfigMap, Service) is created

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
@@ -54,6 +54,11 @@ func OperatorStatusChecks(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	}
 	// Pod name is changed, means operator restarted
 	if i.Status.Operator.Pod != operatorPod {
+		if i.Spec.Autoscale != nil {
+			errMsg := "Autoscale is no longer supported. Please remove spec.autoscale field."
+			ctx.EventRecorder().Event(i, corev1.EventTypeWarning, "AutoscaleNotSupported", errMsg)
+			ctx.Log().Error(fmt.Errorf("AutoscaleNotSupported"), errMsg)
+		}
 		ctx.Requeue(
 			ctx.UpdateInfinispan(func() {
 				i.Status.Operator.Pod = operatorPod


### PR DESCRIPTION
Block setting of spec.autoscale on new cr and emit error log during operator upgrade if spec.autoscale is not nil

#2079 
