### PR TITLE
Use cluster rather then single node in upgrade test

### DIFF
--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -67,7 +67,7 @@ func TestUpgrade(t *testing.T) {
 	testKube.CreateSubscriptionAndApproveInitialVersion(sub)
 
 	// Create the Infinispan CR
-	replicas := 1
+	replicas := 2
 	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
 		i.Spec.Replicas = int32(replicas)
 		i.Spec.Service.Container.EphemeralStorage = false


### PR DESCRIPTION
https://github.com/infinispan/infinispan-operator/pull/2147 changed the replicas count to of UpgradeTest to 1. This prevents discovery any of the upgrade issue that may be related to upgrading a cluster.

There's also an issue when upgrading from older Infinispan/Operator version that the CR may not enter the Pending state (CVE upgrade) which halts the tests. The issue doesn't happen with cluster upgrade and is specific to a particular version.