### PR TITLE
feat: support propagation of external labels (e.g. Kyverno) to StatefulSet pod selector 

### DIFF
--- a/.github/workflows/image_release.yaml
+++ b/.github/workflows/image_release.yaml
@@ -2,7 +2,7 @@ name: Image Release
 
 on:
   schedule:
-    - cron: '30 4 * * *'
+    - cron: '0 0 * * *'
 
   workflow_dispatch:
     inputs:
@@ -31,26 +31,54 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          fetch-depth: 2
+          fetch-depth: 0
           ref: ${{ github.event.inputs.ref || 'main' }}
           repository: ${{ github.repository }}
           token: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
           path: operator
 
       - name: Check if new operand added
+        id: check_operand
         working-directory: operator
-        id: check
         run: |
-          PREV_COMMIT=$(git rev-parse HEAD~1 2>/dev/null || echo HEAD)
-          if git diff --quiet $PREV_COMMIT HEAD -- config/manager/manager.yaml; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
+          LAST_TAG=$(git describe --tags --abbrev=0)
+          echo "Last release tag: $LAST_TAG"
+          ADDED=$(git diff $LAST_TAG HEAD -- config/manager/manager.yaml | grep '^+' | grep '"upstream-version"')
+          echo "Added operand:"
+          echo "$ADDED"
+          if [ -n "$ADDED" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Check open PRs from forks repository
+        id: check_pr_status
+        env:
+          GH_TOKEN: ${{ secrets.FORK_PAT }}
+        run: |
+          PR1=$(gh pr list \
+            --repo infinispan-qe-bot/community-operators \
+            --state open \
+            --json number \
+            --jq 'length')
+          PR2=$(gh pr list \
+            --repo infinispan-qe-bot/community-operators-prod \
+            --state open \
+            --json number \
+            --jq 'length')
+          echo "Repo infinispan-qe-bot/community-operators PR count: $PR1"
+          echo "Repo infinispan-qe-bot/community-operators-prod  PR count: $PR2"
+          if [ "$PR1" -gt 0 ] || [ "$PR2" -gt 0 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi  
+
 
   release:
     needs: check_operand
-    if: needs.check_operand.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
+    if: (needs.check_operand.outputs.changed == 'true' && needs.check_pr_status.outputs.skip != 'true') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Configure Git
@@ -181,6 +209,6 @@ jobs:
         with:
           ghToken: ${{ secrets.INFINISPAN_RELEASE_TOKEN }}
           targetBranch: 'main'
-          templateYmlFile: './infinispan-operator/.github-scheduled-workflows/publish-main.yaml'
+          templateYmlFile: 'operator/.github-scheduled-workflows/publish-main.yaml'
           targetYmlFileName: publish-main.yaml
           copyEnvVariables: REF REL_VERSION

--- a/api/v1/types_util.go
+++ b/api/v1/types_util.go
@@ -29,6 +29,8 @@ const (
 const (
 	// PodTargetLabels labels propagated to pods
 	PodTargetLabels string = "infinispan.org/podTargetLabels"
+	// PodSelectorLabels labels included in the pod selector
+	PodSelectorLabels string = "infinispan.org/podSelectorLabels"
 	// TargetLabels labels propagated to services/ingresses/routes
 	TargetLabels string = "infinispan.org/targetLabels"
 	// ServiceMonitorTargetLabels labels propagated to ServiceMonitor targetLabel for the label retainment
@@ -659,10 +661,12 @@ func (ispn *Infinispan) ServiceMonitorTargetLabels() []string {
 }
 
 func (ispn *Infinispan) ServiceSelectorLabels() map[string]string {
-	return map[string]string{
+	labels := map[string]string{
 		"clusterName": ispn.Name,
 		"app":         "infinispan-pod",
 	}
+	addLabelsFor(ispn, PodSelectorLabels, labels)
+	return labels
 }
 
 // ExternalServiceLabels returns all labels to be applied to the external service pods, including those defined by the
@@ -690,7 +694,9 @@ func (ispn *Infinispan) PodLabels() map[string]string {
 // PodSelectorLabels returns the minimum required labels to identify an Infinispan Pod. It does not contain any user
 // defined labels. This should always be used for selectors so that updates to user labels don't break the controller logic.
 func (ispn *Infinispan) PodSelectorLabels() map[string]string {
-	return ispn.Labels("infinispan-pod")
+	labels := ispn.Labels("infinispan-pod")
+	addLabelsFor(ispn, PodSelectorLabels, labels)
+	return labels
 }
 
 // GossipRouterPodLabels returns all labels to be applied to the GossipRouter pod. It's values


### PR DESCRIPTION
## Summary

This change allows the Infinispan operator to handle labels injected by Kyverno (or any external controller) by enabling them to be included in the StatefulSet's immutable pod selector.

## Changes

- Added a new internal annotation `infinispan.org/podSelectorLabels` in `api/v1/types_util.go`.
- Updated `PodSelectorLabels()` to include labels listed in this annotation when they are present on the Infinispan CR.
- Updated `ServiceSelectorLabels()` to include those same labels, ensuring consistent pod discovery across services (ping, etc.).
- Together, these changes allow users to explicitly declare which CR labels should be propagated to both Pod labels and the StatefulSet's immutable `Spec.Selector.MatchLabels`.

## Notes

To use this feature, add the desired label to your Infinispan CR and list it in the `infinispan.org/podSelectorLabels` annotation:
```yaml
apiVersion: infinispan.org/v1
kind: Infinispan
metadata:
  name: example-infinispan
  labels:
    my-kyverno-label: my-value
  annotations:
    infinispan.org/podSelectorLabels: my-kyverno-label
spec:
  replicas: 3
```

> ⚠️ Because `Spec.Selector` is immutable on StatefulSets, the labels listed in this annotation must be set on the CR **before** the StatefulSet is first created. Changing them on an existing StatefulSet will require its deletion and recreation.