### PR TITLE
[x2207] Add OpenSSL to runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN go mod download
 
 # $rootfs will contain the libraries to manually export to the runtime container
 ENV rootfs=/tmp/rootfs
-RUN dnf install -y --installroot $rootfs openssl && \
+RUN dnf install -y --installroot $rootfs --setopt install_weak_deps=false --nodocs openssl && \
     dnf --installroot $rootfs clean all && \
     rm -rf $rootfs/var/cache/* $rootfs/var/log/dnf* $rootfs/var/log/yum.*
 
@@ -31,7 +31,8 @@ FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=build /bin/infinispan-operator /usr/local/bin/infinispan-operator
 # Open SSL library is not directly used by our operator, 
 # but it may be invoked by OCP using FIPS with GoLang 1.22
-COPY --from=build /tmp/rootfs/ /
+COPY --from=build /tmp/rootfs/usr/bin/openssl /usr/bin/openssl
+COPY --from=build /tmp/rootfs/lib64 /lib64
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
 ENV GOTRACEBACK=single

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,12 @@ COPY go.sum go.sum
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download
 
+# $rootfs will contain the libraries to manually export to the runtime container
+ENV rootfs=/tmp/rootfs
+RUN dnf install -y --installroot $rootfs openssl && \
+    dnf --installroot $rootfs clean all && \
+    rm -rf $rootfs/var/cache/* $rootfs/var/log/dnf* $rootfs/var/log/yum.*
+
 # Copy the go source
 COPY main.go main.go
 COPY api/ api/
@@ -23,6 +29,9 @@ RUN CGO_ENABLED=1 GOOS=linux GO111MODULE=on \
 
 FROM registry.access.redhat.com/ubi9/ubi-micro
 COPY --from=build /bin/infinispan-operator /usr/local/bin/infinispan-operator
+# Open SSL library is not directly used by our operator, 
+# but it may be invoked by OCP using FIPS with GoLang 1.22
+COPY --from=build /tmp/rootfs/ /
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).
 ENV GOTRACEBACK=single


### PR DESCRIPTION
Closes #2207

```
(base) fax@fercoli-redhat-com:~/code/infinispan-operator$ docker run --rm -it --entrypoint bash localhost:5001/infinispan-operator
bash-5.1# openssl version
OpenSSL 3.2.2 4 Jun 2024 (Library: OpenSSL 3.2.2 4 Jun 2024)
bash-5.1# openssl s_client -connect redhat.com
^C
bash-5.1# openssl s_client -connect redhat.com:443
Connecting to 52.200.142.250
CONNECTED(00000003)
depth=2 C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root G2
verify return:1
depth=1 C=US, O=DigiCert Inc, CN=DigiCert Global G2 TLS RSA SHA256 2020 CA1
verify return:1
depth=0 C=US, ST=North Carolina, L=Raleigh, O=Red Hat, Inc., CN=redhat.com
verify return:1
---
Certificate chain
...
```