### PR TITLE
Operator is using deprecated cache-managers endpoint for health check…

### DIFF
--- a/pkg/infinispan/client/api/infinispan.go
+++ b/pkg/infinispan/client/api/infinispan.go
@@ -154,6 +154,7 @@ type BackupRestoreResources struct {
 type ContainerInfo struct {
 	Coordinator bool           `json:"coordinator"`
 	SitesView   *[]interface{} `json:"sites_view,omitempty"`
+	Version     string         `json:"version"`
 }
 
 type NotSupportedError struct {
@@ -162,4 +163,12 @@ type NotSupportedError struct {
 
 func (n *NotSupportedError) Error() string {
 	return fmt.Sprintf("Operation not supported with Operand Major Version'%s'", n.Version)
+}
+
+type PathResolver interface {
+	Caches(string) string
+	CacheManager(string) string
+	Container(string) string
+	Logging(string) string
+	Server(string) string
 }

--- a/pkg/infinispan/client/v13/backups_restores.go
+++ b/pkg/infinispan/client/v13/backups_restores.go
@@ -12,39 +12,40 @@ import (
 	"github.com/infinispan/infinispan-operator/pkg/mime"
 )
 
-const (
-	BackupPath  = CacheManagerPath + "/backups"
-	RestorePath = CacheManagerPath + "/restores"
-)
-
 var validator = inputValidator.New()
 
 type backups struct {
+	api.PathResolver
 	httpClient.HttpClient
 }
 
 type restores struct {
+	api.PathResolver
 	httpClient.HttpClient
 }
 
 func (b backups) Create(name string, config *api.BackupConfig) (err error) {
-	url := fmt.Sprintf("%s/%s", BackupPath, name)
-	return create(url, name, "backup", config, b)
+	return create(b.backup(name), name, "backup", config, b)
 }
 
 func (b backups) Status(name string) (api.Status, error) {
-	url := fmt.Sprintf("%s/%s", BackupPath, name)
-	return status(url, name, "Backup", b)
+	return status(b.backup(name), name, "Backup", b)
 }
 
 func (r restores) Create(name string, config *api.RestoreConfig) (err error) {
-	url := fmt.Sprintf("%s/%s", RestorePath, name)
-	return create(url, name, "restore", config, r)
+	return create(r.restore(name), name, "restore", config, r)
 }
 
 func (r restores) Status(name string) (api.Status, error) {
-	url := fmt.Sprintf("%s/%s", RestorePath, name)
-	return status(url, name, "Restore", r)
+	return status(r.restore(name), name, "Restore", r)
+}
+
+func (b backups) backup(name string) string {
+	return b.CacheManager("/backups/" + name)
+}
+
+func (r restores) restore(name string) string {
+	return r.CacheManager("/restores/" + name)
 }
 
 func create(url, name, op string, config interface{}, client httpClient.HttpClient) (err error) {

--- a/pkg/infinispan/client/v13/caches.go
+++ b/pkg/infinispan/client/v13/caches.go
@@ -14,19 +14,19 @@ import (
 	"github.com/infinispan/infinispan-operator/pkg/mime"
 )
 
-const CachesPath = BasePath + "/caches"
-
 type cache struct {
+	api.PathResolver
 	httpClient.HttpClient
 	name string
 }
 
 type caches struct {
+	api.PathResolver
 	httpClient.HttpClient
 }
 
 func (c *cache) url() string {
-	return fmt.Sprintf("%s/%s", CachesPath, url.PathEscape(c.name))
+	return fmt.Sprintf("%s/%s", c.Caches(""), url.PathEscape(c.name))
 }
 
 func (c *cache) entryUrl(key string) string {
@@ -172,7 +172,7 @@ func (c *cache) UpdateConfig(config string, contentType mime.MimeType) (err erro
 }
 
 func (c *caches) ConvertConfiguration(config string, contentType mime.MimeType, reqType mime.MimeType) (transformed string, err error) {
-	path := CachesPath + "?action=convert"
+	path := c.Caches("?action=convert")
 	headers := map[string]string{
 		"Accept":       string(reqType),
 		"Content-Type": string(contentType),
@@ -196,7 +196,7 @@ func (c *caches) EqualConfiguration(_, _ string) (bool, error) {
 }
 
 func (c *caches) Names() (names []string, err error) {
-	rsp, err := c.Get(CachesPath, nil)
+	rsp, err := c.Get(c.Caches(""), nil)
 	if err = httpClient.ValidateResponse(rsp, err, "getting caches", http.StatusOK); err != nil {
 		return
 	}

--- a/pkg/infinispan/client/v13/infinispan_v13.go
+++ b/pkg/infinispan/client/v13/infinispan_v13.go
@@ -7,32 +7,36 @@ import (
 )
 
 const (
-	BasePath     = "rest/v2"
 	MajorVersion = "13"
 )
 
 type infinispan struct {
+	api.PathResolver
 	http.HttpClient
 }
 
 func New(client http.HttpClient) api.Infinispan {
-	return &infinispan{client}
+	return NewWithPathResolver(client, NewPathResolver())
+}
+
+func NewWithPathResolver(client http.HttpClient, pathResolver api.PathResolver) api.Infinispan {
+	return &infinispan{pathResolver, client}
 }
 
 func (i *infinispan) Cache(name string) api.Cache {
-	return &cache{i.HttpClient, name}
+	return &cache{i.PathResolver, i.HttpClient, name}
 }
 
 func (i *infinispan) Caches() api.Caches {
-	return &caches{i.HttpClient}
+	return &caches{i.PathResolver, i.HttpClient}
 }
 
 func (i *infinispan) Container() api.Container {
-	return &container{i.HttpClient}
+	return &Container{i.PathResolver, i.HttpClient}
 }
 
 func (i *infinispan) Logging() api.Logging {
-	return &logging{i.HttpClient}
+	return &logging{i.PathResolver, i.HttpClient}
 }
 
 func (i *infinispan) Metrics() api.Metrics {
@@ -48,5 +52,5 @@ func (i *infinispan) ScriptCacheName() string {
 }
 
 func (i *infinispan) Server() api.Server {
-	return &server{i.HttpClient}
+	return &server{i.PathResolver, i.HttpClient}
 }

--- a/pkg/infinispan/client/v13/logging.go
+++ b/pkg/infinispan/client/v13/logging.go
@@ -7,16 +7,16 @@ import (
 	"strings"
 
 	httpClient "github.com/infinispan/infinispan-operator/pkg/http"
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
 )
 
-const LoggersPath = BasePath + "/logging/loggers"
-
 type logging struct {
+	api.PathResolver
 	httpClient.HttpClient
 }
 
 func (l *logging) GetLoggers() (lm map[string]string, err error) {
-	rsp, err := l.Get(LoggersPath, nil)
+	rsp, err := l.Get(l.Logging(""), nil)
 	defer func() {
 		err = httpClient.CloseBody(rsp, err)
 	}()
@@ -43,7 +43,7 @@ func (l *logging) GetLoggers() (lm map[string]string, err error) {
 }
 
 func (l *logging) SetLogger(name, level string) error {
-	path := fmt.Sprintf("%s/%s?level=%s", LoggersPath, name, strings.ToUpper(level))
+	path := l.Logging(fmt.Sprintf("/%s?level=%s", name, strings.ToUpper(level)))
 	rsp, err := l.Put(path, "", nil)
 	defer func() {
 		err = httpClient.CloseBody(rsp, err)

--- a/pkg/infinispan/client/v13/path_resolver.go
+++ b/pkg/infinispan/client/v13/path_resolver.go
@@ -1,0 +1,31 @@
+package v13
+
+import "github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
+
+func NewPathResolver() api.PathResolver {
+	return &pathResolver{Root: "rest/v2"}
+}
+
+type pathResolver struct {
+	Root string
+}
+
+func (r *pathResolver) Caches(s string) string {
+	return r.Root + "/caches" + s
+}
+
+func (r *pathResolver) CacheManager(s string) string {
+	return r.Root + "/cache-managers/default" + s
+}
+
+func (r *pathResolver) Container(s string) string {
+	return r.Root + "/container" + s
+}
+
+func (r *pathResolver) Logging(s string) string {
+	return r.Root + "/logging/loggers" + s
+}
+
+func (r *pathResolver) Server(s string) string {
+	return r.Root + "/server" + s
+}

--- a/pkg/infinispan/client/v13/server.go
+++ b/pkg/infinispan/client/v13/server.go
@@ -4,16 +4,16 @@ import (
 	"net/http"
 
 	httpClient "github.com/infinispan/infinispan-operator/pkg/http"
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
 )
 
-const ServerPath = BasePath + "/server"
-
 type server struct {
+	api.PathResolver
 	httpClient.HttpClient
 }
 
 func (s *server) Stop() (err error) {
-	rsp, err := s.Post(ServerPath+"?action=stop", "", nil)
+	rsp, err := s.Post(s.Server("?action=stop"), "", nil)
 	defer func() {
 		err = httpClient.CloseBody(rsp, err)
 	}()

--- a/pkg/infinispan/client/v13/xsite.go
+++ b/pkg/infinispan/client/v13/xsite.go
@@ -6,16 +6,17 @@ import (
 	"net/http"
 
 	httpClient "github.com/infinispan/infinispan-operator/pkg/http"
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
 )
-
-const XSitePath = CacheManagerPath + "/x-site/backups"
 
 type xsite struct {
 	httpClient.HttpClient
+	api.PathResolver
 }
 
 func (x *xsite) PushAllState() (err error) {
-	rsp, err := x.Get(XSitePath, nil)
+	xsitePath := x.CacheManager("/x-site/backups")
+	rsp, err := x.Get(xsitePath, nil)
 	if err = httpClient.ValidateResponse(rsp, err, "Retrieving xsite status", http.StatusOK); err != nil {
 		return
 	}
@@ -38,7 +39,7 @@ func (x *xsite) PushAllState() (err error) {
 	// Statuses will be empty if no xsite caches are configured
 	for k, v := range statuses {
 		if v.Status == "online" {
-			url := fmt.Sprintf("%s/%s?action=start-push-state", XSitePath, k)
+			url := fmt.Sprintf("%s/%s?action=start-push-state", xsitePath, k)
 			rsp, err = x.Post(url, "", nil)
 			if err = httpClient.ValidateResponse(rsp, err, "Pushing xsite state", http.StatusOK); err != nil {
 				return

--- a/pkg/infinispan/client/v14/caches.go
+++ b/pkg/infinispan/client/v14/caches.go
@@ -5,16 +5,16 @@ import (
 
 	httpClient "github.com/infinispan/infinispan-operator/pkg/http"
 	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
-	v13 "github.com/infinispan/infinispan-operator/pkg/infinispan/client/v13"
 )
 
 type caches struct {
 	httpClient.HttpClient
 	api.Caches
+	api.PathResolver
 }
 
 func (c *caches) EqualConfiguration(a, b string) (bool, error) {
-	path := v13.CachesPath + "?action=compare"
+	path := c.PathResolver.Caches("?action=compare")
 	parts := map[string]string{
 		"a": a,
 		"b": b,

--- a/pkg/infinispan/client/v14/infinispan_v14.go
+++ b/pkg/infinispan/client/v14/infinispan_v14.go
@@ -9,12 +9,18 @@ import (
 type infinispan struct {
 	http.HttpClient
 	ispn13 api.Infinispan
+	api.PathResolver
 }
 
 func New(client http.HttpClient) api.Infinispan {
+	return NewWithPathResolver(client, v13.NewPathResolver())
+}
+
+func NewWithPathResolver(client http.HttpClient, pathResolver api.PathResolver) api.Infinispan {
 	return &infinispan{
-		HttpClient: client,
-		ispn13:     v13.New(client),
+		HttpClient:   client,
+		ispn13:       v13.NewWithPathResolver(client, pathResolver),
+		PathResolver: pathResolver,
 	}
 }
 
@@ -24,8 +30,9 @@ func (i *infinispan) Cache(name string) api.Cache {
 
 func (i *infinispan) Caches() api.Caches {
 	return &caches{
-		HttpClient: i.HttpClient,
-		Caches:     i.ispn13.Caches(),
+		HttpClient:   i.HttpClient,
+		Caches:       i.ispn13.Caches(),
+		PathResolver: i.PathResolver,
 	}
 }
 

--- a/pkg/infinispan/client/v15/infinispan_v15.go
+++ b/pkg/infinispan/client/v15/infinispan_v15.go
@@ -1,0 +1,19 @@
+package v15
+
+import (
+	"github.com/infinispan/infinispan-operator/pkg/http"
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
+	v14 "github.com/infinispan/infinispan-operator/pkg/infinispan/client/v14"
+)
+
+type infinispan struct {
+	http.HttpClient
+	api.Infinispan
+}
+
+func New(client http.HttpClient) api.Infinispan {
+	return &infinispan{
+		HttpClient: client,
+		Infinispan: v14.NewWithPathResolver(client, NewPathResolver()),
+	}
+}

--- a/pkg/infinispan/client/v15/path_resolver.go
+++ b/pkg/infinispan/client/v15/path_resolver.go
@@ -1,0 +1,18 @@
+package v15
+
+import (
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/client/api"
+	v13 "github.com/infinispan/infinispan-operator/pkg/infinispan/client/v13"
+)
+
+func NewPathResolver() api.PathResolver {
+	return &pathResolver{v13.NewPathResolver()}
+}
+
+type pathResolver struct {
+	api.PathResolver
+}
+
+func (r *pathResolver) CacheManager(s string) string {
+	return r.Container(s)
+}

--- a/pkg/reconcile/pipeline/infinispan/api.go
+++ b/pkg/reconcile/pipeline/infinispan/api.go
@@ -83,6 +83,9 @@ type Context interface {
 	// InfinispanClientForPod returns a client for the specific pod
 	InfinispanClientForPod(podName string) ispnApi.Infinispan
 
+	// InfinispanClientUnknownVersion returns a client for a specified pod based upon the version returned by the server
+	InfinispanClientUnknownVersion(podName string) (ispnApi.Infinispan, error)
+
 	// InfinispanPods returns all pods associated with the Infinispan cluster's StatefulSet
 	// The list is created Lazily and cached per Pipeline execution to prevent repeated calls to retrieve the cluster pods
 	// If an error is returned, then RetryProcessing is automatically set

--- a/pkg/reconcile/pipeline/infinispan/api_mocks.go
+++ b/pkg/reconcile/pipeline/infinispan/api_mocks.go
@@ -270,6 +270,21 @@ func (mr *MockContextMockRecorder) InfinispanClientForPod(podName interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfinispanClientForPod", reflect.TypeOf((*MockContext)(nil).InfinispanClientForPod), podName)
 }
 
+// InfinispanClientUnknownVersion mocks base method.
+func (m *MockContext) InfinispanClientUnknownVersion(podName string) (api.Infinispan, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InfinispanClientUnknownVersion", podName)
+	ret0, _ := ret[0].(api.Infinispan)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// InfinispanClientUnknownVersion indicates an expected call of InfinispanClientUnknownVersion.
+func (mr *MockContextMockRecorder) InfinispanClientUnknownVersion(podName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InfinispanClientUnknownVersion", reflect.TypeOf((*MockContext)(nil).InfinispanClientUnknownVersion), podName)
+}
+
 // InfinispanPods mocks base method.
 func (m *MockContext) InfinispanPods() (*v10.PodList, error) {
 	m.ctrl.T.Helper()

--- a/pkg/reconcile/pipeline/infinispan/context/context.go
+++ b/pkg/reconcile/pipeline/infinispan/context/context.go
@@ -113,6 +113,11 @@ func (c *contextImpl) InfinispanClientForPod(podName string) api.Infinispan {
 	return ispnClient.New(c.Operand(), curlClient)
 }
 
+func (c *contextImpl) InfinispanClientUnknownVersion(podName string) (api.Infinispan, error) {
+	curlClient := c.curlClient(podName)
+	return ispnClient.NewUnknownVersion(curlClient)
+}
+
 func (c *contextImpl) InfinispanPods() (*corev1.PodList, error) {
 	if c.ispnPods == nil {
 		statefulSet := &appsv1.StatefulSet{}

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
@@ -122,7 +122,11 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 				}
 
 				for idx, pod := range podList.Items {
-					ispnClient := ctx.InfinispanClientForPod(pod.Name)
+					ispnClient, err := ctx.InfinispanClientUnknownVersion(pod.Name)
+					if err != nil {
+						ctx.Requeue(fmt.Errorf("unable to create Infinispan client for cluster being upgraded: %w", err))
+						return
+					}
 					if idx == 0 {
 						if err := ispnClient.Container().RebalanceDisable(); err != nil {
 							ctx.Requeue(fmt.Errorf("unable to disable rebalancing: %w", err))

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -85,7 +85,8 @@ func TestRollingUpgrade(t *testing.T) {
 	testKube.Create(spec)
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	spec = testKube.WaitForInfinispanCondition(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed)
-	client := tutils.HTTPClientForCluster(spec, testKube)
+	versionManager := testKube.VersionManagerFromCSV(sub)
+	client := tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
 
 	// Create caches
 	createCache("textCache", mime.TextPlain, client)
@@ -118,17 +119,7 @@ func TestRollingUpgrade(t *testing.T) {
 		// https://github.com/infinispan/infinispan-operator/issues/1719
 		time.Sleep(time.Minute)
 
-		operands := func() *version.Manager {
-			testKube.SetRelatedImagesEnvs(sub)
-			operandVersions := testKube.InstalledCSVEnv(ispnv1.OperatorOperandVersionEnvVarName, sub)
-			if operandVersions == "" {
-				panic(fmt.Sprintf("%s env empty, cannot continue", ispnv1.OperatorOperandVersionEnvVarName))
-			}
-			versionManager, err := version.ManagerFromJson(operandVersions)
-			tutils.ExpectNoError(err)
-			return versionManager
-		}
-
+		versionManager = testKube.VersionManagerFromCSV(sub)
 		assertMigration := func(expectedImage string, isRollingUpgrade, indexedSupported bool) {
 			if !isRollingUpgrade {
 				clusterCounter++
@@ -147,7 +138,8 @@ func TestRollingUpgrade(t *testing.T) {
 				}
 			}
 
-			if !tutils.CheckExternalAddress(client) {
+			operand := tutils.Operand(spec.Spec.Version, versionManager)
+			if !tutils.CheckExternalAddress(client, operand) {
 				panic("Error contacting server")
 			}
 
@@ -171,7 +163,7 @@ func TestRollingUpgrade(t *testing.T) {
 			}
 
 			// This is the first upgrade to an Operator with multi-operand support, so wait for the oldest Operand
-			oldestOperand := operands().Oldest()
+			oldestOperand := versionManager.Oldest()
 			ispnPreUpgrade = testKube.WaitForInfinispanState(spec.Name, spec.Namespace, func(i *ispnv1.Infinispan) bool {
 				return i.IsConditionTrue(ispnv1.ConditionWellFormed) &&
 					i.Status.Operand.Version == oldestOperand.Ref() &&
@@ -188,9 +180,9 @@ func TestRollingUpgrade(t *testing.T) {
 			}
 		}
 
-		versionManager := operands()
 		latestOperand := versionManager.Latest()
 		currentOperand, err := versionManager.WithRef(ispnPreUpgrade.Spec.Version)
+		client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
 		tutils.ExpectNoError(err)
 		if !currentOperand.EQ(latestOperand) {
 			ispn := testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
@@ -214,7 +206,7 @@ func TestRollingUpgrade(t *testing.T) {
 					i.Status.Operand.Image == latestOperand.Image &&
 					i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
 			})
-			lastOperand, err := operands().WithRef(ispnPreUpgrade.Status.Operand.Version)
+			lastOperand, err := versionManager.WithRef(ispnPreUpgrade.Status.Operand.Version)
 			tutils.ExpectNoError(err)
 			isRolling := latestOperand.CVE && lastOperand.UpstreamVersion.EQ(*latestOperand.UpstreamVersion)
 			assertMigration(latestOperand.Image, isRolling, indexSupported)

--- a/test/e2e/infinispan/authentication_test.go
+++ b/test/e2e/infinispan/authentication_test.go
@@ -111,7 +111,7 @@ func TestExplicitCredentials(t *testing.T) {
 }
 
 func testAuthentication(ispn *ispnv1.Infinispan, schema, usr, pass string) {
-	client_ := testKube.WaitForExternalService(ispn, tutils.RouteTimeout, tutils.NewHTTPClient(usr, pass, schema))
+	client_ := testKube.WaitForExternalService(ispn, tutils.RouteTimeout, tutils.NewHTTPClient(usr, pass, schema), nil)
 
 	badCredClient := tutils.NewHTTPClient("badUser", "badPass", schema)
 	badCredClient.SetHostAndPort(client_.GetHostAndPort())
@@ -168,7 +168,7 @@ func TestAuthenticationDisabled(t *testing.T) {
 
 	// Ensure that rest requests do not require authentication
 	schema := testKube.GetSchemaForRest(spec)
-	client_ := testKube.WaitForExternalService(spec, tutils.RouteTimeout, tutils.NewHTTPClientNoAuth(schema))
+	client_ := testKube.WaitForExternalService(spec, tutils.RouteTimeout, tutils.NewHTTPClientNoAuth(schema), nil)
 	rsp, err := client_.Get("rest/v2/caches", nil)
 	tutils.ExpectNoError(err)
 	if rsp.StatusCode != http.StatusOK {

--- a/test/e2e/infinispan/authorization_test.go
+++ b/test/e2e/infinispan/authorization_test.go
@@ -115,7 +115,7 @@ func testAuthorization(ispn *v1.Infinispan, createIdentities func() users.Identi
 	schema := testKube.GetSchemaForRest(ispn)
 	user := identities.Credentials[0].Username
 	pass := identities.Credentials[0].Password
-	client_ := testKube.WaitForExternalService(ispn, tutils.RouteTimeout, tutils.NewHTTPClient(user, pass, schema))
+	client_ := testKube.WaitForExternalService(ispn, tutils.RouteTimeout, tutils.NewHTTPClient(user, pass, schema), nil)
 
 	// Verify authorization works as expected
 	verify(client_)

--- a/test/e2e/utils/cache.go
+++ b/test/e2e/utils/cache.go
@@ -152,7 +152,7 @@ func (c *CacheHelper) Available(available bool) {
 	} else {
 		availability = "DEGRADED_MODE"
 	}
-	path := fmt.Sprintf("%s/%s?action=set-availability&availability=%s", v13.CachesPath, url.PathEscape(c.CacheName), availability)
+	path := v13.NewPathResolver().Caches(fmt.Sprintf("/%s?action=set-availability&availability=%s", url.PathEscape(c.CacheName), availability))
 	_, err := c.Client.Post(path, "", nil)
 	ExpectNoError(err)
 }

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -395,7 +395,11 @@ func clientForCluster(i *ispnv1.Infinispan, kube *TestKubernetes) HTTPClient {
 }
 
 func HTTPClientForCluster(i *ispnv1.Infinispan, kube *TestKubernetes) HTTPClient {
-	return kube.WaitForExternalService(i, RouteTimeout, clientForCluster(i, kube))
+	return HTTPClientForClusterWithVersionManager(i, kube, nil)
+}
+
+func HTTPClientForClusterWithVersionManager(i *ispnv1.Infinispan, kube *TestKubernetes, manager *version.Manager) HTTPClient {
+	return kube.WaitForExternalService(i, RouteTimeout, clientForCluster(i, kube), manager)
 }
 
 func HTTPSClientForCluster(i *ispnv1.Infinispan, tlsConfig *tls.Config, kube *TestKubernetes) HTTPClient {
@@ -424,5 +428,15 @@ func HTTPSClientForCluster(i *ispnv1.Infinispan, tlsConfig *tls.Config, kube *Te
 			client = NewClient(authNone, nil, nil, "https", tlsConfig)
 		}
 	}
-	return kube.WaitForExternalService(i, RouteTimeout, client)
+	return kube.WaitForExternalService(i, RouteTimeout, client, nil)
+}
+
+// Operand replicates the semantics of InitialiseOperandVersion pipeline handler for determing Operand version when no version is explicitly provided
+func Operand(ref string, manager *version.Manager) version.Operand {
+	if ref == "" {
+		return manager.Oldest()
+	}
+	operand, err := manager.WithRef(ref)
+	ExpectNoError(err)
+	return operand
 }


### PR DESCRIPTION
This PR introduces a PathResolver interface which allows the urls of the various server resources to be abstracted so that we don't need to duplicate resource logic between versions when the path has changed but the semantics remain the same.