### PR TITLE
Add AI agent instructions for coding, testing, reviews, and issues

### DIFF
--- a/.cursor/rules/operator.mdc
+++ b/.cursor/rules/operator.mdc
@@ -1,0 +1,9 @@
+---
+description: Infinispan Operator project guidelines for coding and reviews
+globs:
+alwaysApply: true
+---
+
+# Project Context: Infinispan Operator
+
+Read and follow the instructions in AI.md at the repository root.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,3 @@
+# Project Context: Infinispan Operator
+
+Read and follow the instructions in AI.md at the repository root.

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,12 @@ bundle.Dockerfile
 
 # Ignore directory created by scripts/create-olm-catalog.sh
 infinispan-olm-catalog/
+
+# ignore agent-specific instruction files
+CLAUDE.md
+GEMINI.md
+.augment*
+.clinerules
+.goosehints
+AGENTS.md
+.claude/

--- a/AI-CODE.md
+++ b/AI-CODE.md
@@ -1,0 +1,101 @@
+# Coding Instructions
+
+## Tech Stack
+* **Go Version:** 1.25 (see `go.mod`)
+* **Build Tool:** Make
+* **Framework:** Operator SDK / kubebuilder v3
+* **Key Libraries:**
+  - `sigs.k8s.io/controller-runtime` — core operator framework (reconciler, manager, client)
+  - `k8s.io/api`, `k8s.io/client-go` — Kubernetes client libraries
+  - `github.com/onsi/ginkgo` + `github.com/onsi/gomega` — BDD testing
+  - `go.uber.org/zap` — structured logging
+  - `github.com/openshift/api` — OpenShift-specific APIs (Routes)
+  - `github.com/prometheus-operator/prometheus-operator` — Prometheus monitoring integration
+
+## Project Architecture
+
+* **`main.go`** — Entry point. Selects between `operator` and `listener` subcommands.
+* **`api/v1/`** — Infinispan CRD type definitions, webhooks, and utilities.
+* **`api/v2alpha1/`** — Backup, Restore, Cache, Batch, Schema CRD types and webhooks.
+* **`controllers/`** — Reconciler implementations for each CRD.
+* **`controllers/constants/`** — Shared controller constants.
+* **`controllers/resources/`** — Kubernetes resource builders.
+* **`pkg/reconcile/pipeline/infinispan/`** — Pipeline-based reconciliation architecture.
+  - `api.go` — Pipeline interfaces (Handler, Context, FlowStatus).
+  - `handler/provision/` — Provision phase: ConfigMaps, Secrets, dependencies.
+  - `handler/configure/` — Configure phase: auth, TLS, server configuration.
+  - `handler/manage/` — Manage phase: upgrades, scaling, StatefulSet updates.
+  - `context/` — Pipeline context implementation.
+  - `pipeline/` — Pipeline orchestration.
+* **`pkg/infinispan/`** — Infinispan client (REST/Hot Rod) and version management.
+* **`pkg/kubernetes/`** — Kubernetes utility helpers.
+* **`pkg/http/`** — HTTP client utilities.
+* **`pkg/templates/`** — Go template management.
+* **`launcher/`** — Operator and listener launcher packages.
+* **`config/`** — Kustomize-managed Kubernetes manifests (CRDs, RBAC, webhooks, manager deployment, samples).
+* **`test/e2e/`** — End-to-end tests (Ginkgo-based).
+* **`test-integration/`** — Java/Maven integration tests.
+* **`documentation/`** — AsciiDoc documentation.
+* **`scripts/`** — CI and utility scripts.
+* **`hack/`** — Development helper scripts.
+
+## Custom Resources
+
+| Kind       | API Version   | Description                              |
+|------------|---------------|------------------------------------------|
+| Infinispan | v1            | Main CRD — manages Infinispan clusters   |
+| Cache      | v2alpha1      | Manages individual caches                |
+| Backup     | v2alpha1      | Manages cluster backups                  |
+| Restore    | v2alpha1      | Manages cluster restores                 |
+| Batch      | v2alpha1      | Executes batch operations                |
+| Schema     | v2alpha1      | Manages Protobuf schemas                 |
+
+All CRDs have validating and defaulting webhooks.
+
+## Common Build Commands
+* **Build operator binary:** `make manager`
+* **Run unit tests:** `make test`
+* **Lint:** `make lint`
+* **Format:** `make fmt`
+* **Vet:** `make vet`
+* **Generate CRDs/RBAC/webhooks:** `make manifests`
+* **Generate deepcopy methods:** `make generate`
+* **Generate mocks:** `make generate-mocks`
+* **Build operator image:** `make operator-build IMG=<image>`
+* **Install CRDs into cluster:** `make install`
+* **Run operator locally:** `make run`
+* **Run E2E tests:** `make infinispan-test`, `make cache-test`, `make batch-test`, `make schema-test`, `make backuprestore-test`, `make xsite-test`, `make webhook-test`, `make upgrade-test`
+
+## Development Standards
+
+### CRD and API Changes
+* CRD types live in `api/v1/` and `api/v2alpha1/`. After modifying types, always run `make manifests` and `make generate` to regenerate CRD YAML and deepcopy methods.
+* Use kubebuilder markers for validation, defaults, and documentation (e.g., `// +kubebuilder:validation:Minimum=0`).
+* Webhooks for defaulting and validation are in `*_webhook.go` files alongside the types.
+* CRD changes must be backward-compatible with existing Custom Resources in live clusters.
+
+### Controller Patterns
+* The main Infinispan reconciler uses a **pipeline architecture**: handlers chained in three phases (Provision, Configure, Manage).
+* Other reconcilers (Cache, Backup, Restore, Batch, Schema) use simpler direct reconciliation.
+* Controllers use Kubernetes ownership semantics (`OwnerReference`) for garbage collection.
+* Use the `EventRecorder` to log important events to the Kubernetes cluster.
+
+### Code Style
+* **Formatting:** `go fmt` (via `make fmt`).
+* **Linting:** golangci-lint with `errorlint` and `bodyclose` linters (via `make lint`).
+* **Vet:** `go vet` (via `make vet`).
+* Run `make fmt` and `make vet` before committing.
+
+### Commit Messages
+* Commit messages must start with `[#00000] Summary` where `00000` is the GitHub issue number.
+
+### Git Branches
+* Branches should be named `issueid/issue_summary` and use `origin/main` as the upstream.
+
+## Development Platform
+* **Issues:** Use GitHub issues. No issue templates are currently defined — use plain issues with a descriptive title and body.
+
+## Related Projects
+* **Server:** The Infinispan server source code is in `../infinispan`
+* **Console:** The Infinispan Console source code is in `../infinispan-console`
+* **Website:** The Infinispan website source code is in `../infinispan.github.io`

--- a/AI-DOCS.md
+++ b/AI-DOCS.md
@@ -1,0 +1,114 @@
+# Documentation Instructions
+
+## Content Organization
+
+Infinispan Operator documentation follows Red Hat Modular Documentation with a three-layer hierarchy:
+
+```
+Title (guide/book)  →  titles/{guide}/{guide}.asciidoc
+  └── Story (assembly)  →  stories/assembly_*.adoc
+      └── Topic (reusable content)  →  topics/{con,proc,ref}_*.adoc
+          └── Code/Config examples  →  topics/{code_examples,cmd_examples,rest_examples,xml,json,yaml,...}
+```
+
+### Titles
+- Located in `documentation/asciidoc/titles/{guide}/`
+- Each title has a main `.asciidoc` file and a `stories.adoc` that includes assemblies
+- Sets document attributes and `:context:`
+
+### Stories (Assemblies)
+- Located in `documentation/asciidoc/stories/`
+- Named `assembly_*.adoc`
+- Assemble multiple topics into a user journey
+- Set and restore `:context:` for anchor scoping
+- Include topics with `include::{topics}/con_*.adoc[leveloffset=+N]`
+
+### Topics
+- Located in `documentation/asciidoc/topics/`
+- Three types with strict naming prefixes:
+  - **`con_*`** — Concept: explains what something is and why it matters
+  - **`proc_*`** — Procedure: step-by-step instructions (uses `.Procedure` header with numbered steps)
+  - **`ref_*`** — Reference: tables, API details, configuration options
+- Each topic must have an ID: `[id='descriptive-name_{context}']`
+- Topics are designed for reuse across multiple guides
+
+### Code and Configuration Examples
+- Java code examples: `topics/code_examples/*.java`
+- CLI command examples: `topics/cmd_examples/`
+- REST request examples: `topics/rest_examples/`
+- Configuration files by format: `topics/xml/`, `topics/json/`, `topics/yaml/`, `topics/properties/`
+- Include in topics with: `include::code_examples/MyClass.java[]`
+
+## Writing Style
+
+### Voice and Tense
+- **Active voice**, present tense, second person ("you")
+- Never use first person ("we", "I")
+- No contractions ("do not", not "don't")
+- American English spelling
+
+### Formatting
+- One sentence per line (hard wrap at sentence boundaries, not at column width)
+- Use `{ispn_operator}` attribute for the product name, never hardcode "Infinispan Operator" in content
+- Use `{brandname}` attribute for the server name, never hardcode "Infinispan" in content
+- File paths, class names, XML attributes: backticks (`` ` ``)
+- GUI elements: bold (`*Add*`)
+- First occurrence of a term: italics (`_High availability_`)
+- Numbers below 10: spell out ("four"); 10 and above: numerals ("12")
+- Avoid Latin abbreviations (use "for example" not "e.g.", "that is" not "i.e.")
+- Never use "simply" unless it genuinely clarifies
+
+### Section IDs and Cross-References
+- Section IDs use underscores: `[id='cache_interface_{context}']`
+- Reusable topics must include `{context}` in their ID
+- Internal links: `link:#anchor_name[Link Text]`
+
+### Admonitions
+```asciidoc
+[NOTE]
+====
+Note content.
+====
+```
+Use `NOTE`, `TIP`, `WARNING`, `IMPORTANT` as appropriate.
+
+### Code Blocks
+```asciidoc
+[source,java,options="nowrap",subs=attributes+]
+.MyClass.java
+----
+include::code_examples/MyClass.java[]
+----
+```
+
+### Images
+- Format: PNG or JPG, minimum 660px wide at 110 dpi, maximum 300KB
+- Location: `topics/images/`
+- All images must have alt text for accessibility
+- Syntax: `image::filename.png[Alt text description]`
+
+## Conditional Content
+
+Use `ifdef` / `endif` for community vs enterprise content:
+```asciidoc
+ifdef::community[]
+Community-only content here.
+endif::community[]
+```
+
+## Terminology
+
+Key terms:
+- **Cache Manager** — two words, capitalized (use `CacheManager` only for the Java interface)
+- **Off-heap** — always hyphenated when used as an adjective
+- **Query** — use "query" not "search" for looking up information
+- **Reindex** — one word, no hyphen
+- **Add/Remove** — for container membership; **Create/Delete** — for building/destroying objects; **Clear** — delete all elements
+
+## When Creating New Documentation
+1. Determine if the content is a concept, procedure, or reference — use the correct `con_`/`proc_`/`ref_` prefix
+2. Place the topic file in `documentation/asciidoc/topics/`
+3. Create or update an assembly in `documentation/asciidoc/stories/` to include the new topic
+4. Update the relevant `stories.adoc` in the title directory if adding a new assembly
+5. Always set `[id='descriptive-name_{context}']` at the top of the topic
+6. Include code examples as separate files, not inline

--- a/AI-ISSUES.md
+++ b/AI-ISSUES.md
@@ -1,0 +1,45 @@
+# Issue Creation Instructions
+
+## Issue Types
+
+The Infinispan Operator uses plain GitHub issues (no issue templates are currently defined). Use labels for classification:
+
+| Label              | When to Use                                                          |
+|--------------------|----------------------------------------------------------------------|
+| **kind/bug**       | Something is broken or behaving incorrectly                          |
+| **kind/enhancement** | New functionality or enhancement to existing functionality         |
+| **area/housekeeping** | Cleanup, refactoring, dependency updates — not a bug or feature   |
+
+## Required Information by Type
+
+### Bug Report
+- **Title** — concise description of the bug
+- **Description** — what is broken
+- **Expected behavior** — what should happen
+- **Actual behavior** — what happens instead
+- **How to reproduce** — steps, CR YAML, or cluster configuration to reproduce
+- **Environment** — Kubernetes/OpenShift version, operator version, Infinispan version
+
+Note: security vulnerabilities should be reported privately to security@infinispan.org, not as public issues.
+
+### Feature / Enhancement
+- **Title** — concise description of the feature
+- **Description** — what the feature does and why it is needed
+- **Implementation ideas** (optional) — technical approach, affected CRDs, API changes
+
+### Housekeeping
+- **Title** — concise description of the task
+- **Description** — what needs to be done
+- **Implementation ideas** (optional) — technical approach
+
+## Conventions
+
+- Issue titles should be concise and descriptive
+- Reference related issues and PRs using `#number` format
+- When creating issues from code investigation, include file paths, CRD kinds, and controller names where relevant
+- Commit messages reference issues using `[#00000] Summary` format
+
+## External Resources
+
+- Community discussions: [GitHub Discussions](https://github.com/infinispan/infinispan/discussions)
+- Live chat: [Infinispan Zulip](https://infinispan.zulipchat.com/)

--- a/AI-TEST.md
+++ b/AI-TEST.md
@@ -1,0 +1,129 @@
+# Testing Instructions
+
+## Test Frameworks
+
+The Infinispan Operator uses two levels of testing:
+
+| Type           | Framework                  | Location                                          | Run Command       |
+|----------------|----------------------------|---------------------------------------------------|--------------------|
+| Unit tests     | Ginkgo + Gomega + envtest  | `api/**/*_test.go`, `controllers/*_test.go`, `pkg/**/*_test.go` | `make test`        |
+| E2E tests      | Ginkgo + Gomega            | `test/e2e/`                                       | `make <cr>-test`   |
+
+## Writing Unit Tests
+
+### Framework
+
+Unit tests use the standard Go testing package with Ginkgo (BDD-style) and Gomega (assertions). The `envtest` package provides a local Kubernetes API server for controller and webhook tests.
+
+### Location
+
+Unit tests are colocated with source files following Go convention:
+- `api/v1/infinispan_webhook_test.go` — webhook validation tests
+- `api/v1/types_util_test.go` — type utility tests
+- `api/v2alpha1/*_test.go` — v2alpha1 API tests
+- `controllers/*_test.go` — controller unit tests
+- `pkg/**/*_test.go` — package-level tests
+
+### Example: Webhook Test
+
+```go
+var _ = Describe("Infinispan Webhooks", func() {
+    Context("when validating an Infinispan CR", func() {
+        It("should reject invalid replicas", func() {
+            ispn := &v1.Infinispan{
+                Spec: v1.InfinispanSpec{
+                    Replicas: -1,
+                },
+            }
+            _, err := ispn.ValidateCreate()
+            Expect(err).To(HaveOccurred())
+        })
+    })
+})
+```
+
+### Example: Standard Go Test
+
+```go
+func TestMyFunction(t *testing.T) {
+    result := MyFunction("input")
+    assert.Equal(t, "expected", result)
+}
+```
+
+### Mocking
+
+- Mocks are generated using `mockgen` (via `make generate-mocks`).
+- Pipeline interface mocks live in `pkg/reconcile/pipeline/infinispan/api_mocks.go`.
+- After modifying interfaces in `api.go`, regenerate mocks with `make generate-mocks`.
+
+## Writing E2E Tests
+
+### Directory Structure
+
+E2E tests are organized by Custom Resource type under `test/e2e/`:
+- `test/e2e/infinispan/` — Infinispan CR tests
+- `test/e2e/cache/` — Cache CR tests
+- `test/e2e/batch/` — Batch CR tests
+- `test/e2e/schema/` — Schema CR tests
+- `test/e2e/backup-restore/` — Backup/Restore CR tests
+- `test/e2e/xsite/` — Cross-site replication tests
+- `test/e2e/webhook/` — OLM webhook integration tests
+- `test/e2e/upgrade/` — OLM upgrade tests
+- `test/e2e/hotrod-rolling-upgrade/` — Hot Rod rolling upgrade tests
+- `test/e2e/multinamespace/` — Multi-namespace tests
+- `test/e2e/utils/` — Shared test utilities and helpers
+
+### Prerequisites
+
+E2E tests run against a real Kubernetes cluster:
+- A running Kubernetes or OpenShift cluster (configured via `KUBECONFIG`)
+- The operator CRDs installed (`make install`)
+- The `WATCH_NAMESPACE` environment variable set
+
+### Running E2E Tests
+
+```bash
+# Run Infinispan CR E2E tests
+make infinispan-test
+
+# Run Cache CR E2E tests
+make cache-test
+
+# Run Batch CR E2E tests
+make batch-test
+
+# Run Schema CR E2E tests
+make schema-test
+
+# Run Backup/Restore E2E tests
+make backuprestore-test
+
+# Run cross-site E2E tests (45 min timeout)
+make xsite-test
+
+# Run OLM webhook E2E tests
+make webhook-test
+
+# Run OLM upgrade E2E tests (2h timeout)
+make upgrade-test
+
+# Run tests via script directly with custom timeout and parallelism
+scripts/run-tests.sh <test-bundle> [timeout] [parallel-count]
+```
+
+## Running Tests
+
+```bash
+# Unit tests (uses envtest for K8s API server)
+make test
+
+# Lint before committing
+make lint
+
+# Format before committing
+make fmt
+
+# Vet before committing
+make vet
+```

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,20 @@
+# Project Context: Infinispan Operator
+
+The Infinispan Operator is a Kubernetes operator for automating the deployment, scaling, and management of Infinispan clusters on Kubernetes and OpenShift. It is built with Go using the Operator SDK (kubebuilder v3 layout).
+
+## Shared guidelines
+- Use the project's established patterns and terminology. When in doubt, follow the conventions of the package you are working in.
+- Prefer clarity over cleverness. This is a long-lived open-source project with many contributors.
+- Be aware of backward compatibility implications — CRD changes must be compatible with existing Custom Resources in live clusters.
+
+## Coding instructions
+When planning and writing code, read and follow the instructions in AI-CODE.md.
+
+## Testing instructions
+When writing or modifying tests, read and follow the instructions in AI-TEST.md.
+
+## Issue creation instructions
+When creating GitHub issues, read and follow the instructions in AI-ISSUES.md.
+
+## Pull request review instructions
+When reviewing PRs, read and follow the instructions in REVIEW.md.

--- a/AI.md
+++ b/AI.md
@@ -1,0 +1,23 @@
+# Project Context: Infinispan Operator
+
+The Infinispan Operator is a Kubernetes operator for automating the deployment, scaling, and management of Infinispan clusters on Kubernetes and OpenShift. It is built with Go using the Operator SDK (kubebuilder v3 layout).
+
+## Shared guidelines
+- Use the project's established patterns and terminology. When in doubt, follow the conventions of the package you are working in.
+- Prefer clarity over cleverness. This is a long-lived open-source project with many contributors.
+- Be aware of backward compatibility implications — CRD changes must be compatible with existing Custom Resources in live clusters.
+
+## Coding instructions
+When planning and writing code, read and follow the instructions in AI-CODE.md.
+
+## Testing instructions
+When writing or modifying tests, read and follow the instructions in AI-TEST.md.
+
+## Issue creation instructions
+When creating GitHub issues, read and follow the instructions in AI-ISSUES.md.
+
+## Documentation instructions
+When writing or modifying documentation, read and follow the instructions in AI-DOCS.md.
+
+## Pull request review instructions
+When reviewing PRs, read and follow the instructions in REVIEW.md.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,108 @@
+Guidelines for contributing to the Infinispan Operator
+====
+
+Contributions from the community are essential in keeping the Infinispan Operator strong and successful.
+
+This guide focuses on how to contribute back to the Infinispan Operator using GitHub pull requests.
+
+## Legal
+
+All original contributions to the Infinispan Operator are licensed under the
+[ASL - Apache License](https://www.apache.org/licenses/LICENSE-2.0),
+version 2.0 or later, or, if another license is specified as governing the file or directory being
+modified, such other license.
+
+All contributions are subject to the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
+
+## Getting Started
+
+If you are just getting started with Git, GitHub and/or contributing to the Infinispan Operator there are a
+few prerequisite steps:
+
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* [Fork](https://help.github.com/articles/fork-a-repo/) the
+  Infinispan Operator [repository](https://github.com/infinispan/infinispan-operator).
+* Install [Go](https://go.dev/doc/install) (see `go.mod` for the required version)
+* Install [Make](https://www.gnu.org/software/make/)
+* Have access to a Kubernetes or OpenShift cluster for E2E testing
+
+## Building
+
+```shell
+make manager
+```
+
+## Running Tests
+
+```shell
+# Unit tests
+make test
+
+# Lint
+make lint
+
+# E2E tests (requires a running cluster)
+make infinispan-test
+make cache-test
+```
+
+## Create a topic branch
+
+Create a "topic" branch on which you will work. The convention is to name the branch
+using the issue number. If there is not already an issue covering the work you
+want to do, create one. Assuming you will be working from the main branch and working
+on issue 1234:
+
+```shell
+git checkout -b 1234/my-feature origin/main
+```
+
+## Code
+
+Code away...
+
+After modifying CRD types, always run:
+
+```shell
+make manifests    # Regenerate CRD YAML, RBAC, webhooks
+make generate     # Regenerate deepcopy methods
+```
+
+## Commit
+
+* Make commits of logical units.
+* Be sure to start the commit messages with the issue number you are working on, in the format `[#1234] Summary`. This allows easy cross-referencing on GitHub.
+* Avoid formatting changes to existing code as much as possible: they make the intent of your patch less clear.
+* Make sure you have added the necessary tests for your changes.
+* Run the tests to assure nothing else was accidentally broken:
+
+```shell
+make test
+make lint
+```
+
+_Prior to committing, if you want to pull in the latest upstream changes (highly
+appreciated by the way), please use rebasing rather than merging. Merging creates
+"merge commits" that really muck up the project timeline._
+
+```shell
+git pull --rebase upstream main
+```
+
+## Use of Generative AI
+
+Generative AI tools may be used to assist in writing code, tests, or documentation, provided that you fully understand every change you submit. The goal is to keep the Operator's code consistent and high-quality while respecting reviewers' limited time.
+
+If you use generative AI to assist with your contribution, all the following are required:
+
+* You understand the change. You must be able to explain what your code does and why. Submitting AI-generated code you do not understand is not acceptable.
+* You engage with review feedback. You are expected to respond to questions and comments from reviewers. If you use AI to help draft responses, you must edit and proofread them to ensure they are accurate and address the reviewer's point.
+* You can revise the code yourself. If a reviewer requests changes, you are responsible for addressing them, even if your AI tool is unable to produce a suitable fix.
+* You disclose AI agents usage. Include a note in the PR description indicating the usage of AI agents for generating complete solutions from a prompt (i.e. you do not need to mention a simple AI autocomplete). This helps reviewers calibrate their review.
+* You ensure licensing compliance. All generated code must be released under the Apache License, Version 2.0, the same license as the Infinispan Operator. You are responsible for verifying that the tools you use do not introduce additional licensing restrictions.
+
+## Submit
+
+* Push your changes to a topic branch in your fork of the repository.
+* Initiate a [pull request](http://help.github.com/send-pull-requests/).
+* Cross-reference the issue number in the pull request description.

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,41 @@
+# Pull Request Reviewing Instructions
+
+## Verify the basics
+
+- Commit messages reference a GitHub issue in the `[#00000] Summary` format.
+- Commits are squashed into self-contained units of work.
+- Tests are included or a convincing justification is provided.
+
+## What Important means here
+
+Reserve Important for findings that would break behavior, cause data loss, or block a rollback: incorrect reconciliation
+logic, CRD schema changes that break existing Custom Resources, RBAC permission gaps, missing error handling for
+Kubernetes API calls, and security issues (leaked secrets, overly broad RBAC). Style, naming, and refactoring
+suggestions are Nit at most.
+
+## Operator-specific concerns
+
+Watch for these domain-specific issues that general review might miss:
+- **CRD backward compatibility:** changes to CRD types (`api/v1/`, `api/v2alpha1/`) must not break existing Custom Resources in live clusters. Field removals, type changes, and required field additions are breaking changes.
+- **Generated code:** after API type changes, `make manifests` and `make generate` must be run. Verify that `zz_generated.deepcopy.go` and CRD YAML in `config/crd/bases/` are up to date.
+- **RBAC permissions:** changes to the resources a controller watches or modifies may require RBAC marker updates (`// +kubebuilder:rbac:...`) and regeneration of `config/rbac/`.
+- **Reconciliation idempotency:** reconcilers must be idempotent — running the same reconciliation twice with no external changes must produce the same result. Watch for side effects that are not guarded by state checks.
+- **Error handling:** Kubernetes API calls can fail transiently. Verify that errors are returned (triggering a requeue) rather than silently swallowed.
+- **Status updates:** changes to status subresources should use `Status().Update()`, not `Update()`, to avoid conflicts with spec changes.
+- **Ownership and garbage collection:** resources created by the operator should have `OwnerReference` set so they are cleaned up when the parent CR is deleted.
+- **Webhook validation:** defaulting and validating webhooks must handle both create and update operations correctly. Validation should not block legitimate updates.
+- **Pipeline handler ordering:** the Infinispan reconciler uses a pipeline with three phases (Provision, Configure, Manage). New handlers must be placed in the correct phase and position.
+
+## Cap the nits
+
+Report at most five Nits per review. If you found more, say "plus N similar items" in the summary instead of posting
+them inline. If everything you found is a Nit, lead the summary with "No blocking issues."
+
+## Do not report
+
+- Anything CI already enforces: lint, formatting, vet errors
+- Test-only code that intentionally violates production rules
+
+## CI Failures
+
+- If the CI checks have been executed, look at the results and try to determine if any failures are related to the changes.


### PR DESCRIPTION
Closes: #2498

## Summary

Add structured AI agent instructions to help AI coding assistants (Claude, Copilot, Cursor, etc.) work effectively with the Infinispan Operator codebase. Mirrors the approach used in the main Infinispan repository (infinispan/infinispan#17265).

### New files
- `AI.md` — main entry point with project context and pointers
- `AI-CODE.md` — coding instructions: Go/Operator SDK patterns, CRD architecture, pipeline reconciliation, custom resources table, build commands, code style
- `AI-TEST.md` — testing instructions: Ginkgo/Gomega unit tests with envtest, E2E test suites per CRD type
- `AI-ISSUES.md` — issue creation instructions (no templates exist yet, documents label-based classification)
- `REVIEW.md` — PR review instructions with operator-specific concerns (CRD backward compatibility, RBAC, reconciliation idempotency, webhook validation, pipeline handler ordering, ownership/GC)
- `CONTRIBUTING.md` — contribution guide with build/test instructions and generative AI usage section
- `.github/copilot-instructions.md` — GitHub Copilot pointer to AI.md
- `.cursor/rules/operator.mdc` — Cursor rules pointer to AI.md

### Modified files
- `.gitignore` — added patterns for agent-specific files (CLAUDE.md, GEMINI.md, .augment*, .clinerules, .goosehints, AGENTS.md, .claude/)

## Test plan
- [x] Verify all referenced paths, commands, and patterns match the current codebase
- [x] Documentation-only change — no functional tests needed