### PR TITLE
Merge TestSpecImage and TestCustomImage

### DIFF
--- a/test/e2e/infinispan/custom_image_test.go
+++ b/test/e2e/infinispan/custom_image_test.go
@@ -2,11 +2,9 @@ package infinispan
 
 import (
 	"context"
-	"strconv"
 	"testing"
 
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
-	"github.com/infinispan/infinispan-operator/pkg/infinispan/version"
 	"github.com/infinispan/infinispan-operator/pkg/kubernetes"
 	"github.com/infinispan/infinispan-operator/pkg/reconcile/pipeline/infinispan/handler/provision"
 	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
@@ -20,30 +18,31 @@ func TestCustomImage(t *testing.T) {
 	t.Parallel()
 	defer testKube.CleanNamespaceAndLogOnPanic(t, tutils.Namespace)
 
-	var operand version.Operand
-	versionManager := tutils.VersionManager()
-	// Attempting to use latest Infinispan Server image while having version set to different major will result in misconfiguration by Operator
-	if tutils.OperandVersion != "" {
-		operand, _ = versionManager.WithRef(tutils.OperandVersion)
-	} else {
-		operand = versionManager.Latest()
-	}
-	img := "quay.io/infinispan/server:" + strconv.FormatUint(operand.UpstreamVersion.Major, 10) + "." + strconv.FormatUint(operand.UpstreamVersion.Minor, 10)
+	// Get the two latest Operands that share the same major/minor version, otherwise we'll hit incompatibility issue
+	customOperand, versionOperand := specImageOperands()
 
+	// Use customerOperand (previous release) as a custom image and spec.version of the latest release in the stream
 	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
-		i.Spec.Image = pointer.String(img)
+		i.Spec.Image = pointer.String(customOperand.Image)
+		i.Spec.Version = versionOperand.Ref()
 	})
 
 	testKube.CreateInfinispan(spec, tutils.Namespace)
 	testKube.WaitForInfinispanPods(1, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
+
 	ispn := testKube.WaitForInfinispanCondition(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed)
-	assert.Equal(t, img, ispn.Status.Operand.Image)
+
+	assert.True(t, ispn.Status.Operand.CustomImage)
+	assert.Equal(t, customOperand.Image, ispn.Status.Operand.Image)
+	assert.Equal(t, versionOperand.Ref(), ispn.Status.Operand.Version)
+	assert.Equal(t, ispnv1.OperandPhaseRunning, ispn.Status.Operand.Phase)
 
 	ss := &appsv1.StatefulSet{}
 	tutils.ExpectNoError(testKube.Kubernetes.Client.Get(context.TODO(), types.NamespacedName{Namespace: spec.Namespace, Name: spec.GetStatefulSetName()}, ss))
 	container := kubernetes.GetContainer(provision.InfinispanContainer, &ss.Spec.Template.Spec)
+
 	// Ensure that no SS rolling upgrade is executed as the default test Operand is marked as a CVE release
 	// https://github.com/infinispan/infinispan-operator/issues/1817
 	assert.Equal(t, int64(1), ss.Generation)
-	assert.Equal(t, img, container.Image)
+	assert.Equal(t, customOperand.Image, container.Image)
 }


### PR DESCRIPTION
TestSpecImage auto selects images and versions from the list of the supported versions for testing, ignoring whether custom version is set for testing. Then it expects the version to match the custom version to test if set. Given this test tests Operator specific behavior for which the versions being tested should be irrelevant I'm opting out for the test to ignore the custom version completely.