### PR TITLE
[#2297] Allow existing Operands in manager.yaml to be overwritten

### DIFF
--- a/.github/workflows/test_upgrades.yml
+++ b/.github/workflows/test_upgrades.yml
@@ -120,7 +120,7 @@ jobs:
         run: |
           if [ "${DEPTH}" -gt -1 ]; then
             export SUBSCRIPTION_STARTING_CSV=$(cat scripts/test-catalog.yml | yq "select(document_index == 1) | .entries[${DEPTH}].name")
-            if [ "${SUBSCRIPTION_STARTING_CSV}" == "null"; then
+            if [[ "${SUBSCRIPTION_STARTING_CSV}" == "null" ]]; then
               echo "No CSV found in test catalog for upgradeDepth '${DEPTH}'"
               exit 1
             fi

--- a/scripts/ci/add_operand_to_csv.sh
+++ b/scripts/ci/add_operand_to_csv.sh
@@ -10,11 +10,18 @@ source "${SCRIPT_DIR}/operand_common.sh"
 
 requiredEnv IMAGE
 
-LATEST_OPERAND_VERSION=$(operandJson | jq -r '. | last | ."upstream-version"')
+JSON=$(operandJson)
+LATEST_OPERAND_VERSION=$(echo "${JSON}" | jq -r '. | last | ."upstream-version"')
 
 if [[ -z "${VERSION}" ]]; then
   VERSION=$(echo "${LATEST_OPERAND_VERSION}" | awk -F. -v OFS=. '{$NF += 1 ; print}')
 fi
 
-NEW_OPERANDS=$(operandJson | jq -r '.[. | length] |= . + {"upstream-version":"'${VERSION}'", "image":"'${IMAGE}'"} | sort_by(."upstream-version" | split(".") | map(tonumber))')
+VERSION_EXISTS=$(echo "${JSON}" | jq "any(.[]; .\"upstream-version\" == \"${VERSION}\")")
+if [[ "${VERSION_EXISTS}" == "true" ]]; then
+  NEW_OPERANDS=$(echo "${JSON}" | jq "(.[] | select(.\"upstream-version\" == \"${VERSION}\").image) |= \"${IMAGE}\"")
+else
+  NEW_OPERANDS=$(echo "${JSON}" | jq -r '.[. | length] |= . + {"upstream-version":"'${VERSION}'", "image":"'${IMAGE}'"} | sort_by(."upstream-version" | split(".") | map(tonumber))')
+fi
+
 operands=${NEW_OPERANDS} yq -i '(select(document_index == 1) | .spec.template.spec.containers[0].env[] | select(.name == "INFINISPAN_OPERAND_VERSIONS")).value = strenv(operands)' ${DEPLOYMENT_FILE}


### PR DESCRIPTION
Closes #2297 

Can be tested with ` IMAGE=test VERSION=16.0.0 ./scripts/ci/add_operand_to_csv.sh; cat config/manager/manager.yaml`