### PR TITLE
[#2194] Fix hr rolling upgrades action name

### DIFF
--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -26,7 +26,7 @@ jobs:
         uses: ./.github/actions/kind
 
       - name: Run Hot Rod Rolling Upgrade Tests
-        run: make upgrade-test
+        run: make hotrod-upgrade-test
         env:
           SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.3.2
           TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}

--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -30,6 +30,7 @@ jobs:
         env:
           SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.3.2
           TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}
+          INFINISPAN_CPU: 500m # prevent insufficient cpu error on test-rolling-upgrade pod start
 
       - name: Inspect Cluster
         if: failure()

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -71,7 +71,6 @@ func TestRollingUpgrade(t *testing.T) {
 	entriesPerCache := 100
 	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
 		i.Spec.Replicas = int32(replicas)
-		i.Spec.Container.CPU = "1000m"
 		i.Spec.Service.Container.EphemeralStorage = false
 		i.Spec.Upgrades = &ispnv1.InfinispanUpgradesSpec{
 			Type: ispnv1.UpgradeTypeHotRodRolling,


### PR DESCRIPTION
Closes #2194

Draft: need to verify the `test_hr_rolling_upgrades.yml` action execution