### PR TITLE
Add encoding configuration to the test caches

### DIFF
--- a/test/e2e/backup-restore/backup_restore_test.go
+++ b/test/e2e/backup-restore/backup_restore_test.go
@@ -60,7 +60,7 @@ func testBackupRestore(t *testing.T, clusterSpec clusterSpec, clusterSize, numEn
 
 	cache := tutils.NewCacheHelper(cacheName, client)
 
-	config := "{\"distributed-cache\":{\"mode\":\"SYNC\", \"statistics\":\"true\"}}"
+	config := "{\"distributed-cache\":{\"mode\":\"SYNC\", \"statistics\":\"true\", \"encoding\": {\"media-type\": \"application/json\"}}}"
 	cache.Create(config, mime.ApplicationJson)
 	cache.Populate(numEntries)
 	cache.AssertSize(numEntries)

--- a/test/e2e/upgrade/common.go
+++ b/test/e2e/upgrade/common.go
@@ -65,7 +65,7 @@ func subscription(olm tutils.OLMEnv) *coreos.Subscription {
 func createAndPopulateVolatileCache(cacheName string, numEntries int, client tutils.HTTPClient) {
 	c := tutils.NewCacheHelper(cacheName, client)
 	if !c.Exists() {
-		c.Create(`{"distributed-cache":{"mode":"SYNC"}}`, mime.ApplicationJson)
+		c.Create(`{"distributed-cache":{"mode":"SYNC", "encoding": {"media-type": "application/json"}}}`, mime.ApplicationJson)
 	}
 	if c.Size() != numEntries {
 		c.Populate(numEntries)
@@ -75,7 +75,7 @@ func createAndPopulateVolatileCache(cacheName string, numEntries int, client tut
 
 func createAndPopulatePersistentCache(cacheName string, numEntries int, client tutils.HTTPClient) {
 	cache := tutils.NewCacheHelper(cacheName, client)
-	config := `{"distributed-cache":{"mode":"SYNC", "persistence":{"file-store":{}}}}`
+	config := `{"distributed-cache":{"mode":"SYNC", "persistence":{"file-store":{}}, "encoding": {"media-type": "application/json"}}}`
 	cache.Create(config, mime.ApplicationJson)
 	cache.Populate(numEntries)
 	cache.AssertSize(numEntries)

--- a/test/e2e/xsite/xsite_test.go
+++ b/test/e2e/xsite/xsite_test.go
@@ -894,7 +894,7 @@ func testBackupCrossSiteCache(t *testing.T, useTLS bool) {
 	cacheName := "xsiteCache"
 
 	cache := tutils.NewCacheHelper(cacheName, client)
-	config := "{\"distributed-cache\":{\"mode\":\"SYNC\",\"backups\":{\"xsite2\":{\"backup\":{\"strategy\":\"SYNC\"}}}}}"
+	config := "{\"distributed-cache\":{\"mode\":\"SYNC\",\"backups\":{\"xsite2\":{\"backup\":{\"strategy\":\"SYNC\"}}}, \"encoding\": {\"media-type\": \"application/json\"}}}"
 	cache.Create(config, mime.ApplicationJson)
 	cache.Populate(10)
 	cache.AssertSize(10)


### PR DESCRIPTION
After changes introduced by [deprecation removals ](https://github.com/infinispan/infinispan/pull/15370) puts with `Content-Type: application/json` will fail against caches that don't have encoding configured to either `application/json` or `text/plain`