### PR TITLE
Add Operand auto PR is not created against a fork

### DIFF
--- a/.github/workflows/add_operand.yml
+++ b/.github/workflows/add_operand.yml
@@ -80,7 +80,6 @@ jobs:
           author: Infinispan <infinispan@infinispan.org>
           branch: operand-${{ env.VERSION }}
           delete-branch: true
-          push-to-fork: ${{ inputs.repository }}
           title: 'Add Operand ${{ env.VERSION }}'
           body: 'Add Operand ${{ env.VERSION }}'
 


### PR DESCRIPTION
'push-to-fork' will fail the action as the ${{inputs.repository}} is not a fork