### PR TITLE
Triggerable CI: Forgotten input

### DIFF
--- a/.github/actions/operand-cache/action.yml
+++ b/.github/actions/operand-cache/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'Populate cache with operand images if true'
     default: 'false'
     required: false
+  operand:
+    description: 'The FQN of the Operand image to be used. Used to decide whether to add a snapshot image.'
+    required: false
+    type: string
 
 runs:
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
         uses: ./.github/actions/operand-cache
         with:
           populate: 'true'
+          operand: ${{ inputs.operand }}
 
       - name: Inject custom Operand
         uses: ./.github/actions/custom-operand
@@ -155,6 +156,7 @@ jobs:
       operandVersion: ${{ inputs.operandVersion }}
       ref: ${{ inputs.ref }}
       repository: ${{ inputs.repository }}
+      skipList: ${{ inputs.skipList }}
 
   hr-rolling-upgrades:
     needs: images

--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Cache Operand Images
         uses: ./.github/actions/operand-cache
+        with:
+          operand: ${{ inputs.operand }}
 
       - name: Inject custom Operand
         uses: ./.github/actions/custom-operand

--- a/.github/workflows/test_upgrades.yml
+++ b/.github/workflows/test_upgrades.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Cache Operand Images
         uses: ./.github/actions/operand-cache
+        with:
+          operand: ${{ inputs.operand }}
 
       - name: Inject custom Operand
         uses: ./.github/actions/custom-operand

--- a/.github/workflows/test_without_olm.yml
+++ b/.github/workflows/test_without_olm.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Cache Operand Images
         uses: ./.github/actions/operand-cache
+        with:
+          operand: ${{ inputs.operand }}
 
       - name: Inject custom Operand
         uses: ./.github/actions/custom-operand

--- a/.github/workflows/test_xsite.yml
+++ b/.github/workflows/test_xsite.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Cache Operand Images
         uses: ./.github/actions/operand-cache
+        with:
+          operand: ${{ inputs.operand }}
 
       - name: Inject custom Operand
         uses: ./.github/actions/custom-operand


### PR DESCRIPTION
`operand` input in the cache images action is used to either include or exclude the snapshot image