### PR TITLE
Remove image from local registry after push to kind registry

### DIFF
--- a/.github/actions/kind/action.yml
+++ b/.github/actions/kind/action.yml
@@ -25,6 +25,10 @@ runs:
       run: ./scripts/ci/kind.sh
       shell: bash    
 
+    - name: Clean up cached server images
+      run: ./scripts/ci/operand_cleanup.sh
+      shell: bash
+
     - name: Build Operator Image
       run: make operator-build operator-push IMG="localhost:5001/infinispan-operator"
       shell: bash

--- a/.github/actions/operand-cache/action.yml
+++ b/.github/actions/operand-cache/action.yml
@@ -61,3 +61,10 @@ runs:
     - name: Available Images
       shell: bash
       run: docker images
+
+    # Clean up
+    - name: Remove the tar file
+      if: steps.cache-docker-images.outputs.cache-hit == 'true'
+      shell: bash
+      run: |
+        rm ${{ steps.images.outputs.tar }}

--- a/scripts/ci/operand_cleanup.sh
+++ b/scripts/ci/operand_cleanup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+if [[ "$RUNNER_DEBUG" == "1" ]]; then
+  set -x
+fi
+
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+source "${SCRIPT_DIR}/operand_common.sh"
+
+# Remove defined operands from the local registry to free up space on the CI
+for img in ${SERVER_IMAGES}; do
+  docker rmi "${img}" || true
+done


### PR DESCRIPTION
Should solve `No space left on device` workflow failures