### PR TITLE
RESP and HotRodMigration test fixes

### DIFF
--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -188,7 +188,7 @@ func TestRollingUpgrade(t *testing.T) {
 			ispn := testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
 
 			// ISPN-15651 Test migrating Indexed caches from 14.0.25.Final onwards
-			indexSupported := latestOperand.GTE(version.Operand{UpstreamVersion: &semver.Version{Major: 14, Minor: 0, Patch: 25}})
+			indexSupported := latestOperand.UpstreamVersion.GTE(*version.Operand{UpstreamVersion: &semver.Version{Major: 14, Minor: 0, Patch: 25}}.UpstreamVersion)
 			if indexSupported {
 				createIndexedCache(entriesPerCache, client)
 			}

--- a/test/e2e/infinispan/smoke_test.go
+++ b/test/e2e/infinispan/smoke_test.go
@@ -67,11 +67,13 @@ func TestBaseFunctionality(t *testing.T) {
 	verifyDefaultAuthention(require, ispn)
 	verifyScheduling(assert, require, ispn)
 
-	// Verify that the Redis endpoint is accessible
-	redis := tutils.RedisClientForCluster(ispn, testKube)
-	size, err := redis.DBSize(context.TODO()).Result()
-	tutils.ExpectNoError(err)
-	assert.Equal(int64(0), size)
+	if tutils.IsVersionAtLeast("15.0.0") {
+		// Verify that the Redis endpoint is accessible
+		redis := tutils.RedisClientForCluster(ispn, testKube)
+		size, err := redis.DBSize(context.TODO()).Result()
+		tutils.ExpectNoError(err)
+		assert.Equal(int64(0), size)
+	}
 }
 
 // Make sure no PVCs were created

--- a/test/e2e/utils/asserts.go
+++ b/test/e2e/utils/asserts.go
@@ -48,13 +48,20 @@ func SkipForMajor(t *testing.T, infinispanMajor uint64, message string) {
 	}
 }
 
-func SkipPriorTo(t *testing.T, version, message string) {
+func IsVersionAtLeast(version string) bool {
 	if OperandVersion != "" {
 		operand_cur, _ := VersionManager().WithRef(OperandVersion)
 		version_min, _ := semver.Parse(version)
-		if operand_cur.UpstreamVersion.LE(version_min) {
-			t.Skip(message)
-		}
+		return operand_cur.UpstreamVersion.GE(version_min)
+	}
+
+	// Assume yes if OperandVersion isn't specified
+	return true
+}
+
+func SkipPriorTo(t *testing.T, version, message string) {
+	if !IsVersionAtLeast(version) {
+		t.Skip(message)
 	}
 }
 

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -518,7 +518,11 @@ func (k TestKubernetes) WaitForExternalService(ispn *ispnv1.Infinispan, timeout 
 			err = k.Kubernetes.ResourcesList(ispn.Namespace, ispn.ExternalServiceSelectorLabels(), routeList, context.TODO())
 			ExpectNoError(err)
 			if len(routeList.Items) > 0 {
-				hostAndPort = routeList.Items[0].Spec.Host
+				if routeList.Items[0].Spec.TLS != nil {
+					hostAndPort = routeList.Items[0].Spec.Host + ":443"
+				} else {
+					hostAndPort = routeList.Items[0].Spec.Host + ":80"
+				}
 			}
 		}
 		if hostAndPort == "" {


### PR DESCRIPTION
Several test fixes to adjust for branding versions, feature availability and different default behavior on OpenShift:
* TestRollingUpgrade compared a given version to an upstream one, which is incorrectly evaluated in case of brand versioning
* Redis is available by default starting from 15.0.0
* Running the tests on the OpenShift makes the cluster encrypted by default but Redis client does not account for that
* Fix HostAndPort to really have a port in case of Route expose type. Redis will complain on missing port otherwise