### PR TITLE
Add runner diagnostics and increase HR rolling upgrade timeout

### DIFF
--- a/.github/actions/dependencies/action.yml
+++ b/.github/actions/dependencies/action.yml
@@ -4,6 +4,16 @@ description: Install Operator Build Dependencies
 runs:
   using: composite
   steps:
+    - name: Runner Diagnostics
+      shell: bash
+      run: |
+        echo "=== CPU ==="
+        lscpu | grep -E "Model name|CPU MHz|CPU\(s\)|Thread"
+        echo "=== Memory ==="
+        free -h
+        echo "=== CPU Governor ==="
+        cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor 2>/dev/null || echo "N/A"
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -71,6 +71,7 @@ jobs:
           SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.3.7
           TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}
           INFINISPAN_CPU: 500m # prevent insufficient cpu error on test-rolling-upgrade pod start
+          TEST_SINGLE_POD_TIMEOUT: 10m
 
       - name: Inspect Cluster
         if: failure()


### PR DESCRIPTION
## Summary
- Add CPU/memory diagnostics to the `dependencies` action so all CI jobs log the runner hardware profile. This helps correlate test failures with slower GitHub-hosted runners.
- Increase the `SinglePodTimeout` for the Hot Rod Rolling Upgrade test from 5m to 10m via the `TEST_SINGLE_POD_TIMEOUT` env var.

## Context
The `TestHotRodRollingUpgrade` test occasionally fails in the infinispan repo CI when upgrading the operand to 15.2.6. The upgrade consistently takes close to the 5 minute `SinglePodTimeout` boundary and times out on slower runners:

| Run | 15.2.6 result |
|-----|---------------|
| Passing | ~3m58s, success |
| Failing (3 runs) | timeout at exactly 5m |

GitHub runners are not homogeneous (AMD EPYC vs Intel Ice Lake, different clock speeds), so the diagnostics step will help identify whether failures correlate with specific runner hardware.

Created with the assistance of an AI tool