### PR TITLE
Experiment for safe-mode

### DIFF
--- a/api/v1/infinispan_types.go
+++ b/api/v1/infinispan_types.go
@@ -292,6 +292,15 @@ type InfinispanLoggingSpec struct {
 	Categories map[string]LoggingLevelType `json:"categories,omitempty"`
 }
 
+type InfinispanPodOverrides struct {
+	Targets []InfinispanSinglePodOverride `json:"targets,omitempty"`
+}
+
+type InfinispanSinglePodOverride struct {
+	Offset   int  `json:"offset,omitempty"`
+	SafeMode bool `json:"safeMode,omitempty"`
+}
+
 // ExposeType describe different exposition methods for Infinispan
 // +kubebuilder:validation:Enum=NodePort;LoadBalancer;Route
 type ExposeType string
@@ -513,6 +522,8 @@ type InfinispanSpec struct {
 	Service InfinispanServiceSpec `json:"service,omitempty"`
 	// +optional
 	Logging *InfinispanLoggingSpec `json:"logging,omitempty"`
+	// +optional
+	Overrides *InfinispanPodOverrides `json:"overrides,omitempty"`
 	// +optional
 	Expose *ExposeSpec `json:"expose,omitempty"`
 	// +optional

--- a/config/crd/bases/infinispan.org_infinispans.yaml
+++ b/config/crd/bases/infinispan.org_infinispans.yaml
@@ -982,6 +982,18 @@ spec:
                       output
                     type: string
                 type: object
+              overrides:
+                properties:
+                  targets:
+                    items:
+                      properties:
+                        offset:
+                          type: integer
+                        safeMode:
+                          type: boolean
+                      type: object
+                    type: array
+                type: object
               replicas:
                 description: The number of nodes in the Infinispan cluster.
                 format: int32

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/hotrod_upgrades.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/hotrod_upgrades.go
@@ -275,7 +275,7 @@ func (r *HotRodRollingUpgradeRequest) reconcileNewConfigMap() (string, error) {
 	configFiles.ServerAdminConfig = adminCfg
 	configFiles.ServerBaseConfig = baseCfg
 	configFiles.ZeroConfig = zeroConfig
-	provision.PopulateServerConfigMap(baseCfg, adminCfg, zeroConfig, configFiles.Log4j, cm)
+	provision.PopulateServerConfigMap(baseCfg, adminCfg, zeroConfig, configFiles.Log4j, nil, cm)
 	return hash.HashString(baseCfg, adminCfg), r.ctx.Resources().Create(cm, true)
 }
 

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/configmaps.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/configmaps.go
@@ -1,6 +1,9 @@
 package provision
 
 import (
+	"bytes"
+	"fmt"
+
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
 	pipeline "github.com/infinispan/infinispan-operator/pkg/reconcile/pipeline/infinispan"
 	corev1 "k8s.io/api/core/v1"
@@ -18,18 +21,64 @@ func InfinispanConfigMap(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	}
 
 	mutateFn := func() error {
-		PopulateServerConfigMap(config.ServerBaseConfig, config.ServerAdminConfig, config.ZeroConfig, config.Log4j, configmap)
+		extras := CalculateExtraParameters(i, ctx)
+		PopulateServerConfigMap(config.ServerBaseConfig, config.ServerAdminConfig, config.ZeroConfig, config.Log4j, extras, configmap)
 		configmap.Labels = i.Labels("infinispan-configmap-configuration")
 		return nil
 	}
 	_, _ = ctx.Resources().CreateOrUpdate(configmap, true, mutateFn, pipeline.RetryOnErr)
 }
 
-func PopulateServerConfigMap(baseConfig, adminConfig, zeroConfig, log4jConfig string, cm *corev1.ConfigMap) {
+func PopulateServerConfigMap(baseConfig, adminConfig, zeroConfig, log4jConfig string, extras map[string]string, cm *corev1.ConfigMap) {
 	cm.Data = map[string]string{
 		"infinispan-admin.xml": adminConfig,
 		"infinispan-base.xml":  baseConfig,
 		"infinispan-zero.xml":  zeroConfig,
 		"log4j.xml":            log4jConfig,
 	}
+
+	if extras != nil {
+		for k, v := range extras {
+			cm.Data[k] = v
+		}
+	}
+}
+
+func CalculateExtraParameters(i *ispnv1.Infinispan, ctx pipeline.Context) map[string]string {
+	extras := make(map[string]string)
+	extras["overrides.env"] = CalculateOverridesEnv(i, ctx)
+	return extras
+}
+
+func CalculateOverridesEnv(infinispan *ispnv1.Infinispan, ctx pipeline.Context) string {
+	var buffer bytes.Buffer
+	if infinispan.Spec.Overrides != nil && len(infinispan.Spec.Overrides.Targets) > 0 {
+		ctx.Log().Info("Overriding pod parameters", "params", infinispan.Spec.Overrides.Targets)
+		podList, err := ctx.InfinispanPods()
+		if err != nil {
+			return ""
+		}
+
+		for _, target := range infinispan.Spec.Overrides.Targets {
+			if target.Offset < 0 || len(podList.Items) <= target.Offset {
+				continue
+			}
+			pod := &podList.Items[target.Offset]
+
+			ctx.Log().Info("Updating pod now", "pod", pod.Name, "safe-mode", target.SafeMode)
+
+			args := ""
+			if target.SafeMode {
+				args += "--safe-mode "
+			}
+
+			if args != "" {
+				buffer.WriteString(fmt.Sprintf("%s=%s\n", pod.Name, args))
+			}
+		}
+	}
+	// Writing an empty string does not delete the file and does not remove the file contents.
+	// Keep the new line so we override any existing content with only the new line.
+	buffer.WriteString("\n")
+	return buffer.String()
 }


### PR DESCRIPTION
I was experimenting with this idea for toggling safe mode on the operator side.

The idea is to expose pod-level parameters on the Infinispan CR. The offset indexes the target pod. It looks like:

```yaml
apiVersion: infinispan.org/v1
kind: Infinispan
metadata:
  name: infinispan
spec:
  replicas: 3
  version: 16.0.3
  overrides:
    targets:
      - offset: 1
        safeMode: true
  service:
    type: DataGrid
```

This opens the possibility of including extra parameters in the future.

When the user updates the CR with the `overrides` arguments, we intercept that and update the ConfigMap. The idea is to cause an `overrides.env` file to be written in the volume by the operator. This file will look something like:

```
$ cat server/conf/operator/overrides.env 
infinispan-1=--safe-mode 

```

It uses the node's hostname to index all the parameters we define. This file is written in ALL pods in the system, in my example above:

```
NAME                                                      READY   STATUS      RESTARTS   AGE     IP            NODE                 NOMINATED NODE   READINESS GATES
infinispan-0                                              1/1     Running     0          2m48s   10.244.0.16   kind-control-plane   <none>           <none>
infinispan-1                                              1/1     Running     0          2m32s   10.244.0.18   kind-control-plane   <none>           <none>
infinispan-2                                              1/1     Running     0          2m23s   10.244.0.20   kind-control-plane   <none>           <none>
```

They all have the `overrides.env` with the same content.

The second part requires a change on Infinispan's side to search for the `overrides.env` file, parse it, and collect all the options specified by the operator when starting the server.


I think this approach also requires the operator to delete the targeted pods to trigger a restart in some cases. If the pod is already in a crash loop state, then it is all good; the pod will restart with safe mode enabled. But if the pod is alive but not ready, toggling safe-mode would require an additional step of forcing the pod restart.