### PR TITLE
Do not assume latest Operand in tests

### DIFF
--- a/test/e2e/batch/batch_test.go
+++ b/test/e2e/batch/batch_test.go
@@ -46,7 +46,7 @@ func testBatchInlineConfig(t *testing.T, infinispan *v1.Infinispan) {
 	helper.WaitForValidBatchPhase(name, v2.BatchSucceeded)
 
 	httpClient := tutils.HTTPClientForCluster(infinispan, testKube)
-	ispn := ispnClient.New(tutils.LatestOperand, httpClient)
+	ispn := ispnClient.New(tutils.CurrentOperand, httpClient)
 	assertCacheExists("batch-cache", ispn)
 	assertCounterExists("batch-counter", ispn)
 	testKube.DeleteBatch(batch)
@@ -80,7 +80,7 @@ func TestBatchConfigMap(t *testing.T) {
 	waitForK8sResourceCleanup(infinispan.Name)
 
 	httpClient := tutils.HTTPClientForCluster(infinispan, testKube)
-	ispn := ispnClient.New(tutils.LatestOperand, httpClient)
+	ispn := ispnClient.New(tutils.CurrentOperand, httpClient)
 	assertCacheExists("batch-cache", ispn)
 	assertCounterExists("batch-counter", ispn)
 }

--- a/test/e2e/infinispan/authentication_test.go
+++ b/test/e2e/infinispan/authentication_test.go
@@ -131,7 +131,7 @@ func testAuthentication(ispn *ispnv1.Infinispan, schema, usr, pass string) {
 }
 
 func createCacheBadCreds(cacheName string, client tutils.HTTPClient) {
-	err := ispnClient.New(tutils.LatestOperand, client).Cache(cacheName).Create("", mime.ApplicationYaml)
+	err := ispnClient.New(tutils.CurrentOperand, client).Cache(cacheName).Create("", mime.ApplicationYaml)
 	if err == nil {
 		panic("Cache creation should fail")
 	}

--- a/test/e2e/infinispan/authorization_test.go
+++ b/test/e2e/infinispan/authorization_test.go
@@ -31,7 +31,7 @@ func TestAuthorizationDisabledByDefault(t *testing.T) {
 	}
 
 	verify := func(client tutils.HTTPClient) {
-		_, err := ispnClient.New(tutils.LatestOperand, client).Caches().Names()
+		_, err := ispnClient.New(tutils.CurrentOperand, client).Caches().Names()
 		tutils.ExpectNoError(err)
 	}
 	testAuthorization(ispn, identities, verify)

--- a/test/e2e/infinispan/encryption_test.go
+++ b/test/e2e/infinispan/encryption_test.go
@@ -72,7 +72,7 @@ func TestTLSConditionWithBadKeystore(t *testing.T) {
 }
 
 func checkRestConnection(client tutils.HTTPClient) {
-	_, err := ispnClient.New(tutils.LatestOperand, client).Container().Members()
+	_, err := ispnClient.New(tutils.CurrentOperand, client).Container().Members()
 	tutils.ExpectNoError(err)
 }
 

--- a/test/e2e/utils/cache.go
+++ b/test/e2e/utils/cache.go
@@ -21,7 +21,7 @@ type CacheHelper struct {
 
 func NewCacheHelper(cacheName string, client HTTPClient) *CacheHelper {
 	return &CacheHelper{
-		CacheClient: ispnClient.New(LatestOperand, client).Cache(cacheName),
+		CacheClient: ispnClient.New(CurrentOperand, client).Cache(cacheName),
 		CacheName:   cacheName,
 		Client:      client,
 	}

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -108,7 +108,16 @@ var VersionManager = func() *version.Manager {
 	}
 }
 
-var LatestOperand = VersionManager().Latest()
+var CurrentOperand = GetCurrentOperand()
+
+func GetCurrentOperand() version.Operand {
+	if OperandVersion != "" {
+		operand, err := VersionManager().WithRef(OperandVersion)
+		ExpectNoError(err)
+		return operand
+	}
+	return VersionManager().Latest()
+}
 
 func EndpointEncryption(name string) *ispnv1.EndpointEncryption {
 	return &ispnv1.EndpointEncryption{


### PR DESCRIPTION
Testsuite assumes that tests are always executed with latest Operand using latest API. That's causing test failures when executed against older operand versions.