### PR TITLE
Fix WaitForSubscription sub reference

### DIFF
--- a/test/e2e/utils/olm.go
+++ b/test/e2e/utils/olm.go
@@ -400,7 +400,7 @@ func (k TestKubernetes) WaitForSubscription(sub *coreos.Subscription, predicate 
 				// Create new Subscription with the startingCSV set to the failed version
 				fmt.Println("Attempting to recreate Subscription")
 				startingCSV := sub.Status.InstalledCSV
-				sub = &coreos.Subscription{
+				*sub = coreos.Subscription{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      sub.Name,
 						Namespace: sub.Namespace,


### PR DESCRIPTION
`sub = &coreos.Subscription{...`  makes sub point to a new location in a memory locally but sub called from other function still accesses the old memory location and stale Subscription. As a result the sub in the check is never updated and the waiter fails.