### PR TITLE
[#2190] Skip upgrades to 2.4.8 and 2.4.9

### DIFF
--- a/config/manifests/bases/infinispan-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infinispan-operator.clusterserviceversion.yaml
@@ -314,4 +314,7 @@ spec:
   provider:
     name: Infinispan
   replaces: infinispan-operator.v2.4.8
+  skips:
+  - infinispan-operator.v2.4.7
+  - infinispan-operator.v2.4.8
   version: 0.0.0

--- a/scripts/create-olm-catalog.sh
+++ b/scripts/create-olm-catalog.sh
@@ -26,7 +26,10 @@ name: stable
 package: infinispan
 entries:
   - name: infinispan-operator.v2.4.9
-    replaces: infinispan-operator.v2.4.8
+    replaces: infinispan-operator.v2.4.6
+    skips:
+      - infinispan-operator.v2.4.8
+      - infinispan-operator.v2.4.7
   - name: infinispan-operator.v2.4.8
     replaces: infinispan-operator.v2.4.7
   - name: infinispan-operator.v2.4.7


### PR DESCRIPTION
Closes #2190

@fax4ever I had to update both the csv file and the file-based catalog we use for testing. The reason for this duplication is because we're still using the sqllite based catalogues in the community-operator repositories.