### PR TITLE
Switch openJDK with eclipse-temurin-21 in docker file

### DIFF
--- a/test-integration/Dockerfile
+++ b/test-integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8-openjdk-11
+FROM maven:3.9-eclipse-temurin-21
 
 ENV JAVA_TOOL_OPTIONS="-XX:+IgnoreUnrecognizedVMOptions --add-exports java.base/jdk.compiler=ALL-UNNAMED"
 


### PR DESCRIPTION
infinispan requires Java 17, and since OpenJDK will be obsolete soon 
we are moving the operator to use  Eclipse Temurin 