### PR TITLE
Set source channel to target channel in operand upgrades

### DIFF
--- a/test/e2e/upgrade/upgrade_operands_test.go
+++ b/test/e2e/upgrade/upgrade_operands_test.go
@@ -17,6 +17,7 @@ func TestOperandUpgrades(t *testing.T) {
 	olm := testKube.OLMTestEnv()
 	// Only test Operands in the most recent CSV
 	olm.SubStartingCSV = olm.TargetChannel.CurrentCSVName
+	olm.SourceChannel = olm.TargetChannel
 	olm.PrintManifest()
 
 	testKube.NewNamespace(tutils.Namespace)


### PR DESCRIPTION
The test assumes using latest Operator release but if source channel configuration differs from target channel then the test will fail on unknown CSV.