### PR TITLE
TestBatchWithResources doesn't cleanup after itself

### DIFF
--- a/test/e2e/batch/batch_test.go
+++ b/test/e2e/batch/batch_test.go
@@ -101,6 +101,9 @@ func TestBatchFail(t *testing.T) {
 }
 
 func TestBatchWithResources(t *testing.T) {
+	t.Parallel()
+	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
+
 	infinispan := createCluster(t)
 	batchScript := batchString()
 	bcSpec := &v2.BatchContainerSpec{Memory: "1Gi:1Gi", CPU: "500m:500m"}


### PR DESCRIPTION
Test leaves running cluster after it ends