### PR TITLE
[#2192] Add test to ensure that all upgrades work across Operand graph in latest CSV release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,14 @@ jobs:
   upgrades:
     needs: unit
     uses: ./.github/workflows/test_upgrades.yml
+    with:
+      skipList: '15.1.0,15.1.1'
 
   hr-rolling-upgrades:
     needs: unit
     uses: ./.github/workflows/test_hr_rolling_upgrades.yml
+    with:
+      skipList: '15.1.0,15.1.1'
 
   xsite:
     needs: unit

--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -2,6 +2,11 @@ name: Hot Rod Rolling Upgrade Tests
 
 on:
   workflow_call:
+    inputs:
+      skipList:
+        description: 'A CSV of Operand versions to be skipped when executing TestOperandUpgrades'
+        required: false
+        type: string
 
 env:
   TESTING_LOG_DIR: ${{ github.workspace }}/test/reports
@@ -21,7 +26,10 @@ jobs:
         uses: ./.github/actions/kind
 
       - name: Run Hot Rod Rolling Upgrade Tests
-        run: make upgrade-test SUBSCRIPTION_STARTING_CSV=infinispan-operator.v2.3.2
+        run: make upgrade-test
+        env:
+          SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.3.2
+          TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}
 
       - name: Inspect Cluster
         if: failure()

--- a/.github/workflows/test_upgrades.yml
+++ b/.github/workflows/test_upgrades.yml
@@ -11,6 +11,49 @@ on:
         description: 'The name of the GH artifact containing the Operand image'
         required: false
         type: string
+      skipList:
+        description: 'A CSV of Operand versions to be skipped when executing TestOperandUpgrades'
+        required: false
+        type: string
+      testName:
+        description: 'The name of a specific upgrade test to be executed'
+        required: false
+        type: string
+      upgradeDepth:
+        description: 'The number of previous Operator versions to be installed before the latest version. Defaults to -1 which indicates all Operators in the OLM update graph should be applied.'
+        default: -1
+        required: false
+        type: number
+      ref:
+        type: string
+        required: false
+      repository:
+        type: string
+        required: false
+
+  workflow_dispatch:
+    inputs:
+      operand:
+        description: 'The FQN of the Operand image to be used. If left blank the most recent Operand defined in the Operator repository is used.'
+        required: false
+        type: string
+      operandArtifact:
+        description: 'The name of the GH artifact containing the Operand image'
+        required: false
+        type: string
+      skipList:
+        description: 'A CSV of Operand versions to be skipped when executing TestOperandUpgrades'
+        required: false
+        type: string
+      testName:
+        description: 'The name of a specific upgrade test to be executed'
+        required: false
+        type: string
+      upgradeDepth:
+        description: 'The number of previous Operator versions to be installed before the latest version. Defaults to -1 which indicates all Operators in the OLM update graph should be applied.'
+        default: -1
+        required: false
+        type: number
       ref:
         type: string
         required: false
@@ -65,7 +108,21 @@ jobs:
           kind load docker-image ${{ inputs.operand }}
 
       - name: Run GracefulShutdown Upgrade Tests
-        run: make upgrade-test SUBSCRIPTION_STARTING_CSV=infinispan-operator.v2.3.2
+        run: |
+          if [ "${DEPTH}" -gt -1 ]; then
+            export SUBSCRIPTION_STARTING_CSV=$(cat scripts/test-catalog.yml | yq "select(document_index == 1) | .entries[${DEPTH}].name")
+            if [ "${SUBSCRIPTION_STARTING_CSV}" == "null"; then
+              echo "No CSV found in test catalog for upgradeDepth '${DEPTH}'"
+              exit 1
+            fi
+          else
+            export SUBSCRIPTION_STARTING_CSV=infinispan-operator.v2.3.2
+          fi
+          make upgrade-test
+        env:
+          DEPTH: ${{ inputs.upgradeDepth }}
+          TEST_NAME: ${{ inputs.testName }}
+          TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}
 
       - name: Inspect Cluster
         if: failure()

--- a/config/manifests/bases/infinispan-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/infinispan-operator.clusterserviceversion.yaml
@@ -314,4 +314,7 @@ spec:
   provider:
     name: Infinispan
   replaces: infinispan-operator.v2.4.8
+  skips:
+  - infinispan-operator.v2.4.7
+  - infinispan-operator.v2.4.8
   version: 0.0.0

--- a/pkg/infinispan/version/version.go
+++ b/pkg/infinispan/version/version.go
@@ -56,6 +56,13 @@ func (o Operand) EQ(other Operand) bool {
 	return o.UpstreamVersion.EQ(*other.UpstreamVersion)
 }
 
+func (o Operand) GT(other Operand) bool {
+	if o.DownstreamVersion != nil {
+		return o.DownstreamVersion.GT(*other.DownstreamVersion)
+	}
+	return o.UpstreamVersion.GT(*other.UpstreamVersion)
+}
+
 func (o Operand) GTE(other Operand) bool {
 	if o.DownstreamVersion != nil {
 		return o.DownstreamVersion.GTE(*other.DownstreamVersion)
@@ -94,6 +101,21 @@ func (m *Manager) WithRef(version string) (Operand, error) {
 // Latest returns the most recent Operand release
 func (m *Manager) Latest() Operand {
 	return *m.Operands[len(m.Operands)-1]
+}
+
+// LatestUpstreamPatch returns the most recent Operand patch release associated with the upstream stream, e.g. 15.0.x
+func (m *Manager) LatestUpstreamPatch(stream semver.Version) (Operand, error) {
+	var latest *Operand
+	for _, v := range m.Operands {
+		if v.UpstreamVersion.Major == stream.Major && v.UpstreamVersion.Minor == stream.Minor {
+			latest = v
+		}
+	}
+
+	if latest != nil {
+		return *latest, nil
+	}
+	return Operand{}, fmt.Errorf("no Operands found in upstream stream '%d.%d'", stream.Major, stream.Minor)
 }
 
 func (m *Manager) Oldest() Operand {

--- a/scripts/create-olm-catalog.sh
+++ b/scripts/create-olm-catalog.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 CATALOG_DIR=infinispan-olm-catalog
 DOCKERFILE=${CATALOG_DIR}.Dockerfile
 CATALOG=${CATALOG_DIR}/catalog.yaml
@@ -14,76 +15,7 @@ done
 rm -rf ${CATALOG_DIR}
 mkdir ${CATALOG_DIR}
 
-# Define OLM update graph
-cat <<EOF >> ${CATALOG}
----
-schema: olm.package
-name: infinispan
-defaultChannel: stable
----
-schema: olm.channel
-name: stable
-package: infinispan
-entries:
-  - name: infinispan-operator.v2.4.9
-    replaces: infinispan-operator.v2.4.8
-  - name: infinispan-operator.v2.4.8
-    replaces: infinispan-operator.v2.4.7
-  - name: infinispan-operator.v2.4.7
-    replaces: infinispan-operator.v2.4.6
-  - name: infinispan-operator.v2.4.6
-    replaces: infinispan-operator.v2.4.5
-  - name: infinispan-operator.v2.4.5
-    replaces: infinispan-operator.v2.4.4
-  - name: infinispan-operator.v2.4.4
-    replaces: infinispan-operator.v2.4.3
-  - name: infinispan-operator.v2.4.3
-    replaces: infinispan-operator.v2.4.2
-  - name: infinispan-operator.v2.4.2
-    replaces: infinispan-operator.v2.4.1
-  - name: infinispan-operator.v2.4.1
-    replaces: infinispan-operator.v2.4.0
-  - name: infinispan-operator.v2.4.0
-    replaces: infinispan-operator.v2.3.7
-  - name: infinispan-operator.v2.3.7
-    replaces: infinispan-operator.v2.3.6
-  - name: infinispan-operator.v2.3.6
-    replaces: infinispan-operator.v2.3.5
-  - name: infinispan-operator.v2.3.5
-    replaces: infinispan-operator.v2.3.4
-  - name: infinispan-operator.v2.3.4
-    replaces: infinispan-operator.v2.3.3
-  - name: infinispan-operator.v2.3.3
-    replaces: infinispan-operator.v2.3.2
-  - name: infinispan-operator.v2.3.2
-    replaces: infinispan-operator.v2.3.1
-  - name: infinispan-operator.v2.3.1
-    replaces: infinispan-operator.v2.3.0
-  - name: infinispan-operator.v2.3.0
-    replaces: infinispan-operator.v2.2.5
----
-schema: olm.channel
-name: 2.3.x
-package: infinispan
-entries:
-- name: infinispan-operator.v2.3.7
-  replaces: infinispan-operator.v2.3.6
-- name: infinispan-operator.v2.3.6
-  replaces: infinispan-operator.v2.3.5
-- name: infinispan-operator.v2.3.5
-  replaces: infinispan-operator.v2.3.4
-- name: infinispan-operator.v2.3.4
-  replaces: infinispan-operator.v2.3.3
-- name: infinispan-operator.v2.3.3
-  replaces: infinispan-operator.v2.3.2
-- name: infinispan-operator.v2.3.2
-  replaces: infinispan-operator.v2.3.1
-- name: infinispan-operator.v2.3.1
-  replaces: infinispan-operator.v2.3.0
-- name: infinispan-operator.v2.3.0
-  replaces: infinispan-operator.v2.2.5
-EOF
-
+cp ${SCRIPT_DIR}/test-catalog.yml ${CATALOG}
 ${OPM} render --use-http -o yaml ${BUNDLE_IMGS} >> ${CATALOG}
 
 ${OPM} validate ${CATALOG_DIR}

--- a/scripts/test-catalog.yml
+++ b/scripts/test-catalog.yml
@@ -1,0 +1,68 @@
+schema: olm.package
+name: infinispan
+defaultChannel: stable
+---
+schema: olm.channel
+name: stable
+package: infinispan
+entries:
+  - name: infinispan-operator.v2.4.9
+    replaces: infinispan-operator.v2.4.6
+    skips:
+      - infinispan-operator.v2.4.8
+      - infinispan-operator.v2.4.7
+  - name: infinispan-operator.v2.4.8
+    replaces: infinispan-operator.v2.4.7
+  - name: infinispan-operator.v2.4.7
+    replaces: infinispan-operator.v2.4.6
+  - name: infinispan-operator.v2.4.6
+    replaces: infinispan-operator.v2.4.5
+  - name: infinispan-operator.v2.4.5
+    replaces: infinispan-operator.v2.4.4
+  - name: infinispan-operator.v2.4.4
+    replaces: infinispan-operator.v2.4.3
+  - name: infinispan-operator.v2.4.3
+    replaces: infinispan-operator.v2.4.2
+  - name: infinispan-operator.v2.4.2
+    replaces: infinispan-operator.v2.4.1
+  - name: infinispan-operator.v2.4.1
+    replaces: infinispan-operator.v2.4.0
+  - name: infinispan-operator.v2.4.0
+    replaces: infinispan-operator.v2.3.7
+  - name: infinispan-operator.v2.3.7
+    replaces: infinispan-operator.v2.3.6
+  - name: infinispan-operator.v2.3.6
+    replaces: infinispan-operator.v2.3.5
+  - name: infinispan-operator.v2.3.5
+    replaces: infinispan-operator.v2.3.4
+  - name: infinispan-operator.v2.3.4
+    replaces: infinispan-operator.v2.3.3
+  - name: infinispan-operator.v2.3.3
+    replaces: infinispan-operator.v2.3.2
+  - name: infinispan-operator.v2.3.2
+    replaces: infinispan-operator.v2.3.1
+  - name: infinispan-operator.v2.3.1
+    replaces: infinispan-operator.v2.3.0
+  - name: infinispan-operator.v2.3.0
+    replaces: infinispan-operator.v2.2.5
+---
+schema: olm.channel
+name: 2.3.x
+package: infinispan
+entries:
+  - name: infinispan-operator.v2.3.7
+    replaces: infinispan-operator.v2.3.6
+  - name: infinispan-operator.v2.3.6
+    replaces: infinispan-operator.v2.3.5
+  - name: infinispan-operator.v2.3.5
+    replaces: infinispan-operator.v2.3.4
+  - name: infinispan-operator.v2.3.4
+    replaces: infinispan-operator.v2.3.3
+  - name: infinispan-operator.v2.3.3
+    replaces: infinispan-operator.v2.3.2
+  - name: infinispan-operator.v2.3.2
+    replaces: infinispan-operator.v2.3.1
+  - name: infinispan-operator.v2.3.1
+    replaces: infinispan-operator.v2.3.0
+  - name: infinispan-operator.v2.3.0
+    replaces: infinispan-operator.v2.2.5

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -194,6 +194,13 @@ func TestRollingUpgrade(t *testing.T) {
 				createIndexedCache(entriesPerCache, client)
 			}
 
+			skippedOperands := tutils.OperandSkipSet()
+			if _, skip := skippedOperands[latestOperand.Ref()]; skip {
+				// Skip Operand upgrade if explicitly ignored
+				fmt.Printf("Skipping Operand %s\n", latestOperand.Ref())
+				continue
+			}
+
 			tutils.ExpectNoError(
 				testKube.UpdateInfinispan(ispn, func() {
 					ispn.Spec.Version = latestOperand.Ref()

--- a/test/e2e/upgrade/common.go
+++ b/test/e2e/upgrade/common.go
@@ -1,0 +1,252 @@
+package upgrade
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blang/semver"
+	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
+	v2 "github.com/infinispan/infinispan-operator/api/v2alpha1"
+	"github.com/infinispan/infinispan-operator/controllers/constants"
+	"github.com/infinispan/infinispan-operator/pkg/infinispan/version"
+	"github.com/infinispan/infinispan-operator/pkg/mime"
+	"github.com/infinispan/infinispan-operator/pkg/reconcile/pipeline/infinispan/handler/provision"
+	batchtest "github.com/infinispan/infinispan-operator/test/e2e/batch"
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+	coreos "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	persistentCacheName = "persistentCache"
+	volatileCacheName   = "volatileCache"
+)
+
+var (
+	conditionTimeout = 2 * tutils.ConditionWaitTimeout
+	ctx              = context.TODO()
+	testKube         = tutils.NewTestKubernetes(os.Getenv("TESTING_CONTEXT"))
+)
+
+func subscription(olm tutils.OLMEnv) *coreos.Subscription {
+	return &coreos.Subscription{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: coreos.SubscriptionCRDAPIVersion,
+			Kind:       coreos.SubscriptionKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      olm.SubName,
+			Namespace: olm.SubNamespace,
+		},
+		Spec: &coreos.SubscriptionSpec{
+			Channel:                olm.SourceChannel.Name,
+			CatalogSource:          olm.CatalogSource,
+			CatalogSourceNamespace: olm.CatalogSourceNamespace,
+			InstallPlanApproval:    coreos.ApprovalManual,
+			Package:                olm.SubPackage,
+			StartingCSV:            olm.SubStartingCSV,
+			Config: coreos.SubscriptionConfig{
+				Env: []corev1.EnvVar{
+					{Name: "THREAD_DUMP_PRE_STOP", Value: "TRUE"},
+				},
+			},
+		},
+	}
+}
+
+func createAndPopulateVolatileCache(cacheName string, numEntries int, client tutils.HTTPClient) {
+	c := tutils.NewCacheHelper(cacheName, client)
+	if !c.Exists() {
+		c.Create(`{"distributed-cache":{"mode":"SYNC"}}`, mime.ApplicationJson)
+	}
+	if c.Size() != numEntries {
+		c.Populate(numEntries)
+		c.AssertSize(numEntries)
+	}
+}
+
+func createAndPopulatePersistentCache(cacheName string, numEntries int, client tutils.HTTPClient) {
+	cache := tutils.NewCacheHelper(cacheName, client)
+	config := `{"distributed-cache":{"mode":"SYNC", "persistence":{"file-store":{}}}}`
+	cache.Create(config, mime.ApplicationJson)
+	cache.Populate(numEntries)
+	cache.AssertSize(numEntries)
+}
+
+func createBackupAndWaitToSucceed(name string, t *testing.T) *v2.Backup {
+	backup := &v2.Backup{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infinispan.org/v2alpha1",
+			Kind:       "Backup",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upgrade-backup",
+			Namespace: tutils.Namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
+		},
+		Spec: v2.BackupSpec{
+			Cluster: name,
+		},
+	}
+	testKube.Create(backup)
+	return testKube.WaitForValidBackupPhase(backup.Name, backup.Namespace, v2.BackupSucceeded)
+}
+
+func createRestoreAndWaitToSucceed(name string, backup *v2.Backup, t *testing.T) (*v2.Restore, error) {
+	restore := &v2.Restore{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "infinispan.org/v2alpha1",
+			Kind:       "Restore",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: tutils.Namespace,
+			Labels:    map[string]string{"test-name": t.Name()},
+		},
+		Spec: v2.RestoreSpec{
+			Backup:  backup.Name,
+			Cluster: backup.Spec.Cluster,
+		},
+	}
+	testKube.Create(restore)
+	return waitForValidRestorePhase(restore.Name, restore.Namespace, v2.RestoreSucceeded)
+}
+
+func waitForValidRestorePhase(name, namespace string, phase v2.RestorePhase) (restore *v2.Restore, err error) {
+	err = wait.Poll(10*time.Millisecond, tutils.TestTimeout, func() (bool, error) {
+		restore = testKube.GetRestore(name, namespace)
+		if restore.Status.Phase == v2.RestoreFailed {
+			return true, fmt.Errorf("restore failed. Reason: %s", restore.Status.Reason)
+		}
+		return phase == restore.Status.Phase, nil
+	})
+	if err != nil {
+		err = fmt.Errorf("Expected Restore Phase %s, got %s:%s", phase, restore.Status.Phase, restore.Status.Reason)
+	}
+	return
+}
+
+// ignoreRestoreError returns nil if the Restore failure can safely be ignored for the given Operand
+func ignoreRestoreError(csv string, operand *version.Operand, ispn *ispnv1.Infinispan, restore *v2.Restore, client tutils.HTTPClient, err error) error {
+	fmt.Println(err)
+	switch restore.Status.Phase {
+	case v2.RestoreInitializing:
+	case v2.RestoreInitialized:
+		// Ignore errors where the Restore state is stuck initializing due to a MERGED cluster view from PublishNotReadyAddresses=false
+		// Fixed in Operator 2.3.2, but ISPN-14793 should fix this for Operands >= 14.0.9 even with PublishNotReadyAddresses=false
+		operatorVersion := semver.MustParse(strings.Split(csv, "v")[1])
+		if operatorVersion.LT(semver.Version{Major: 2, Minor: 3, Patch: 2}) {
+			return nil
+		}
+		fallthrough
+	case v2.RestoreRunning:
+	case v2.RestoreSucceeded:
+	case v2.RestoreUnknown:
+		return err
+	}
+
+	// Ignore split brain errors on older Operands that are caused by one of the cluster members
+	// restarting due to an incompatible configuration caused by ISPN-15089 and ISPN-15191
+	if operand.UpstreamVersion.LT(semver.Version{Major: 14, Minor: 0, Patch: 17}) &&
+		strings.Contains(restore.Status.Reason, "Key 'ClusteredLockKey{name=BackupManagerImpl-restore}' is not available. Not all owners are in this partition") {
+		// Check the restartCount and logs of the cluster pods to ensure ISPN-15089 is the cause of
+		// a server pod restarting
+		podList := &corev1.PodList{}
+		tutils.ExpectNoError(
+			testKube.Kubernetes.ResourcesList(restore.Namespace, map[string]string{"app": "infinispan-pod", "infinispan_cr": ispn.Name}, podList, ctx),
+		)
+
+		r := regexp.MustCompile("FATAL.*ISPN080028.*GlobalConfigurationManager failed to start")
+		for _, pod := range podList.Items {
+			for _, c := range pod.Status.ContainerStatuses {
+				if c.Name == provision.InfinispanContainer && c.RestartCount > 0 {
+					logs, err := testKube.Kubernetes.Logs(pod.Name, pod.Namespace, true, ctx)
+					tutils.ExpectNoError(err)
+
+					if r.MatchString(logs) {
+						fmt.Printf("Ignoring Restore failure caused by ISPN-15089 on Operand %s\n", operand)
+						// Force the org.infinispan.LOCKS cache to become available so that subsequent upgrades will proceed
+						tutils.NewCacheHelper("org.infinispan.LOCKS", client).Available(true)
+						return nil
+					}
+				}
+			}
+		}
+	}
+
+	if strings.Contains(restore.Status.Reason, "EOF") {
+		logs, err := testKube.Kubernetes.Logs(restore.Name, restore.Namespace, false, ctx)
+		tutils.ExpectNoError(err)
+
+		if operand.UpstreamVersion.LT(semver.Version{Major: 14, Minor: 0, Patch: 18}) {
+			// Ignore ISPN-15181 related errors on older Operands
+			r := regexp.MustCompile(`Error executing command PutKeyValueCommand on Cache 'org.infinispan.CONFIG'.*org.infinispan.util.concurrent.TimeoutException: ISPN000476`)
+			if r.MatchString(logs) {
+				fmt.Printf("Ignoring Restore failure caused by ISPN-15181 on Operand %s\n", operand)
+				return nil
+			}
+		}
+
+		if operand.UpstreamVersion.EQ(semver.Version{Major: 14, Minor: 0, Patch: 9}) {
+			// Ignore example.PROTOBUF_DIST incompatibility. Users can workaround this issue by excluding the example.PROTOBUF_DIST
+			// template from their Restore CR
+			r := regexp.MustCompile(`ISPN000961: Incompatible attribute 'media-type.example.PROTOBUF_DIST.distributed-cache-configuration.encoding'`)
+			if r.MatchString(logs) {
+				fmt.Printf("Ignoring Restore failure caused by example.PROTOBUF_DIST template encoding incompatibility %s\n", operand)
+				return nil
+			}
+		}
+	}
+
+	if strings.Contains(restore.Status.Reason, "unable to retrieve Restore with name") {
+		logs, err := testKube.Kubernetes.Logs(restore.Name, restore.Namespace, false, ctx)
+		tutils.ExpectNoError(err)
+
+		// Ignore https://github.com/infinispan/infinispan/issues/13571
+		r := regexp.MustCompile(`ISPN000436: Cache 'volatileCache' has been requested, but no matching cache configuration exists`)
+		if r.MatchString(logs) {
+			fmt.Printf("Ignoring Restore failure caused by https://github.com/infinispan/infinispan/issues/13571 on Operand %s\n", operand)
+			return nil
+		}
+	}
+	return err
+}
+
+func assertOperandImage(expectedImage string, i *ispnv1.Infinispan) {
+	pods := &corev1.PodList{}
+	err := testKube.Kubernetes.ResourcesList(tutils.Namespace, i.PodSelectorLabels(), pods, ctx)
+	tutils.ExpectNoError(err)
+	for _, pod := range pods.Items {
+		if pod.Spec.Containers[0].Image != expectedImage {
+			panic(fmt.Errorf("upgraded image [%v] in Pod not equal desired cluster image [%v]", pod.Spec.Containers[0].Image, expectedImage))
+		}
+	}
+}
+
+func checkServicePorts(t *testing.T, name string) {
+	// Check two services are exposed and the admin service listens on its own port
+	userPort := testKube.GetServicePorts(tutils.Namespace, name)
+	assert.Equal(t, 1, len(userPort))
+	assert.Equal(t, constants.InfinispanUserPort, int(userPort[0].Port))
+
+	adminPort := testKube.GetAdminServicePorts(tutils.Namespace, name)
+	assert.Equal(t, 1, len(adminPort))
+	assert.Equal(t, constants.InfinispanAdminPort, int(adminPort[0].Port))
+}
+
+func checkBatch(t *testing.T, name string) {
+	// Run a batch in the migrated cluster
+	batchHelper := batchtest.NewBatchHelper(testKube)
+	config := "create cache --template=org.infinispan.DIST_SYNC batch-cache"
+	batch := batchHelper.CreateBatch(t, name, name, &config, nil, nil)
+	batchHelper.WaitForValidBatchPhase(name, v2.BatchSucceeded)
+	testKube.DeleteBatch(batch)
+}

--- a/test/e2e/upgrade/upgrade_operands_test.go
+++ b/test/e2e/upgrade/upgrade_operands_test.go
@@ -1,0 +1,128 @@
+package upgrade
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestOperandUpgrades ensures that the Operand upgrade graph can be traversed for a given OLM Operator
+func TestOperandUpgrades(t *testing.T) {
+	olm := testKube.OLMTestEnv()
+	// Only test Operands in the most recent CSV
+	olm.SubStartingCSV = olm.TargetChannel.CurrentCSVName
+	olm.PrintManifest()
+
+	testKube.NewNamespace(tutils.Namespace)
+	sub := subscription(olm)
+
+	defer testKube.CleanupOLMTest(t, tutils.TestName(t), olm.SubName, olm.SubNamespace, olm.SubPackage)
+	testKube.CreateOperatorGroup(olm)
+	testKube.CreateSubscriptionAndApproveInitialVersion(sub)
+
+	versionManager := testKube.VersionManagerFromCSV(sub)
+
+	startingOperandIdx := -1
+	for i, op := range versionManager.Operands {
+		// We must start at Infinispan 14.0.8 or higher due to ISPN-12224
+		if op.UpstreamVersion.Major == 14 && op.UpstreamVersion.Patch >= 8 {
+			startingOperandIdx = i
+			break
+		}
+	}
+	assert.Truef(t, startingOperandIdx >= 0, "unable to find suitable starting Operand")
+
+	// Create the Infinispan CR
+	replicas := 2
+	ispn := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
+		i.Spec.Replicas = int32(replicas)
+		i.Spec.Service.Container.EphemeralStorage = false
+		i.Spec.Logging.Categories["org.infinispan.topology"] = ispnv1.LoggingLevelTrace
+		i.Spec.Version = versionManager.Operands[startingOperandIdx].Ref()
+	})
+
+	fmt.Printf("Testing upgrades from Operand '%s' to '%s'\n", ispn.Spec.Version, versionManager.Latest().Ref())
+	testKube.CreateInfinispan(ispn, tutils.Namespace)
+	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, ispn.Name, tutils.Namespace)
+	testKube.WaitForInfinispanConditionWithTimeout(ispn.Name, ispn.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
+
+	numEntries := 100
+	client := tutils.HTTPClientForClusterWithVersionManager(ispn, testKube, versionManager)
+
+	// Add a persistent cache with data to ensure contents can be read after upgrade(s)
+	createAndPopulatePersistentCache(persistentCacheName, numEntries, client)
+
+	// Add a volatile cache with data to ensure contents can be backed up and then restored after upgrade(s)
+	createAndPopulateVolatileCache(volatileCacheName, numEntries, client)
+
+	backup := createBackupAndWaitToSucceed(ispn.Name, t)
+
+	skippedOperands := tutils.OperandSkipSet()
+	for _, operand := range versionManager.Operands[startingOperandIdx:] {
+		// Skip an Operand in the upgrade graph if there's a known issue
+		if _, skip := skippedOperands[operand.Ref()]; skip {
+			fmt.Printf("Skipping Operand %s\n", operand.Ref())
+			continue
+		}
+		fmt.Printf("Next Operand %s\n", operand.Ref())
+
+		ispn = testKube.WaitForInfinispanConditionWithTimeout(ispn.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
+		tutils.ExpectNoError(
+			testKube.UpdateInfinispan(ispn, func() {
+				ispn.Spec.Version = operand.Ref()
+				fmt.Printf("Upgrading Operand to %s\n", ispn.Spec.Version)
+			}),
+		)
+		testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, ispn.Name, tutils.Namespace)
+		testKube.WaitForInfinispanState(ispn.Name, ispn.Namespace, func(i *ispnv1.Infinispan) bool {
+			return i.IsConditionTrue(ispnv1.ConditionWellFormed) &&
+				i.Status.Operand.Version == operand.Ref() &&
+				i.Status.Operand.Image == operand.Image &&
+				i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
+		})
+		assertOperandImage(operand.Image, ispn)
+
+		// Ensure that persistent cache entries have survived the upgrade(s)
+		// Refresh the hostAddr and client as the url will change if NodePort is used.
+		client = tutils.HTTPClientForClusterWithVersionManager(ispn, testKube, versionManager)
+		tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
+
+		// Restore the backup and ensure that the cache exists with the expected number of entries
+
+		restoreName := strings.ReplaceAll(operand.Ref(), ".", "-")
+		if restore, err := createRestoreAndWaitToSucceed(restoreName, backup, t); err != nil {
+			tutils.ExpectNoError(
+				ignoreRestoreError(sub.Status.InstalledCSV, operand, ispn, restore, client, err),
+			)
+			// We must recreate the caches that should have been restored if the Restore CR had succeeded
+			// so that the Backup CR executed in the next loop has the expected content
+			createAndPopulateVolatileCache(volatileCacheName, numEntries, client)
+		}
+
+		tutils.NewCacheHelper(volatileCacheName, client).AssertSize(numEntries)
+		checkServicePorts(t, ispn.Name)
+		checkBatch(t, ispn.Name)
+
+		// Kill the first pod to ensure that the cluster can recover from failover after upgrade
+		err := testKube.Kubernetes.Client.Delete(ctx, &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ispn.Name + "-0",
+				Namespace: tutils.Namespace,
+			},
+		})
+		tutils.ExpectNoError(err)
+		testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, ispn.Name, tutils.Namespace)
+		testKube.WaitForInfinispanConditionWithTimeout(ispn.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
+
+		// Ensure that persistent cache entries still contain the expected numEntries
+		versionManager = testKube.VersionManagerFromCSV(sub)
+		client = tutils.HTTPClientForClusterWithVersionManager(ispn, testKube, versionManager)
+		tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
+	}
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -1,36 +1,19 @@
 package upgrade
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/blang/semver"
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
-	v2 "github.com/infinispan/infinispan-operator/api/v2alpha1"
-	"github.com/infinispan/infinispan-operator/controllers/constants"
-	"github.com/infinispan/infinispan-operator/pkg/infinispan/version"
-	"github.com/infinispan/infinispan-operator/pkg/mime"
-	"github.com/infinispan/infinispan-operator/pkg/reconcile/pipeline/infinispan/handler/provision"
-	batchtest "github.com/infinispan/infinispan-operator/test/e2e/batch"
 	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
 	coreos "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var (
-	ctx              = context.TODO()
-	testKube         = tutils.NewTestKubernetes(os.Getenv("TESTING_CONTEXT"))
-	conditionTimeout = 2 * tutils.ConditionWaitTimeout
-)
-
+// TestUpgrade ensures that the OLM upgrade graph can be traversed and Operands installed as expected
 func TestUpgrade(t *testing.T) {
 	olm := testKube.OLMTestEnv()
 	olm.PrintManifest()
@@ -38,29 +21,7 @@ func TestUpgrade(t *testing.T) {
 	targetChannel := olm.TargetChannel
 
 	testKube.NewNamespace(tutils.Namespace)
-	sub := &coreos.Subscription{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: coreos.SubscriptionCRDAPIVersion,
-			Kind:       coreos.SubscriptionKind,
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      olm.SubName,
-			Namespace: olm.SubNamespace,
-		},
-		Spec: &coreos.SubscriptionSpec{
-			Channel:                olm.SourceChannel.Name,
-			CatalogSource:          olm.CatalogSource,
-			CatalogSourceNamespace: olm.CatalogSourceNamespace,
-			InstallPlanApproval:    coreos.ApprovalManual,
-			Package:                olm.SubPackage,
-			StartingCSV:            olm.SubStartingCSV,
-			Config: coreos.SubscriptionConfig{
-				Env: []corev1.EnvVar{
-					{Name: "THREAD_DUMP_PRE_STOP", Value: "TRUE"},
-				},
-			},
-		},
-	}
+	sub := subscription(olm)
 
 	defer testKube.CleanupOLMTest(t, tutils.TestName(t), olm.SubName, olm.SubNamespace, olm.SubPackage)
 	testKube.CreateOperatorGroup(olm)
@@ -83,48 +44,17 @@ func TestUpgrade(t *testing.T) {
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	testKube.WaitForInfinispanConditionWithTimeout(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
 
-	// Add a persistent cache with data to ensure contents can be read after upgrade(s)
 	numEntries := 100
 	client := tutils.HTTPClientForClusterWithVersionManager(spec, testKube, testKube.VersionManagerFromCSV(sub))
 
-	peristentCache := "persistentCache"
-	cache := tutils.NewCacheHelper(peristentCache, client)
-	config := `{"distributed-cache":{"mode":"SYNC", "persistence":{"file-store":{}}}}`
-	cache.Create(config, mime.ApplicationJson)
-	cache.Populate(numEntries)
-	cache.AssertSize(numEntries)
+	// Add a persistent cache with data to ensure contents can be read after upgrade(s)
+	createAndPopulatePersistentCache(persistentCacheName, numEntries, client)
 
 	// Add a volatile cache with data to ensure contents can be backed up and then restored after upgrade(s)
-	volatileCache := "volatileCache"
-	createAndPopulateVolatileCache := func(client tutils.HTTPClient) {
-		c := tutils.NewCacheHelper(volatileCache, client)
-		if !c.Exists() {
-			c.Create(`{"distributed-cache":{"mode":"SYNC"}}`, mime.ApplicationJson)
-		}
-		if c.Size() != numEntries {
-			c.Populate(numEntries)
-			c.AssertSize(numEntries)
-		}
-	}
-	createAndPopulateVolatileCache(client)
+	createAndPopulateVolatileCache(volatileCacheName, numEntries, client)
 
 	// Create Backup
-	backup := &v2.Backup{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "infinispan.org/v2alpha1",
-			Kind:       "Backup",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "upgrade-backup",
-			Namespace: tutils.Namespace,
-			Labels:    map[string]string{"test-name": t.Name()},
-		},
-		Spec: v2.BackupSpec{
-			Cluster: spec.Name,
-		},
-	}
-	testKube.Create(backup)
-	testKube.WaitForValidBackupPhase(backup.Name, backup.Namespace, v2.BackupSucceeded)
+	backup := createBackupAndWaitToSucceed(spec.Name, t)
 
 	// Upgrade the Subscription channel if required
 	if sourceChannel != targetChannel {
@@ -146,17 +76,6 @@ func TestUpgrade(t *testing.T) {
 		// https://github.com/infinispan/infinispan-operator/issues/1719
 		time.Sleep(time.Minute)
 
-		assertOperandImage := func(expectedImage string) {
-			pods := &corev1.PodList{}
-			err := testKube.Kubernetes.ResourcesList(tutils.Namespace, spec.PodSelectorLabels(), pods, ctx)
-			tutils.ExpectNoError(err)
-			for _, pod := range pods.Items {
-				if pod.Spec.Containers[0].Image != expectedImage {
-					panic(fmt.Errorf("upgraded image [%v] in Pod not equal desired cluster image [%v]", pod.Spec.Containers[0].Image, expectedImage))
-				}
-			}
-		}
-
 		versionManager := testKube.VersionManagerFromCSV(sub)
 		if ispnPreUpgrade.Spec.Version == "" {
 			relatedImageJdk := testKube.InstalledCSVEnv("RELATED_IMAGE_OPENJDK", sub)
@@ -169,9 +88,9 @@ func TestUpgrade(t *testing.T) {
 
 				// The latest Operator version still doesn't support multi-operand so check that the RELATED_IMAGE_OPENJDK
 				// image has been installed on all pods
-				assertOperandImage(relatedImageJdk)
+				assertOperandImage(relatedImageJdk, spec)
 				client = tutils.HTTPClientForCluster(spec, testKube)
-				tutils.NewCacheHelper(peristentCache, client).AssertSize(numEntries)
+				tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
 				continue
 			}
 
@@ -183,13 +102,21 @@ func TestUpgrade(t *testing.T) {
 					i.Status.Operand.Image == oldestOperand.Image &&
 					i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
 			})
-			assertOperandImage(oldestOperand.Image)
+			assertOperandImage(oldestOperand.Image, spec)
 		}
 
 		// Upgrade to the latest available Operand
 		latestOperand := versionManager.Latest()
 		if ispnPreUpgrade.Spec.Version != latestOperand.Ref() {
 			ispn := testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
+
+			skippedOperands := tutils.OperandSkipSet()
+			if _, skip := skippedOperands[latestOperand.Ref()]; skip {
+				// Skip Operand upgrade if explicitly ignored
+				fmt.Printf("Skipping Operand %s\n", latestOperand.Ref())
+				continue
+			}
+
 			tutils.ExpectNoError(
 				testKube.UpdateInfinispan(ispn, func() {
 					ispn.Spec.Version = latestOperand.Ref()
@@ -209,41 +136,25 @@ func TestUpgrade(t *testing.T) {
 					i.Status.Operand.Image == latestOperand.Image &&
 					i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
 			})
-			assertOperandImage(latestOperand.Image)
+			assertOperandImage(latestOperand.Image, spec)
 
 			// Ensure that persistent cache entries have survived the upgrade(s)
 			// Refresh the hostAddr and client as the url will change if NodePort is used.
 			client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
-			tutils.NewCacheHelper(peristentCache, client).AssertSize(numEntries)
+			tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
 
 			// Restore the backup and ensure that the cache exists with the expected number of entries
-			restore := &v2.Restore{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "infinispan.org/v2alpha1",
-					Kind:       "Restore",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "upgrade-restore-" + strings.ReplaceAll(strings.TrimLeft(sub.Status.CurrentCSV, olm.SubName+".v"), ".", "-"),
-					Namespace: tutils.Namespace,
-					Labels:    map[string]string{"test-name": t.Name()},
-				},
-				Spec: v2.RestoreSpec{
-					Backup:  backup.Name,
-					Cluster: spec.Name,
-				},
-			}
-			testKube.Create(restore)
-
-			if restore, err := waitForValidRestorePhase(restore.Name, restore.Namespace, v2.RestoreSucceeded); err != nil {
+			restoreName := "upgrade-restore-" + strings.ReplaceAll(strings.TrimLeft(sub.Status.CurrentCSV, olm.SubName+".v"), ".", "-")
+			if restore, err := createRestoreAndWaitToSucceed(restoreName, backup, t); err != nil {
 				tutils.ExpectNoError(
 					ignoreRestoreError(sub.Status.InstalledCSV, &latestOperand, spec, restore, client, err),
 				)
 				// We must recreate the caches that should have been restored if the Restore CR had succeeded
 				// so that the Backup CR executed in the next loop has the expected content
-				createAndPopulateVolatileCache(client)
+				createAndPopulateVolatileCache(volatileCacheName, numEntries, client)
 			}
 		}
-		tutils.NewCacheHelper(volatileCache, client).AssertSize(numEntries)
+		tutils.NewCacheHelper(volatileCacheName, client).AssertSize(numEntries)
 	}
 
 	checkServicePorts(t, spec.Name)
@@ -263,112 +174,5 @@ func TestUpgrade(t *testing.T) {
 	// Ensure that persistent cache entries still contain the expected numEntries
 	versionManager := testKube.VersionManagerFromCSV(sub)
 	client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
-	tutils.NewCacheHelper(peristentCache, client).AssertSize(numEntries)
-}
-
-func waitForValidRestorePhase(name, namespace string, phase v2.RestorePhase) (restore *v2.Restore, err error) {
-	err = wait.Poll(10*time.Millisecond, tutils.TestTimeout, func() (bool, error) {
-		restore = testKube.GetRestore(name, namespace)
-		if restore.Status.Phase == v2.RestoreFailed {
-			return true, fmt.Errorf("restore failed. Reason: %s", restore.Status.Reason)
-		}
-		return phase == restore.Status.Phase, nil
-	})
-	if err != nil {
-		err = fmt.Errorf("Expected Restore Phase %s, got %s:%s", phase, restore.Status.Phase, restore.Status.Reason)
-	}
-	return
-}
-
-// ignoreRestoreError returns nil if the Restore failure can safely be ignored for the given Operand
-func ignoreRestoreError(csv string, operand *version.Operand, ispn *ispnv1.Infinispan, restore *v2.Restore, client tutils.HTTPClient, err error) error {
-	fmt.Println(err)
-	switch restore.Status.Phase {
-	case v2.RestoreInitializing:
-	case v2.RestoreInitialized:
-		// Ignore errors where the Restore state is stuck initializing due to a MERGED cluster view from PublishNotReadyAddresses=false
-		// Fixed in Operator 2.3.2, but ISPN-14793 should fix this for Operands >= 14.0.9 even with PublishNotReadyAddresses=false
-		operatorVersion := semver.MustParse(strings.Split(csv, "v")[1])
-		if operatorVersion.LT(semver.Version{Major: 2, Minor: 3, Patch: 2}) {
-			return nil
-		}
-		fallthrough
-	case v2.RestoreRunning:
-	case v2.RestoreSucceeded:
-	case v2.RestoreUnknown:
-		return err
-	}
-
-	// Ignore split brain errors on older Operands that are caused by one of the cluster members
-	// restarting due to an incompatible configuration caused by ISPN-15089 and ISPN-15191
-	if operand.UpstreamVersion.LT(semver.Version{Major: 14, Minor: 0, Patch: 17}) &&
-		strings.Contains(restore.Status.Reason, "Key 'ClusteredLockKey{name=BackupManagerImpl-restore}' is not available. Not all owners are in this partition") {
-		// Check the restartCount and logs of the cluster pods to ensure ISPN-15089 is the cause of
-		// a server pod restarting
-		podList := &corev1.PodList{}
-		tutils.ExpectNoError(
-			testKube.Kubernetes.ResourcesList(restore.Namespace, map[string]string{"app": "infinispan-pod", "infinispan_cr": ispn.Name}, podList, ctx),
-		)
-
-		r := regexp.MustCompile("FATAL.*ISPN080028.*GlobalConfigurationManager failed to start")
-		for _, pod := range podList.Items {
-			for _, c := range pod.Status.ContainerStatuses {
-				if c.Name == provision.InfinispanContainer && c.RestartCount > 0 {
-					logs, err := testKube.Kubernetes.Logs(pod.Name, pod.Namespace, true, ctx)
-					tutils.ExpectNoError(err)
-
-					if r.MatchString(logs) {
-						fmt.Printf("Ignoring Restore failure caused by ISPN-15089 on Operand %s\n", operand)
-						// Force the org.infinispan.LOCKS cache to become available so that subsequent upgrades will proceed
-						tutils.NewCacheHelper("org.infinispan.LOCKS", client).Available(true)
-						return nil
-					}
-				}
-			}
-		}
-	}
-
-	if strings.Contains(restore.Status.Reason, "EOF") {
-		logs, err := testKube.Kubernetes.Logs(restore.Name, restore.Namespace, false, ctx)
-		tutils.ExpectNoError(err)
-
-		if operand.UpstreamVersion.LT(semver.Version{Major: 14, Minor: 0, Patch: 18}) {
-			// Ignore ISPN-15181 related errors on older Operands
-			r := regexp.MustCompile(`Error executing command PutKeyValueCommand on Cache 'org.infinispan.CONFIG'.*org.infinispan.util.concurrent.TimeoutException: ISPN000476`)
-			if r.MatchString(logs) {
-				fmt.Printf("Ignoring Restore failure caused by ISPN-15181 on Operand %s\n", operand)
-				return nil
-			}
-		}
-
-		if operand.UpstreamVersion.EQ(semver.Version{Major: 14, Minor: 0, Patch: 9}) {
-			// Ignore example.PROTOBUF_DIST incompatibility. Users can workaround this issue by excluding the example.PROTOBUF_DIST
-			// template from their Restore CR
-			r := regexp.MustCompile(`ISPN000961: Incompatible attribute 'media-type.example.PROTOBUF_DIST.distributed-cache-configuration.encoding'`)
-			if r.MatchString(logs) {
-				fmt.Printf("Ignoring Restore failure caused by example.PROTOBUF_DIST template encoding incompatibility %s\n", operand)
-				return nil
-			}
-		}
-	}
-	return err
-}
-
-func checkServicePorts(t *testing.T, name string) {
-	// Check two services are exposed and the admin service listens on its own port
-	userPort := testKube.GetServicePorts(tutils.Namespace, name)
-	assert.Equal(t, 1, len(userPort))
-	assert.Equal(t, constants.InfinispanUserPort, int(userPort[0].Port))
-
-	adminPort := testKube.GetAdminServicePorts(tutils.Namespace, name)
-	assert.Equal(t, 1, len(adminPort))
-	assert.Equal(t, constants.InfinispanAdminPort, int(adminPort[0].Port))
-}
-
-func checkBatch(t *testing.T, name string) {
-	// Run a batch in the migrated cluster
-	batchHelper := batchtest.NewBatchHelper(testKube)
-	config := "create cache --template=org.infinispan.DIST_SYNC batch-cache"
-	batchHelper.CreateBatch(t, name, name, &config, nil, nil)
-	batchHelper.WaitForValidBatchPhase(name, v2.BatchSucceeded)
+	tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
 }

--- a/test/e2e/utils/constants.go
+++ b/test/e2e/utils/constants.go
@@ -28,6 +28,7 @@ var (
 	Namespace         = strings.ToLower(constants.GetEnvWithDefault("TESTING_NAMESPACE", "namespace-for-testing"))
 	MultiNamespace    = strings.ToLower(constants.GetEnvWithDefault("TESTING_MULTINAMESPACE", "namespace-for-testing-1,namespace-for-testing-2"))
 	OperandVersion    = os.Getenv("TESTING_OPERAND_VERSION")
+	OperandSkipList   = os.Getenv("TESTING_OPERAND_IGNORE_LIST")
 	OperatorNamespace = strings.ToLower(constants.GetEnvWithDefault("TESTING_OPERATOR_NAMESPACE", ""))
 	OperatorName      = "infinispan-operator"
 	OperatorSAName    = strings.ToLower(constants.GetEnvWithDefault("OPERATOR_SA_NAME", "infinispan-operator-controller-manager"))

--- a/test/e2e/utils/kubernetes.go
+++ b/test/e2e/utils/kubernetes.go
@@ -1062,7 +1062,7 @@ func (k TestKubernetes) WaitForResourceRemoval(name, namespace string, obj clien
 	)
 }
 
-func (k TestKubernetes) WaitForValidBackupPhase(name, namespace string, phase ispnv2.BackupPhase) {
+func (k TestKubernetes) WaitForValidBackupPhase(name, namespace string, phase ispnv2.BackupPhase) *ispnv2.Backup {
 	var backup *ispnv2.Backup
 	err := wait.Poll(10*time.Millisecond, TestTimeout, func() (bool, error) {
 		backup = k.GetBackup(name, namespace)
@@ -1075,6 +1075,7 @@ func (k TestKubernetes) WaitForValidBackupPhase(name, namespace string, phase is
 		println(fmt.Sprintf("Expected Backup Phase %s, got %s:%s", phase, backup.Status.Phase, backup.Status.Reason))
 	}
 	ExpectNoError(err)
+	return backup
 }
 
 func (k TestKubernetes) WaitForValidRestorePhase(name, namespace string, phase ispnv2.RestorePhase) error {

--- a/test/e2e/utils/operands.go
+++ b/test/e2e/utils/operands.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	"strings"
+)
+
+func OperandSkipSet() map[string]struct{} {
+	skippedVersions := strings.Split(OperandSkipList, ",")
+	operands := make(map[string]struct{}, len(skippedVersions))
+	for _, v := range skippedVersions {
+		operands[v] = struct{}{}
+	}
+	return operands
+}


### PR DESCRIPTION
Closes #2192 

This test will be called from the Infinispan PR workflows with the equivalent of the following params:

`gh workflow run test_upgrades.yml -f upgradeDepth=0 -f skipList=15.1.0,15.1.1 -f testName=TestOperandUpgrades`

Run on myfork: https://github.com/ryanemerson/infinispan-operator/actions/runs/12469871592/job/34803888270