### PR TITLE
Remove redundant step in upgrade tests workflow

### DIFF
--- a/.github/workflows/test_upgrades.yml
+++ b/.github/workflows/test_upgrades.yml
@@ -118,12 +118,6 @@ jobs:
       - name: Initialize Kubernetes Cluster
         uses: ./.github/actions/kind
 
-      - if: ${{ inputs.operandArtifact != '' }}
-        name: Push Operand image to kind cluster
-        run: |
-          docker push ${{ inputs.operand }}
-          kind load docker-image ${{ inputs.operand }}
-
       - name: Run GracefulShutdown Upgrade Tests
         run: |
           if [ "${DEPTH}" -gt -1 ]; then


### PR DESCRIPTION
#2387 introduced clean up of cached images from local repository in order to safe space, after they've been uploaded to kind repository. Given the clean up is happening as part of the kind action the follow up step to push new operand fails as it was already removed. Given the Operand has been already uploaded to kind in previous step, the step to load it again is redundant and can be removed.

[1] https://github.com/infinispan/infinispan/blob/main/.github/workflows/operator_upgrade.yaml