### PR TITLE
[#2371] Operand cache is not updated when new image sha is available

### DIFF
--- a/.github/actions/operand-cache/action.yml
+++ b/.github/actions/operand-cache/action.yml
@@ -27,7 +27,10 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.images.outputs.tar }}
-        key: ${{ runner.os }}-operands-${{ steps.images.outputs.sha }}
+        # Utilise a unique key with restore-keys as caches cannot be updated on hit
+        key: ${{ runner.os }}-operands-${{ steps.images.outputs.sha }}-${{ github.run_id }}
+        restore-keys: |
+          ${{ runner.os }}-operands-${{ steps.images.outputs.sha }}
 
     # If cache is found, load all images from the single tar file
     - name: Load cached Docker images


### PR DESCRIPTION
Closes #2371