### PR TITLE
[#2535] Update StartingCSV in upgrade tests to latest 2.4 release

### DIFF
--- a/.github/workflows/test_hr_rolling_upgrades.yml
+++ b/.github/workflows/test_hr_rolling_upgrades.yml
@@ -68,7 +68,7 @@ jobs:
           export TESTING_OPERAND_ALLOW_LIST=$(./scripts/ci/operand_versions.sh ,)
           make hotrod-upgrade-test
         env:
-          SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.3.7
+          SUBSCRIPTION_STARTING_CSV: infinispan-operator.v2.4.18
           TESTING_OPERAND_IGNORE_LIST: ${{ inputs.skipList }}
           INFINISPAN_CPU: 500m # prevent insufficient cpu error on test-rolling-upgrade pod start
           TEST_SINGLE_POD_TIMEOUT: 10m

--- a/.github/workflows/test_upgrades.yml
+++ b/.github/workflows/test_upgrades.yml
@@ -119,9 +119,7 @@ jobs:
               exit 1
             fi
           else
-            # We must start on a server version greater than 14.0.23.Final to prevent known clustering issues during upgrades
-            # See commit message for a detailed list
-            export SUBSCRIPTION_STARTING_CSV=infinispan-operator.v2.3.7
+            export SUBSCRIPTION_STARTING_CSV=infinispan-operator.v2.4.18
           fi
           # Only upgrade to Operands that are currently defined in the manager.yaml
           export TESTING_OPERAND_ALLOW_LIST=$(./scripts/ci/operand_versions.sh ,)

--- a/scripts/ci/install_test_operands.sh
+++ b/scripts/ci/install_test_operands.sh
@@ -30,9 +30,6 @@ test_operands=$(echo "${current_versions}" | jq '
  | unique_by(.["upstream-version"])
 ')
 
-# Explicitly include 14.0.24 so that we can continue to test upgrades from 2.3.x CSV bundles
-test_operands=$(echo "${test_operands}" | jq '[{"upstream-version": "14.0.24", "image": "quay.io/infinispan/server:14.0.24.Final"}] + .')
-
 # Append Dev version only if there's no release in the stream yet
 if [ $(echo ${test_operands} | jq 'map(select(.["upstream-version"] | startswith("16."))) | length') -eq 0 ]; then
   test_operands=$(echo "${test_operands}" | jq '.[length] |= . + {"upstream-version": "16.0.0", "image": "quay.io/infinispan/server:16.0"}')

--- a/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
+++ b/test/e2e/hotrod-rolling-upgrade/hotrod_rolling_upgrade_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/blang/semver"
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
-	"github.com/infinispan/infinispan-operator/pkg/infinispan/version"
 	"github.com/infinispan/infinispan-operator/pkg/mime"
 	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
 	coreos "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -86,6 +84,8 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 	testKube.Create(spec)
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	spec = testKube.WaitForInfinispanCondition(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed)
+
+	log.Infof("Initial Operand version: %s", spec.Spec.Version)
 	versionManager := testKube.VersionManagerFromCSV(sub)
 	client := tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
 
@@ -100,6 +100,9 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 	javaCacheHelper := tutils.NewCacheHelper("javaCache", client)
 	javaCacheHelper.CreateDistributedCache(mime.ApplicationJavaObject)
 
+	indexedCacheHelper := tutils.NewCacheHelper(IndexedCacheName, client)
+	indexedCacheHelper.CreateAndPopulateIndexedCache(entriesPerCache)
+
 	// Upgrade the Subscription channel if required
 	if sourceChannel != targetChannel {
 		testKube.UpdateSubscriptionChannel(targetChannel.Name, sub)
@@ -110,7 +113,7 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 
 	// Approve InstallPlans and verify cluster state on each upgrade until the most recent CSV has been reached
 	for testKube.Subscription(sub); sub.Status.InstalledCSV != targetChannel.CurrentCSVName; {
-		log.Infof("Installed csv: %s, Current CSV: %s", sub.Status.InstalledCSV, targetChannel.CurrentCSVName)
+		log.Infof("Installed csv: %s", sub.Status.InstalledCSV)
 		ispnPreUpgrade := testKube.WaitForInfinispanConditionWithTimeout(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
 		testKube.WaitForSubscriptionState(coreos.SubscriptionStateUpgradePending, sub)
 		testKube.ApproveInstallPlan(sub)
@@ -124,7 +127,7 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 		time.Sleep(time.Second * 30)
 
 		versionManager = testKube.VersionManagerFromCSV(sub)
-		assertMigration := func(expectedImage string, isRollingUpgrade, indexedSupported bool) {
+		assertMigration := func(expectedImage string, isRollingUpgrade bool) {
 			if !isRollingUpgrade {
 				clusterCounter++
 				currentStatefulSetName := newStatefulSetName
@@ -151,10 +154,7 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 			assert.Equal(t, entriesPerCache, textCacheHelper.Size())
 			assert.Equal(t, 0, jsonCacheHelper.Size())
 			assert.Equal(t, 0, javaCacheHelper.Size())
-
-			if indexedSupported {
-				assert.Equal(t, entriesPerCache, tutils.NewCacheHelper(IndexedCacheName, client).Size())
-			}
+			assert.Equal(t, entriesPerCache, indexedCacheHelper.Size())
 		}
 
 		latestOperand := versionManager.Latest()
@@ -166,12 +166,6 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 
 			if !tutils.IsTestOperand(latestOperand) {
 				continue
-			}
-
-			// ISPN-15651 Test migrating Indexed caches from 14.0.25.Final onwards
-			indexSupported := latestOperand.UpstreamVersion.GTE(*version.Operand{UpstreamVersion: &semver.Version{Major: 14, Minor: 0, Patch: 25}}.UpstreamVersion)
-			if indexSupported {
-				tutils.NewCacheHelper(IndexedCacheName, client).CreateAndPopulateIndexedCache(entriesPerCache)
 			}
 
 			tutils.ExpectNoError(
@@ -190,7 +184,7 @@ func TestHotRodRollingUpgrade(t *testing.T) {
 			lastOperand, err := versionManager.WithRef(ispnPreUpgrade.Status.Operand.Version)
 			tutils.ExpectNoError(err)
 			isRolling := latestOperand.CVE && lastOperand.UpstreamVersion.EQ(*latestOperand.UpstreamVersion)
-			assertMigration(latestOperand.Image, isRolling, indexSupported)
+			assertMigration(latestOperand.Image, isRolling)
 		}
 	}
 }

--- a/test/e2e/upgrade/common.go
+++ b/test/e2e/upgrade/common.go
@@ -238,29 +238,3 @@ func checkBatch(t *testing.T, infinispan *ispnv1.Infinispan) {
 	batchHelper.WaitForValidBatchPhase(infinispan.Name, v2.BatchSucceeded)
 	testKube.DeleteBatch(batch)
 }
-
-func locksCacheDegraded(operand version.Operand) bool {
-	if operand.UpstreamVersion.Major > 14 {
-		return false
-	}
-	podList := &corev1.PodList{}
-	tutils.ExpectNoError(
-		testKube.Kubernetes.ResourcesList(tutils.Namespace, map[string]string{"app": "infinispan-pod"}, podList, ctx),
-	)
-
-	for _, pod := range podList.Items {
-		log, err := testKube.Kubernetes.Logs(provision.InfinispanContainer, pod.GetName(), pod.GetNamespace(), false, ctx)
-		tutils.ExpectNoError(err)
-		if strings.Contains(log, "DEGRADED_MODE") {
-			return true
-		}
-	}
-	return false
-}
-
-// healDegradedLocksCache forces the org.infinispan.LOCKS cache to AVAILABLE so that subsequent upgrades can proceed
-// can be removed once Infinispan 14.0.x servers are no longer supported
-func healDegradedLocksCache(operand version.Operand, client tutils.HTTPClient) {
-	tutils.Log().Infof("Setting org.infinispan.LOCKS cache to AVAILABLE for Operand %s", operand)
-	tutils.NewCacheHelperForOperand("org.infinispan.LOCKS", operand, client).Available(true)
-}

--- a/test/e2e/upgrade/dropped_operand_test.go
+++ b/test/e2e/upgrade/dropped_operand_test.go
@@ -1,29 +1,21 @@
 package upgrade
 
 import (
-	"os"
-	"strings"
 	"testing"
 
-	"github.com/blang/semver"
 	ispnv1 "github.com/infinispan/infinispan-operator/api/v1"
 	"github.com/infinispan/infinispan-operator/controllers/constants"
 	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
 )
 
 const DroppedOperandVersionEnv = "TESTING_DROPPED_OPERAND_VERSION"
+const DroppedOperandStartingCSVEnv = "SUBSCRIPTION_STARTING_CSV_DROPPED_OPERAND"
 
 func TestUpgradeFromDroppedOperand(t *testing.T) {
+	// Manually define last CSV version containing removed operand
 	olm := testKube.OLMTestEnv()
+	olm.SubStartingCSV = constants.GetEnvWithDefault(DroppedOperandStartingCSVEnv, "infinispan-operator.v2.3.7")
 	olm.PrintManifest()
-
-	// Skip the test when the specified starting CSV makes the test invalid
-	if os.Getenv("DroppedOperandVersionEnv") == "" && strings.HasPrefix(olm.SubStartingCSV, "infinispan") {
-		csv := semver.MustParse(strings.Split(olm.SubStartingCSV, "infinispan-operator.v")[1])
-		if csv.Major >= 2 && csv.Minor >= 4 && csv.Patch >= 3 {
-			t.Skipf("Skipping test as specified CSV '%s' does not contain dropped Operand 13.0.10", olm.SubStartingCSV)
-		}
-	}
 
 	testKube.NewNamespace(tutils.Namespace)
 	sub := subscription(olm)

--- a/test/e2e/upgrade/upgrade_operands_test.go
+++ b/test/e2e/upgrade/upgrade_operands_test.go
@@ -58,10 +58,6 @@ func TestOperandUpgrades(t *testing.T) {
 	numEntries := 100
 	client := tutils.HTTPClientForClusterWithVersionManager(ispn, testKube, versionManager)
 
-	if op := *startingOperand; locksCacheDegraded(op) {
-		healDegradedLocksCache(op, client)
-	}
-
 	// Add a persistent cache with data to ensure contents can be read after upgrade(s)
 	tutils.NewCacheHelper(persistentCacheName, client).CreateAndPopulatePersistentCache(numEntries)
 
@@ -79,9 +75,6 @@ func TestOperandUpgrades(t *testing.T) {
 		log.Debugf("Next Operand %s", operand.Ref())
 
 		ispn = testKube.WaitForInfinispanConditionWithTimeout(ispn.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
-		if op := *operand; locksCacheDegraded(op) {
-			healDegradedLocksCache(op, client)
-		}
 
 		tutils.ExpectNoError(
 			testKube.UpdateInfinispan(ispn, func() {

--- a/test/e2e/upgrade/upgrade_operator_test.go
+++ b/test/e2e/upgrade/upgrade_operator_test.go
@@ -1,0 +1,23 @@
+package upgrade
+
+import (
+	"testing"
+
+	tutils "github.com/infinispan/infinispan-operator/test/e2e/utils"
+)
+
+// TestOperatorUpgradeWontTriggerRollout ensures that the Operator upgrade will not result in unwanted rollout due to changes in ConfigMap
+func TestOperatorUpgradeGA(t *testing.T) {
+	olm := testKube.OLMTestEnv()
+
+	// Only test Operands in the most recent CSV
+	olm.PrintManifest()
+
+	testKube.NewNamespace(tutils.Namespace)
+	sub := subscription(olm)
+
+	defer testKube.CleanupOLMTest(t, tutils.TestName(t), olm.SubName, olm.SubNamespace, olm.SubPackage)
+	testKube.CreateOperatorGroup(olm)
+	testKube.CreateSubscriptionAndApproveInitialVersion(sub)
+
+}

--- a/test/e2e/upgrade/upgrade_test.go
+++ b/test/e2e/upgrade/upgrade_test.go
@@ -12,10 +12,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestUpgradeFromLatestReleased(t *testing.T) {
+	olm := testKube.OLMTestEnv()
+	olm.SubStartingCSV = testKube.GetLatestReleasedCSV()
+
+	testUpgrade(t, olm)
+}
+
 // TestUpgrade ensures that the OLM upgrade graph can be traversed and Operands installed as expected
 func TestUpgrade(t *testing.T) {
-	log := tutils.Log()
 	olm := testKube.OLMTestEnv()
+
+	testUpgrade(t, olm)
+}
+
+func testUpgrade(t *testing.T, olm tutils.OLMEnv) {
+	log := tutils.Log()
 	olm.PrintManifest()
 	sourceChannel := olm.SourceChannel
 	targetChannel := olm.TargetChannel
@@ -32,9 +44,6 @@ func TestUpgrade(t *testing.T) {
 	spec := tutils.DefaultSpec(t, testKube, func(i *ispnv1.Infinispan) {
 		i.Spec.Replicas = int32(replicas)
 		i.Spec.Service.Container.EphemeralStorage = false
-		// Ensure that FIPS is disabled when testing 13.0.x Operand
-		i.Spec.Container.CliExtraJvmOpts = "-Dcom.redhat.fips=false"
-		i.Spec.Container.ExtraJvmOpts = "-Dcom.redhat.fips=false"
 		i.Spec.Logging.Categories["org.infinispan.topology"] = ispnv1.LoggingLevelTrace
 	})
 	// Explicitly reset the Version so that it will be set by the Operator webhook
@@ -44,16 +53,11 @@ func TestUpgrade(t *testing.T) {
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	spec = testKube.WaitForInfinispanConditionWithTimeout(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
 
+	log.Infof("Initial Operand version: %s", spec.Spec.Version)
 	versionManager := testKube.VersionManagerFromCSV(sub)
-	operand, err := versionManager.WithRef(spec.Spec.Version)
-	tutils.ExpectNoError(err)
 
 	numEntries := 100
 	client := tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
-
-	if locksCacheDegraded(operand) {
-		healDegradedLocksCache(operand, client)
-	}
 
 	// Add a persistent cache with data to ensure contents can be read after upgrade(s)
 	tutils.NewCacheHelper(persistentCacheName, client).CreateAndPopulatePersistentCache(numEntries)
@@ -71,7 +75,7 @@ func TestUpgrade(t *testing.T) {
 
 	// Approve InstallPlans and verify cluster state on each upgrade until the most recent CSV has been reached
 	for testKube.Subscription(sub); sub.Status.InstalledCSV != targetChannel.CurrentCSVName; {
-		log.Infof("Installed csv: %s, Current CSV: %s", sub.Status.InstalledCSV, targetChannel.CurrentCSVName)
+		log.Infof("Installed csv: %s", sub.Status.InstalledCSV)
 		ispnPreUpgrade := testKube.WaitForInfinispanConditionWithTimeout(spec.Name, spec.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
 		testKube.WaitForSubscriptionState(coreos.SubscriptionStateUpgradePending, sub)
 		testKube.ApproveInstallPlan(sub)
@@ -85,33 +89,6 @@ func TestUpgrade(t *testing.T) {
 		time.Sleep(time.Minute)
 
 		versionManager = testKube.VersionManagerFromCSV(sub)
-		if ispnPreUpgrade.Spec.Version == "" {
-			relatedImageJdk := testKube.InstalledCSVEnv("RELATED_IMAGE_OPENJDK", sub)
-			if relatedImageJdk != "" {
-				// We're upgrading from an Infinispan version that does not have multi-operand support so expect cluster
-				// GracefulShutdown upgrade to happen automatically
-				testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionStopping, conditionTimeout)
-				testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
-				testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
-
-				// The latest Operator version still doesn't support multi-operand so check that the RELATED_IMAGE_OPENJDK
-				// image has been installed on all pods
-				assertOperandImage(relatedImageJdk, spec)
-				client = tutils.HTTPClientForCluster(spec, testKube)
-				tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
-				continue
-			}
-
-			// This is the first upgrade to an Operator with multi-operand support, so wait for the oldest Operand
-			oldestOperand := versionManager.Oldest()
-			ispnPreUpgrade = testKube.WaitForInfinispanState(spec.Name, spec.Namespace, func(i *ispnv1.Infinispan) bool {
-				return i.IsConditionTrue(ispnv1.ConditionWellFormed) &&
-					i.Status.Operand.Version == oldestOperand.Ref() &&
-					i.Status.Operand.Image == oldestOperand.Image &&
-					i.Status.Operand.Phase == ispnv1.OperandPhaseRunning
-			})
-			assertOperandImage(oldestOperand.Image, spec)
-		}
 
 		// Upgrade to the latest available Operand
 		latestOperand := versionManager.Latest()
@@ -120,13 +97,6 @@ func TestUpgrade(t *testing.T) {
 
 			if !tutils.IsTestOperand(latestOperand) {
 				continue
-			}
-
-			client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
-			op, err := versionManager.WithRef(ispnPreUpgrade.Spec.Version)
-			tutils.ExpectNoError(err)
-			if locksCacheDegraded(op) {
-				healDegradedLocksCache(op, client)
 			}
 
 			tutils.ExpectNoError(
@@ -155,10 +125,6 @@ func TestUpgrade(t *testing.T) {
 			client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
 			tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
 
-			if locksCacheDegraded(latestOperand) {
-				healDegradedLocksCache(latestOperand, client)
-			}
-
 			// Restore the backup and ensure that the cache exists with the expected number of entries
 			restoreName := "upgrade-restore-" + strings.ReplaceAll(strings.TrimLeft(sub.Status.CurrentCSV, olm.SubName+".v"), ".", "-")
 			if restore, err := createRestoreAndWaitToSucceed(restoreName, backup, t); err != nil {
@@ -176,8 +142,9 @@ func TestUpgrade(t *testing.T) {
 	checkServicePorts(t, spec.Name)
 	checkBatch(t, spec)
 
-	// Kill the first pod to ensure that the cluster can recover from failover after upgrade
-	err = testKube.Kubernetes.Client.Delete(ctx, &corev1.Pod{
+	// Check for any corruption that could be caused by upgrade and improper data migration
+	// 1. Kill the first pod to ensure that the cluster can recover from failover after upgrade
+	err := testKube.Kubernetes.Client.Delete(ctx, &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      spec.Name + "-0",
 			Namespace: tutils.Namespace,
@@ -186,6 +153,16 @@ func TestUpgrade(t *testing.T) {
 	tutils.ExpectNoError(err)
 	testKube.WaitForInfinispanPods(replicas, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
 	testKube.WaitForInfinispanConditionWithTimeout(spec.Name, tutils.Namespace, ispnv1.ConditionWellFormed, conditionTimeout)
+
+	// Ensure that persistent cache entries still contain the expected numEntries
+	versionManager = testKube.VersionManagerFromCSV(sub)
+	client = tutils.HTTPClientForClusterWithVersionManager(spec, testKube, versionManager)
+	tutils.NewCacheHelper(persistentCacheName, client).AssertSize(numEntries)
+
+	// 2. Verify all the cluster can be shutdown and brough back up without any issues
+	testKube.GracefulShutdownInfinispan(spec)
+	testKube.WaitForInfinispanPods(0, tutils.SinglePodTimeout, spec.Name, tutils.Namespace)
+	testKube.GracefulRestartInfinispan(spec, int32(replicas), tutils.SinglePodTimeout)
 
 	// Ensure that persistent cache entries still contain the expected numEntries
 	versionManager = testKube.VersionManagerFromCSV(sub)

--- a/test/e2e/utils/olm.go
+++ b/test/e2e/utils/olm.go
@@ -56,6 +56,21 @@ func (env OLMEnv) PrintManifest() {
 	fmt.Println("Starting CSV: " + env.SubStartingCSV)
 }
 
+// Returns last
+func (k TestKubernetes) GetLatestReleasedCSV() string {
+	catalogSource := constants.GetEnvWithDefault("SUBSCRIPTION_CATALOG_SOURCE_GA", "operatorhubio-catalog")
+	subPackage := constants.GetEnvWithDefault("SUBSCRIPTION_PACKAGE", "infinispan")
+
+	packageManifest := k.PackageManifest(subPackage, catalogSource)
+
+	for _, channel := range packageManifest.Channels {
+		if channel.Name == packageManifest.DefaultChannelName {
+			return channel.CurrentCSVName
+		}
+	}
+	panic(fmt.Errorf("unable to find current CSV for package '%s' in CatalogSource '%s'", subPackage, catalogSource))
+}
+
 func (k TestKubernetes) OLMTestEnv() OLMEnv {
 	env := &OLMEnv{
 		CatalogSource:          constants.GetEnvWithDefault("SUBSCRIPTION_CATALOG_SOURCE", "test-catalog"),
@@ -259,6 +274,8 @@ func (k TestKubernetes) ApproveInstallPlan(sub *coreos.Subscription) {
 	retryOnConflict(func() error {
 		installPlan := k.InstallPlan(sub)
 		installPlan.Spec.Approved = true
+
+		Log().Infof("Approving csv: %s", installPlan.Spec.ClusterServiceVersionNames[0])
 		return k.Kubernetes.Client.Update(context.TODO(), installPlan)
 	})
 }


### PR DESCRIPTION
Closes #2535 

Summary:
* Update StartingCSV to 2.4.18 (Last 2.4 release)
* `TestDroppedOperand` is the only test that explicitly uses installs 2.3.7.CSV
* Remove Infinispan 13 and 14 specific workaround from tests as we no longer test upgrades within neither
* Split upgrade test in two since we now allow for skipRange
  * Upgrade from 2.4.18 we allow the first version to skip from (and effectively from Infinispan 15.2.6)
  * Upgrade from last released (from latest available Infinispan)
* Add a shutdown/restart at the end of the upgrade test to verify the upgrade hasn't corrupted any files in addition to pod kill 