### PR TITLE
[#690] Logging refactored

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,6 +101,56 @@ If you use generative AI to assist with your contribution, all the following are
 * You disclose AI agents usage. Include a note in the PR description indicating the usage of AI agents for generating complete solutions from a prompt (i.e. you do not need to mention a simple AI autocomplete). This helps reviewers calibrate their review.
 * You ensure licensing compliance. All generated code must be released under the Apache License, Version 2.0, the same license as the Infinispan Operator. You are responsible for verifying that the tools you use do not introduce additional licensing restrictions.
 
+## Logging Conventions
+
+The operator uses `logr.Logger` from controller-runtime. Follow these conventions for consistent, useful logs.
+
+### Logger source
+
+In `Reconcile` methods and anything called from them, always use `log.FromContext(ctx)`:
+
+```go
+import "sigs.k8s.io/controller-runtime/pkg/log"
+
+func (r *FooReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+    logger := log.FromContext(ctx)
+}
+```
+
+The context logger already includes `namespace`, `name`, `controller`, and `reconcileID` — never add these manually. Pipeline handlers use `ctx.Log()`.
+
+Use `r.setupLog` only in `SetupWithManager` (setup-time logging).
+
+### Log levels
+
+| Level | Use for | Example |
+|-------|---------|---------|
+| `Error(err, msg)` | Real errors requiring attention, always with a non-nil `error` | `logger.Error(err, "Failed to create StatefulSet")` |
+| `Info` / `V(0)` | Production-visible state changes, config changes, create/delete of resources | `logger.Info("Created StatefulSet", "statefulSet", name)` |
+| `V(1)` | Development diagnostics: lifecycle, lookups, no-op paths, waiting messages | `logger.V(1).Info("Waiting for cluster to form")` |
+| `V(2)` | Deep debugging: raw configs, per-pod iteration details | `logger.V(2).Info("Remote store configuration", "config", cfg)` |
+
+### Field keys
+
+All keys must be **lowercase camelCase**: `"pod"`, `"statefulSet"`, `"memoryLimit"`. Never dotted (`"Pod.Name"`), spaced (`"Secret Name"`), or capitalized (`"Namespace"`).
+
+### Message format
+
+- No `fmt.Sprintf` — use structured key-value pairs instead
+- No decorative delimiters (`"+++++"`, `"-----"`)
+- Messages describe what happened, not Go expressions
+- Lowercase, no trailing periods or exclamation marks
+
+### Either log or return an error, never both
+
+If an error is returned (or requeued), controller-runtime logs it. Adding `log.Error` before returning causes double-logging. Pick one:
+- **Return the error** (preferred) — wrap with `fmt.Errorf` for context
+- **Log and handle** — log the error, then recover or return nil
+
+### WithName
+
+Use lowercase camelCase: `WithName("gossipRouter")`, not `WithName("GossipRouter")`.
+
 ## Submit
 
 * Push your changes to a topic branch in your fork of the repository.

--- a/api/v1/infinispan_webhook.go
+++ b/api/v1/infinispan_webhook.go
@@ -20,16 +20,19 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 var (
-	log              = ctrl.Log.WithName("webhook").WithName("Infinispan")
 	eventRec         record.EventRecorder
 	ServingCertsMode string
 	versionManager   *version.Manager
 )
+
+type infinispanDefaulter struct{}
+
+type infinispanValidator struct{}
 
 func (i *Infinispan) SetupWebhookWithManager(mgr ctrl.Manager) (err error) {
 	kubernetes := kube.NewKubernetesFromController(mgr)
@@ -44,15 +47,23 @@ func (i *Infinispan) SetupWebhookWithManager(mgr ctrl.Manager) (err error) {
 
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(i).
+		WithDefaulter(&infinispanDefaulter{}).
+		WithValidator(&infinispanValidator{}).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/mutate-infinispan-org-v1-infinispan,mutating=true,failurePolicy=fail,sideEffects=None,groups=infinispan.org,resources=infinispans,verbs=create;update,versions=v1,name=minfinispan.kb.io,admissionReviewVersions={v1,v1beta1}
 
-var _ webhook.Defaulter = &Infinispan{}
+var _ admission.CustomDefaulter = &infinispanDefaulter{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
-func (i *Infinispan) Default() {
+func (d *infinispanDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	i := obj.(*Infinispan)
+	i.ApplyDefaults()
+	return nil
+}
+
+// ApplyDefaults sets default values on the Infinispan resource.
+func (i *Infinispan) ApplyDefaults() {
 	if i.Spec.Version == "" {
 		i.Spec.Version = versionManager.Latest().Ref()
 	}
@@ -169,21 +180,21 @@ func (i *Infinispan) Default() {
 
 // +kubebuilder:webhook:path=/validate-infinispan-org-v1-infinispan,mutating=false,failurePolicy=fail,sideEffects=None,groups=infinispan.org,resources=infinispans,verbs=create;update,versions=v1,name=vinfinispan.kb.io,admissionReviewVersions={v1,v1beta1}
 
-var _ webhook.Validator = &Infinispan{}
+var _ admission.CustomValidator = &infinispanValidator{}
 
-// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
-func (i *Infinispan) ValidateCreate() (admission.Warnings, error) {
-	return i.validate()
+func (v *infinispanValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	i := obj.(*Infinispan)
+	return v.validate(ctx, i)
 }
 
-// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (i *Infinispan) ValidateUpdate(oldRuntimeObj runtime.Object) (admission.Warnings, error) {
-	if w, err := i.validate(); err != nil {
+func (v *infinispanValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	i := newObj.(*Infinispan)
+	if w, err := v.validate(ctx, i); err != nil {
 		return w, err
 	}
 
 	var allErrs field.ErrorList
-	old := oldRuntimeObj.(*Infinispan)
+	old := oldObj.(*Infinispan)
 	if old.Spec.Version != "" {
 		// We know the versions must be valid as they have already been validated, so the error will always be nil
 		operand, _ := versionManager.WithRef(i.Spec.Version)
@@ -253,13 +264,12 @@ func minorStreamMatch(operand1, operand2 version.Operand) bool {
 	return majorMatch && minorMatch
 }
 
-// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
-func (i *Infinispan) ValidateDelete() (admission.Warnings, error) {
-	// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+func (v *infinispanValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	return nil, nil
 }
 
-func (i *Infinispan) validate() (admission.Warnings, error) {
+func (v *infinispanValidator) validate(ctx context.Context, i *Infinispan) (admission.Warnings, error) {
+	logger := log.FromContext(ctx)
 	var allErrs field.ErrorList
 
 	operand, err := versionManager.WithRef(i.Spec.Version)
@@ -292,7 +302,7 @@ func (i *Infinispan) validate() (admission.Warnings, error) {
 		} else if size.Cmp(memLimit) < 0 {
 			errMsg := "Persistent volume size is less than memory size. Graceful shutdown may not work."
 			eventRec.Event(i, corev1.EventTypeWarning, "LowPersistenceStorage", errMsg)
-			log.Info(errMsg, "Request.Namespace", i.Namespace, "Request.Name", i.Name)
+			logger.Info(errMsg)
 		}
 	}
 
@@ -404,7 +414,7 @@ func (i *Infinispan) validate() (admission.Warnings, error) {
 	if i.IsEphemeralStorage() {
 		errMsg := "Ephemeral storage configured. All data will be lost on cluster shutdown and restart."
 		eventRec.Event(i, corev1.EventTypeWarning, "EphemeralStorageEnables", "Ephemeral storage configured. All data will be lost on cluster shutdown and restart.")
-		log.Info(errMsg, "Request.Namespace", i.Namespace, "Request.Name", i.Name)
+		logger.Info(errMsg)
 	}
 
 	// validate Gossip Router resources requests
@@ -469,7 +479,7 @@ func (i *Infinispan) validate() (admission.Warnings, error) {
 		if i.IsSiteTLSEnabled() && i.Spec.Service.Sites.Local.Encryption.TrustStore == nil {
 			errMsg := "The Trust Store for Cross-Site Encryption is recommended but it is not configured. It will fallback to the JVM default Trust Store."
 			eventRec.Event(i, corev1.EventTypeWarning, "CrossSiteTrustStoreMissing", errMsg)
-			log.Info(errMsg, "Request.Namespace", i.Namespace, "Request.Name", i.Name)
+			logger.Info(errMsg)
 		}
 
 		if !i.IsSiteTLSEnabled() && i.Spec.Service.Sites.Local.Expose.Type == CrossSiteExposeTypeRoute {
@@ -480,7 +490,7 @@ func (i *Infinispan) validate() (admission.Warnings, error) {
 	if i.Spec.CloudEvents != nil && operand.UpstreamVersion.GTE(semver.Version{Major: 15}) {
 		errMsg := "CloudEvents have been removed since Infinispan 15.0.0, ignoring configuration."
 		eventRec.Event(i, corev1.EventTypeWarning, "CloudEventsRemoved", errMsg)
-		log.Info(errMsg, "Request.Namespace", i.Namespace, "Request.Name", i.Name)
+		logger.Info(errMsg)
 	}
 
 	validateProbes := func(c *ContainerProbeSpec, path *field.Path, readinessProbe bool) {

--- a/api/v2alpha1/cache_webhook.go
+++ b/api/v2alpha1/cache_webhook.go
@@ -9,33 +9,39 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-var log = ctrl.Log.WithName("webhook").WithName("Cache")
+type cacheDefaulter struct{}
 
 func (c *Cache) SetupWebhookWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewWebhookManagedBy(mgr).
 		For(c).
+		WithDefaulter(&cacheDefaulter{}).
 		Complete()
 }
 
 // +kubebuilder:webhook:path=/mutate-infinispan-org-v2alpha1-cache,mutating=true,failurePolicy=fail,sideEffects=None,groups=infinispan.org,resources=caches,verbs=create;update,versions=v2alpha1,name=mcache.kb.io,admissionReviewVersions={v1,v1beta1}
 
-var _ webhook.Defaulter = &Cache{}
+var _ admission.CustomDefaulter = &cacheDefaulter{}
 
-// Default implements webhook.Defaulter so a webhook will be registered for the type
-func (c *Cache) Default() {
+func (d *cacheDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	c := obj.(*Cache)
 	if c.Spec.AdminAuth != nil {
-		log.Info("Ignoring and removing 'spec.AdminAuth' field. The operator's admin credentials are now used to perform cache operations")
+		log.FromContext(ctx).Info("Ignoring and removing 'spec.AdminAuth' field. The operator's admin credentials are now used to perform cache operations")
 		c.Spec.AdminAuth = nil
 	}
+	c.ApplyDefaults()
+	return nil
+}
 
+func (c *Cache) ApplyDefaults() {
 	if c.Spec.Updates == nil {
 		c.Spec.Updates = &CacheUpdateSpec{
 			Strategy: CacheUpdateRetain,

--- a/controllers/backup_controller.go
+++ b/controllers/backup_controller.go
@@ -17,6 +17,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // +kubebuilder:rbac:groups=infinispan.org,namespace=infinispan-operator-system,resources=backups;backups/status;backups/finalizers,verbs=get;list;watch;create;update;patch
@@ -173,6 +174,7 @@ func (r *backupResource) getOrCreatePvc() error {
 	if err = r.client.Create(r.ctx, pvc); err != nil {
 		return fmt.Errorf("unable to create pvc: %w", err)
 	}
+	log.FromContext(r.ctx).Info("Created backup PVC", "pvc", pvc.Name)
 	return nil
 }
 
@@ -201,6 +203,7 @@ func (r *backupResource) Exec(client api.Infinispan) error {
 	}
 
 	if status == api.StatusNotFound {
+		log.FromContext(r.ctx).Info("Initiating backup", "backup", instance.Name)
 		return client.Container().Backups().Create(instance.Name, config)
 	}
 	return nil

--- a/controllers/batch_controller.go
+++ b/controllers/batch_controller.go
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -35,7 +36,7 @@ const (
 // BatchReconciler reconciles a Batch object
 type BatchReconciler struct {
 	client.Client
-	log        logr.Logger
+	setupLog   logr.Logger
 	scheme     *runtime.Scheme
 	kubernetes *kube.Kubernetes
 	eventRec   record.EventRecorder
@@ -53,7 +54,7 @@ type batchRequest struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *BatchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Client = mgr.GetClient()
-	r.log = ctrl.Log.WithName("controllers").WithName("Batch")
+	r.setupLog = ctrl.Log.WithName("controllers").WithName("batch")
 	r.scheme = mgr.GetScheme()
 	r.kubernetes = kube.NewKubernetesFromController(mgr)
 	r.eventRec = mgr.GetEventRecorderFor("batch-controller")
@@ -67,8 +68,7 @@ func (r *BatchReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=batch,namespace=infinispan-operator-system,resources=jobs,verbs=get;list;watch;create;update;delete
 
 func (reconciler *BatchReconciler) Reconcile(ctx context.Context, ctrlRequest ctrl.Request) (ctrl.Result, error) {
-	reqLogger := reconciler.log.WithValues("Request.Namespace", ctrlRequest.Namespace, "Request.Name", ctrlRequest.Name)
-	reqLogger.Info("Reconciling Batch")
+	reqLogger := log.FromContext(ctx)
 
 	// Fetch the Batch instance
 	instance := &v2.Batch{}
@@ -122,7 +122,7 @@ func (r *batchRequest) initializeResources() (reconcile.Result, error) {
 	}
 
 	if err := infinispan.EnsureClusterStability(); err != nil {
-		r.log.Info(fmt.Sprintf("Infinispan '%s' not ready: %s", spec.Cluster, err.Error()))
+		r.reqLogger.V(1).Info("Infinispan cluster not ready", "cluster", spec.Cluster, "reason", err.Error())
 		return reconcile.Result{RequeueAfter: consts.DefaultWaitOnCluster}, nil
 	}
 
@@ -142,6 +142,7 @@ func (r *batchRequest) initializeResources() (reconcile.Result, error) {
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("unable to create ConfigMap '%s': %w", configMap.Name, err)
 		}
+		r.reqLogger.V(1).Info("Created batch ConfigMap", "configMap", configMap.Name)
 	}
 
 	_, err := r.update(func() error {
@@ -235,6 +236,7 @@ func (r *batchRequest) execute() (reconcile.Result, error) {
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("unable to create batch job '%s': %w", batch.Name, err)
 	}
+	r.reqLogger.Info("Created batch Job", "job", batch.Name)
 	return reconcile.Result{}, r.UpdatePhase(v2.BatchRunning, nil)
 }
 

--- a/controllers/cache_controller.go
+++ b/controllers/cache_controller.go
@@ -30,13 +30,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // CacheReconciler reconciles a Cache object
 type CacheReconciler struct {
 	client.Client
-	log            logr.Logger
+	setupLog       logr.Logger
 	scheme         *runtime.Scheme
 	kubernetes     *kube.Kubernetes
 	eventRec       record.EventRecorder
@@ -64,7 +65,7 @@ type cacheRequest struct {
 // SetupWithManager sets up the controller with the Manager.
 func (r *CacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) (err error) {
 	r.Client = mgr.GetClient()
-	r.log = ctrl.Log.WithName("controllers").WithName("Cache")
+	r.setupLog = ctrl.Log.WithName("controllers").WithName("cache")
 	r.scheme = mgr.GetScheme()
 	r.kubernetes = kube.NewKubernetesFromController(mgr)
 	r.eventRec = mgr.GetEventRecorderFor("cache-controller")
@@ -94,7 +95,7 @@ func (r *CacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager
 				var requests []reconcile.Request
 				cacheList := &v2alpha1.CacheList{}
 				if err := r.kubernetes.ResourcesListByField(a.GetNamespace(), "spec.clusterName", a.GetName(), cacheList, watchCtx); err != nil {
-					r.log.Error(err, "watches failed to list Cache CRs")
+					r.setupLog.Error(err, "watches failed to list Cache CRs")
 				}
 
 				for _, item := range cacheList.Items {
@@ -109,15 +110,13 @@ func (r *CacheReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager
 // +kubebuilder:rbac:groups=infinispan.org,namespace=infinispan-operator-system,resources=caches;caches/status;caches/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
-	reqLogger := r.log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
-	reqLogger.Info("+++++ Reconciling Cache.")
-	defer reqLogger.Info("----- End Reconciling Cache.")
+	reqLogger := log.FromContext(ctx)
 
 	// Fetch the Cache instance
 	instance := &v2alpha1.Cache{}
 	if err := r.Get(ctx, request.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Info("Cache resource not found. Ignoring it since cache deletion is not supported")
+			reqLogger.V(1).Info("Cache CR not found")
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -133,24 +132,24 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	}
 
 	if cache.markedForDeletion() {
-		reqLogger.Info("Cache CR marked for deletion. Attempting to remove.")
+		reqLogger.V(1).Info("Cache CR marked for deletion")
 		// The ConfigListener has marked this resource for deletion
 		// Remove finalizer and delete CR. No need to update the server as the cache has already been removed
 		if err := cache.removeFinalizer(); err != nil {
 			if errors.IsNotFound(err) {
-				reqLogger.Info("Unable to remove Finalizer as Cache CR not found.")
+				reqLogger.V(1).Info("Cache CR not found, finalizer already removed")
 				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{}, err
 		}
 		if err := cache.kubernetes.Client.Delete(ctx, instance); err != nil {
 			if errors.IsNotFound(err) {
-				reqLogger.Info("Cache CR does not exist, nothing todo.")
+				reqLogger.V(1).Info("Cache CR already deleted")
 				return ctrl.Result{}, nil
 			}
 			return ctrl.Result{}, err
 		}
-		reqLogger.Info("Cache CR Removed.")
+		reqLogger.Info("Cache CR removed")
 		return ctrl.Result{}, nil
 	}
 
@@ -176,7 +175,7 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 	// Fetch the Infinispan cluster
 	if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: instance.Spec.ClusterName}, infinispan); err != nil {
 		if errors.IsNotFound(err) {
-			reqLogger.Error(err, fmt.Sprintf("Infinispan cluster %s not found", instance.Spec.ClusterName))
+			reqLogger.Error(err, "Infinispan cluster not found", "cluster", instance.Spec.ClusterName)
 			if crDeleted {
 				return ctrl.Result{}, cache.removeFinalizer()
 			}
@@ -192,13 +191,13 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 
 	// Cluster must be well formed
 	if !infinispan.IsWellFormed() {
-		reqLogger.Info(fmt.Sprintf("Infinispan cluster %s not well formed", infinispan.Name))
+		reqLogger.Info("Infinispan cluster not well formed", "cluster", infinispan.Name)
 		// No need to requeue request here as the Infinispan watch ensures that a request is queued when the cluster is updated
 		return ctrl.Result{}, nil
 	}
 
 	if infinispan.IsCache() {
-		reqLogger.Info("Ignoring Cache CR as cluster is marked as CacheService")
+		reqLogger.V(1).Info("Ignoring Cache CR as cluster is marked as CacheService")
 		return ctrl.Result{}, nil
 	}
 
@@ -215,6 +214,7 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 			if err := ispnClient.Cache(cacheName).Delete(); err != nil {
 				return ctrl.Result{}, err
 			}
+			reqLogger.Info("Deleted cache from server", "cache", cacheName)
 			return ctrl.Result{}, cache.removeFinalizer()
 		}
 		return ctrl.Result{}, nil
@@ -238,6 +238,7 @@ func (r *CacheReconciler) Reconcile(ctx context.Context, request ctrl.Request) (
 		// Add finalizer so that the Cache is removed on the server when the Cache CR is deleted
 		if !controllerutil.ContainsFinalizer(instance, constants.InfinispanFinalizer) {
 			controllerutil.AddFinalizer(instance, constants.InfinispanFinalizer)
+			reqLogger.V(1).Info("Added finalizer")
 		}
 		return nil
 	})
@@ -266,6 +267,7 @@ func (r *cacheRequest) removeFinalizer() error {
 	if controllerutil.ContainsFinalizer(r.cache, constants.InfinispanFinalizer) {
 		return r.update(func() error {
 			controllerutil.RemoveFinalizer(r.cache, constants.InfinispanFinalizer)
+			r.reqLogger.V(1).Info("Removed finalizer")
 			return nil
 		})
 	}
@@ -278,9 +280,7 @@ func (r *cacheRequest) ispnCreateOrUpdate() (*ctrl.Result, error) {
 
 	cacheExists, err := cacheClient.Exists()
 	if err != nil {
-		err := fmt.Errorf("unable to determine if cache exists: %w", err)
-		r.reqLogger.Error(err, "")
-		return &ctrl.Result{}, err
+		return &ctrl.Result{}, fmt.Errorf("unable to determine if cache exists: %w", err)
 	}
 
 	err = r.reconcileDataGrid(cacheExists, cacheClient)
@@ -312,7 +312,7 @@ func (r *cacheRequest) reconcileDataGrid(cacheExists bool, cache api.Cache) erro
 			return fmt.Errorf("unable to determine if configuration has changed: %w", err)
 		}
 		if !configUpdated {
-			r.log.Info("configuration has not changed, ignoring update")
+			r.reqLogger.V(1).Info("Configuration has not changed, ignoring update")
 			return nil
 		}
 
@@ -321,13 +321,14 @@ func (r *cacheRequest) reconcileDataGrid(cacheExists bool, cache api.Cache) erro
 			if err := cache.UpdateConfig(spec.Template, mime.GuessMarkup(spec.Template)); err != nil {
 				return fmt.Errorf("unable to update cache template at runtime: %w", err)
 			}
+			r.reqLogger.Info("Updated cache configuration", "cache", r.cache.GetCacheName())
 			return nil
 		}
 
 		// Recreate strategy
 		// Update the cache configuration at runtime if possible, retaining data, otherwise delete
 		if err := cache.UpdateConfig(spec.Template, mime.GuessMarkup(spec.Template)); err != nil {
-			r.log.Info("unable to update cache template at runtime, recreating", "error", err)
+			r.reqLogger.V(1).Info("Unable to update cache template at runtime, recreating", "reason", err.Error())
 
 			// Add an annotation to indicate to the ConfigListener that a remote-cache event should be expected for this CR
 			// Required in order to prevent the Cache CR that's being reconciled from being
@@ -365,8 +366,8 @@ func (r *cacheRequest) reconcileDataGrid(cacheExists bool, cache api.Cache) erro
 		}
 	}
 
-	if err != nil {
-		r.reqLogger.Error(err, "Unable to create Cache")
+	if err == nil {
+		r.reqLogger.Info("Created cache", "cache", r.cache.GetCacheName())
 	}
 	return err
 }

--- a/controllers/grafana.go
+++ b/controllers/grafana.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	_ "embed"
 	"errors"
-	"fmt"
 
 	consts "github.com/infinispan/infinispan-operator/controllers/constants"
 	grafanav1alpha1 "github.com/infinispan/infinispan-operator/pkg/apis/integreatly/v1alpha1"
@@ -12,6 +11,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -28,6 +28,7 @@ const (
 
 // reconcileGrafana reconciles grafana object status with the operator configuration settings
 func (r *ReconcileOperatorConfig) reconcileGrafana(ctx context.Context, config, currentConfig map[string]string, operatorNs string) (*reconcile.Result, error) {
+	logger := log.FromContext(ctx)
 	grafanaNs := config[grafanaDashboardNamespaceKey]
 
 	// Delete current grafana dashboard if namespace is changes
@@ -41,11 +42,11 @@ func (r *ReconcileOperatorConfig) reconcileGrafana(ctx context.Context, config, 
 	// detect the GrafanaDashboard resource type resourceExists on the cluster
 	resourceExists, err := r.kubernetes.IsGroupVersionSupported(grafanav1alpha1.SchemeGroupVersion.String(), grafanav1alpha1.GrafanaDashboardKind)
 	if err != nil {
-		r.log.Error(err, "Error checking Grafana support")
+		logger.Error(err, "Error checking Grafana support")
 		return &reconcile.Result{Requeue: true}, nil
 	}
 	if !resourceExists {
-		r.log.Info("Grafana CRD not present - not installing dashboard CR")
+		logger.Info("Grafana CRD not present - not installing dashboard CR")
 		return &reconcile.Result{RequeueAfter: consts.DefaultLongWaitOnCreateResource}, nil
 	}
 	infinispanDashboard := emptyDashboard(config)
@@ -54,22 +55,23 @@ func (r *ReconcileOperatorConfig) reconcileGrafana(ctx context.Context, config, 
 			if grafanaNs == operatorNs {
 				if ownRef, err := kubernetes.GetOperatorPodOwnerRef(operatorNs, r.Client, ctx); err != nil {
 					if errors.Is(err, kubernetes.ErrRunLocal) {
-						r.log.Info(fmt.Sprintf("Not setting controller reference for Grafana Dashboard, cause %s.", err.Error()))
+						logger.Info("Not setting controller reference for Grafana dashboard", "reason", err.Error())
 					} else {
 						return err
 					}
 				} else {
-					r.log.Info("Operator Pod owner found", "Kind", ownRef.Kind, "Name", ownRef.Name)
+					logger.V(1).Info("Operator Pod owner found", "kind", ownRef.Kind, "name", ownRef.Name)
 					infinispanDashboard.SetOwnerReferences([]metav1.OwnerReference{*ownRef})
 				}
 			} else {
-				r.log.Info("Not setting controller reference, cause Infinispan and Grafana are in different namespaces.")
+				logger.Info("Not setting controller reference, Infinispan and Grafana are in different namespaces")
 			}
 		}
 		return populateDashboard(infinispanDashboard, config)
 	}); err != nil {
 		return &reconcile.Result{}, err
 	}
+	logger.Info("Created/Updated Grafana dashboard", "dashboard", infinispanDashboard.Name)
 
 	currentConfig[grafanaDashboardNamespaceKey] = grafanaNs
 	currentConfig[grafanaDashboardNameKey] = config[grafanaDashboardNameKey]
@@ -119,6 +121,7 @@ func (r *ReconcileOperatorConfig) deleteDashboardOnKeyChanged(ctx context.Contex
 		if err := r.kubernetes.Client.Delete(ctx, currGrafana); err != nil && !k8serrors.IsNotFound(err) {
 			return err
 		}
+		log.FromContext(ctx).Info("Deleted Grafana dashboard", "dashboard", currGrafana.Name)
 		currentConfig[grafanaDashboardNamespaceKey] = ""
 		currentConfig[grafanaDashboardNameKey] = ""
 	}

--- a/controllers/infinispan.go
+++ b/controllers/infinispan.go
@@ -24,6 +24,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -31,7 +32,7 @@ import (
 // InfinispanReconciler reconciles a Infinispan object
 type InfinispanReconciler struct {
 	client.Client
-	log                logr.Logger
+	setupLog           logr.Logger
 	contextProvider    infinispan.ContextProvider
 	defaultLabels      map[string]string
 	defaultAnnotations map[string]string
@@ -44,7 +45,7 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 	kubernetes := kube.NewKubernetesFromController(mgr)
 
 	r.Client = mgr.GetClient()
-	r.log = ctrl.Log.WithName("controllers").WithName("Infinispan")
+	r.setupLog = ctrl.Log.WithName("controllers").WithName("infinispan")
 	r.eventRec = mgr.GetEventRecorderFor("controller-infinispan")
 	r.contextProvider = pipelineContext.Provider(
 		r.Client,
@@ -87,7 +88,7 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 		// Validate that GroupVersionKind is supported on runtime platform
 		ok, err := kubernetes.IsGroupVersionKindSupported(gvk)
 		if err != nil {
-			r.log.Error(err, fmt.Sprintf("failed to check if GVK '%s' is supported", gvk))
+			r.setupLog.Error(err, "failed to check if GVK is supported", "gvk", gvk)
 			continue
 		}
 		if ok {
@@ -100,7 +101,7 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 	if err != nil {
 		return err
 	}
-	r.versionManager.Log(r.log)
+	r.versionManager.Log(r.setupLog)
 
 	// Initialize default operator labels and annotations
 	if defaultLabels, defaultAnnotations, err := infinispanv1.LoadDefaultLabelsAndAnnotations(); err != nil {
@@ -108,10 +109,17 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 	} else {
 		r.defaultLabels = defaultLabels
 		r.defaultAnnotations = defaultAnnotations
-		r.log.Info("Defaults:", "Annotations", defaultAnnotations, "Labels", defaultLabels)
+		r.setupLog.V(2).Info("Default labels and annotations", "annotations", defaultAnnotations, "labels", defaultLabels)
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&infinispanv1.Infinispan{}).
+		WithLogConstructor(func(req *reconcile.Request) logr.Logger {
+			log := mgr.GetLogger().WithValues("controller", "infinispan")
+			if req != nil {
+				log = log.WithValues("namespace", req.Namespace, "name", req.Name)
+			}
+			return log
+		}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&corev1.Secret{},
 			builder.WithPredicates(
@@ -152,7 +160,7 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 						for _, field := range []string{"spec.security.endpointSecretName", "spec.security.credentialStoreSecretName", "spec.security.endpointEncryption.certSecretName", "spec.security.endpointEncryption.clientCertSecretName"} {
 							ispnList := &infinispanv1.InfinispanList{}
 							if err := kubernetes.ResourcesListByField(a.GetNamespace(), field, a.GetName(), ispnList, watchCtx); err != nil {
-								r.log.Error(err, "failed to list Infinispan CR")
+								r.setupLog.Error(err, "failed to list Infinispan CR")
 							}
 							for _, item := range ispnList.Items {
 								requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: item.GetNamespace(), Name: item.GetName()}})
@@ -174,7 +182,7 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 					if !kube.IsControlledByGVK(a.GetOwnerReferences(), infinispanv1.SchemeBuilder.GroupVersion.WithKind(reflect.TypeOf(infinispanv1.Infinispan{}).Name())) {
 						ispnList := &infinispanv1.InfinispanList{}
 						if err := kubernetes.ResourcesListByField(a.GetNamespace(), "spec.configMapName", a.GetName(), ispnList, watchCtx); err != nil {
-							r.log.Error(err, "failed to list Infinispan CR")
+							r.setupLog.Error(err, "failed to list Infinispan CR")
 						}
 						for _, item := range ispnList.Items {
 							requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: item.GetNamespace(), Name: item.GetName()}})
@@ -214,12 +222,12 @@ func (r *InfinispanReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 
 // Reconcile the Infinispan CR resource
 func (r *InfinispanReconciler) Reconcile(ctx context.Context, ctrlRequest ctrl.Request) (ctrl.Result, error) {
-	reqLogger := r.log.WithValues("infinispan", ctrlRequest.NamespacedName)
+	reqLogger := log.FromContext(ctx)
 	// Fetch the Infinispan instance
 	instance := &infinispanv1.Infinispan{}
 	if err := r.Get(ctx, ctrlRequest.NamespacedName, instance); err != nil {
 		if errors.IsNotFound(err) {
-			r.log.Info("Infinispan CR not found")
+			reqLogger.V(1).Info("Infinispan CR not found")
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
@@ -228,7 +236,7 @@ func (r *InfinispanReconciler) Reconcile(ctx context.Context, ctrlRequest ctrl.R
 
 	// Don't reconcile Infinispan CRs marked for deletion
 	if instance.GetDeletionTimestamp() != nil {
-		reqLogger.Info(fmt.Sprintf("Ignoring Infinispan CR '%s:%s' marked for deletion", instance.Namespace, instance.Name))
+		reqLogger.V(1).Info("Ignoring CR marked for deletion")
 		return reconcile.Result{}, nil
 	}
 
@@ -247,6 +255,5 @@ func (r *InfinispanReconciler) Reconcile(ctx context.Context, ctrlRequest ctrl.R
 		Build()
 
 	retry, delay, err := pipeline.Process(ctx)
-	reqLogger.Info("Done", "requeue", retry, "requeueAfter", delay, "error", err)
 	return ctrl.Result{Requeue: retry, RequeueAfter: delay}, err
 }

--- a/controllers/operatorconfig_controller.go
+++ b/controllers/operatorconfig_controller.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/go-logr/logr"
 	kube "github.com/infinispan/infinispan-operator/pkg/kubernetes"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -14,6 +12,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -26,14 +25,14 @@ var currentConfig map[string]string = make(map[string]string)
 type ReconcileOperatorConfig struct {
 	Client     client.Client
 	scheme     *runtime.Scheme
-	log        logr.Logger
+	setupLog   logr.Logger
 	kubernetes *kube.Kubernetes
 }
 
 func (r *ReconcileOperatorConfig) SetupWithManager(mgr ctrl.Manager) error {
 	name := "config"
 	r.Client = mgr.GetClient()
-	r.log = ctrl.Log.WithName("controllers").WithName(cases.Title(language.Und).String(name))
+	r.setupLog = ctrl.Log.WithName("controllers").WithName(name)
 	r.scheme = mgr.GetScheme()
 	r.kubernetes = kube.NewKubernetesFromController(mgr)
 
@@ -64,16 +63,18 @@ func (r *ReconcileOperatorConfig) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ReconcileOperatorConfig) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	logger := log.FromContext(ctx)
+
 	operatorNs, err := kube.GetOperatorNamespace()
 	if err != nil {
-		r.log.Error(err, "Error getting operator runtime namespace")
+		logger.Error(err, "Error getting operator runtime namespace")
 		return reconcile.Result{Requeue: true}, nil
 	}
 
 	configMap := &corev1.ConfigMap{}
 	err = r.Client.Get(ctx, types.NamespacedName{Namespace: operatorNs, Name: configMapName}, configMap)
 	if err != nil && !errors.IsNotFound(err) {
-		r.log.Error(err, "Error getting operator configuration resource")
+		logger.Error(err, "Error getting operator configuration resource")
 		return reconcile.Result{Requeue: true}, nil
 	}
 

--- a/controllers/restore_controller.go
+++ b/controllers/restore_controller.go
@@ -15,6 +15,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // +kubebuilder:rbac:groups=infinispan.org,namespace=infinispan-operator-system,resources=restores;restores/status;restores/finalizers,verbs=get;list;watch;create;update;patch
@@ -143,6 +144,7 @@ func (r *restore) Exec(client api.Infinispan) error {
 	}
 
 	if status == api.StatusNotFound {
+		log.FromContext(r.ctx).Info("Initiating restore", "restore", instance.Name)
 		return client.Container().Restores().Create(instance.Name, config)
 	}
 	return nil

--- a/controllers/zero_controller.go
+++ b/controllers/zero_controller.go
@@ -23,6 +23,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -74,7 +75,7 @@ type zeroCapacityController struct {
 	Name           string
 	Reconciler     zeroCapacityReconciler
 	Kube           *kube.Kubernetes
-	Log            logr.Logger
+	setupLog       logr.Logger
 	Scheme         *runtime.Scheme
 	EventRec       record.EventRecorder
 	VersionManager *version.Manager
@@ -110,7 +111,7 @@ func newZeroCapacityController(name string, reconciler zeroCapacityReconciler, m
 		Client:         mgr.GetClient(),
 		Reconciler:     reconciler,
 		Kube:           kube.NewKubernetesFromController(mgr),
-		Log:            ctrl.Log.WithName("controllers").WithName(name),
+		setupLog:       ctrl.Log.WithName("controllers").WithName(name),
 		Scheme:         mgr.GetScheme(),
 		EventRec:       mgr.GetEventRecorderFor(strings.ToLower(name) + "-controller"),
 		VersionManager: versionManager,
@@ -127,10 +128,6 @@ func (z *zeroCapacityController) Reconcile(ctx context.Context, request reconcil
 	resource := reflect.TypeOf(reconciler.Type()).Elem().Name()
 	namespace := request.Namespace
 
-	reqLogger := z.Log.WithValues("Request.Namespace", namespace, "Request.Name", request.Name)
-	reqLogger.Info("Reconciling " + resource)
-	defer reqLogger.Info("----- End Reconciling " + resource)
-
 	instance, err := reconciler.ResourceInstance(ctx, request.NamespacedName, z)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -144,7 +141,7 @@ func (z *zeroCapacityController) Reconcile(ctx context.Context, request reconcil
 	}
 
 	if pausable, ok := instance.AsMeta().(Pausable); ok {
-		if paused, err := HandleReconciliationPause(ctx, pausable, z.Client, z.EventRec, reqLogger); err != nil || paused {
+		if paused, err := HandleReconciliationPause(ctx, pausable, z.Client, z.EventRec, log.FromContext(ctx)); err != nil || paused {
 			return reconcile.Result{}, err
 		}
 	}
@@ -188,7 +185,7 @@ func (z *zeroCapacityController) Reconcile(ctx context.Context, request reconcil
 		return z.cleanupResources(ispnClient, request, ctx)
 	default:
 		// Phase must be ZeroRunning, so wait for execution to complete
-		return z.waitForExecutionToComplete(ispnClient, request, instance)
+		return z.waitForExecutionToComplete(ctx, ispnClient, request, instance)
 	}
 }
 
@@ -201,9 +198,11 @@ func (z *zeroCapacityController) initializeResources(request reconcile.Request, 
 		Name:      clusterName,
 	}
 
+	logger := log.FromContext(ctx)
+
 	infinispan := &v1.Infinispan{}
 	if err := z.Get(ctx, clusterKey, infinispan); err != nil {
-		z.Log.Info(fmt.Sprintf("Unable to load Infinispan Cluster '%s': %s", clusterName, err))
+		logger.V(1).Info("Unable to load Infinispan cluster", "cluster", clusterName, "reason", err.Error())
 		if errors.IsNotFound(err) {
 			return reconcile.Result{RequeueAfter: consts.DefaultWaitOnCluster}, nil
 		}
@@ -211,15 +210,14 @@ func (z *zeroCapacityController) initializeResources(request reconcile.Request, 
 	}
 
 	if err := infinispan.EnsureClusterStability(); err != nil {
-		z.Log.Info(fmt.Sprintf("Infinispan '%s' not ready: %s", clusterName, err.Error()))
+		logger.V(1).Info("Infinispan cluster not ready", "cluster", clusterName, "reason", err.Error())
 		return reconcile.Result{RequeueAfter: consts.DefaultWaitOnCluster}, nil
 	}
 
 	podList := &corev1.PodList{}
 	podLabels := infinispan.PodSelectorLabels()
 	if err := z.Kube.ResourcesList(infinispan.Namespace, podLabels, podList, ctx); err != nil {
-		z.Log.Error(err, "Failed to list pods")
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("failed to list pods: %w", err)
 	}
 	podSecurityCtx := podList.Items[0].Spec.SecurityContext
 
@@ -254,6 +252,7 @@ func (z *zeroCapacityController) initializeResources(request reconcile.Request, 
 		if err := z.Create(ctx, pod); err != nil {
 			return reconcile.Result{}, fmt.Errorf("unable to create zero-capacity pod: %w", err)
 		}
+		log.FromContext(ctx).Info("Created zero-capacity pod", "pod", name)
 	}
 
 	// Update status
@@ -266,19 +265,23 @@ func (z *zeroCapacityController) execute(ispnClient api.Infinispan, request reco
 	}
 
 	if err := instance.Exec(ispnClient); err != nil {
-		z.Log.Error(err, "unable to execute action on zero-capacity pod", "request.Name", request.Name)
+		log.FromContext(ctx).Error(err, "unable to execute action on zero-capacity pod")
 		return reconcile.Result{}, instance.UpdatePhase(ZeroFailed, err)
 	}
 
 	return reconcile.Result{}, instance.UpdatePhase(ZeroRunning, nil)
 }
 
-func (z *zeroCapacityController) waitForExecutionToComplete(ispnClient api.Infinispan, request reconcile.Request, instance zeroCapacityResource) (reconcile.Result, error) {
+func (z *zeroCapacityController) waitForExecutionToComplete(ctx context.Context, ispnClient api.Infinispan, request reconcile.Request, instance zeroCapacityResource) (reconcile.Result, error) {
 	phase, err := instance.ExecStatus(ispnClient)
 
-	if err != nil || phase == ZeroFailed {
-		z.Log.Error(err, "execution failed", "request.Name", request.Name)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "execution failed")
 		return reconcile.Result{}, instance.UpdatePhase(ZeroFailed, err)
+	}
+	if phase == ZeroFailed {
+		log.FromContext(ctx).Info("execution failed")
+		return reconcile.Result{}, instance.UpdatePhase(ZeroFailed, nil)
 	}
 
 	if phase == ZeroSucceeded {
@@ -293,10 +296,9 @@ func (z *zeroCapacityController) cleanupResources(ispnClient api.Infinispan, req
 	// Stop the zero-capacity server so that it leaves the Infinispan cluster
 	if z.isZeroPodReady(request, ctx) {
 		if err := ispnClient.Server().Stop(); err != nil {
-			err = fmt.Errorf("unable to stop zero-capacity server: %w", err)
-			z.Log.Error(err, "error encountered when cleaning up zero-capacity pod")
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("unable to stop zero-capacity server: %w", err)
 		}
+		log.FromContext(ctx).Info("Stopped zero-capacity server", "pod", request.Name)
 	}
 	return reconcile.Result{}, nil
 }

--- a/launcher/operator/operator.go
+++ b/launcher/operator/operator.go
@@ -3,7 +3,6 @@ package operator
 import (
 	"context"
 	"crypto/tls"
-	"fmt"
 	"os"
 	"strings"
 
@@ -181,7 +180,7 @@ func NewWithContext(ctx context.Context, p Parameters) {
 		os.Exit(1)
 	}
 
-	setupLog.Info(fmt.Sprintf("Starting Infinispan Operator Version: %s", launcher.Version))
+	setupLog.Info("Starting Infinispan Operator", "version", launcher.Version)
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)

--- a/pkg/infinispan/upgrades/rolling_upgrades.go
+++ b/pkg/infinispan/upgrades/rolling_upgrades.go
@@ -20,8 +20,7 @@ func ConnectCaches(user, adminPasswordSource, sourceIp string, sourceClient, tar
 		return fmt.Errorf("failed to get cache names from the source cluster: %w", err)
 	}
 
-	logger.Info(fmt.Sprintf("Cache names in the source cluster '%s'", names))
-	logger.Info("Creating caches in the target cluster")
+	logger.Info("Creating caches in the target cluster", "sourceCaches", names)
 	configType := mime.ApplicationJson
 	for _, cacheName := range names {
 		targetCache := targetClient.Cache(cacheName)
@@ -39,9 +38,9 @@ func ConnectCaches(user, adminPasswordSource, sourceIp string, sourceClient, tar
 				if err = targetCache.Create(config, configType); err != nil {
 					return fmt.Errorf("failed to create cache '%s': %w", cacheName, err)
 				}
-				logger.Info(fmt.Sprintf("Cache '%s' created", cacheName))
+				logger.Info("Cache created", "cache", cacheName)
 			} else {
-				logger.Info(fmt.Sprintf("Cache '%s' already exists", cacheName))
+				logger.Info("Cache already exists", "cache", cacheName)
 			}
 		}
 
@@ -57,12 +56,12 @@ func ConnectCaches(user, adminPasswordSource, sourceIp string, sourceClient, tar
 			if err != nil {
 				return fmt.Errorf("failed to generate remote store config '%s': %w", cacheName, err)
 			}
-			logger.Info(remoteStoreCfg)
+			logger.V(2).Info("Remote store configuration", "config", remoteStoreCfg)
 			if err = rollingUpgrade.AddSource(remoteStoreCfg, configType); err != nil {
 				return fmt.Errorf("failed to add remote store to cache '%s': %w", cacheName, err)
 			}
 		} else {
-			logger.Info(fmt.Sprintf("Cache '%s' already connected to remote cluster", cacheName))
+			logger.Info("Cache already connected to remote cluster", "cache", cacheName)
 		}
 
 	}
@@ -75,7 +74,7 @@ func SyncCaches(sourceClient, targetClient api.Infinispan, logger logr.Logger) e
 	if err != nil {
 		return fmt.Errorf("failed to get cache names from the target cluster: %w", err)
 	}
-	logger.Info(fmt.Sprintf("Cache names in the target cluster '%s'", names))
+	logger.Info("Syncing caches from target cluster", "caches", names)
 
 	for _, cacheName := range names {
 		upgrade := targetClient.Cache(cacheName).RollingUpgrade()
@@ -83,7 +82,7 @@ func SyncCaches(sourceClient, targetClient api.Infinispan, logger logr.Logger) e
 		if err != nil {
 			return fmt.Errorf("failed to sync data for cache'%s': %w", cacheName, err)
 		}
-		logger.Info(fmt.Sprintf("Sync result for '%s' %s:'", cacheName, count))
+		logger.Info("Sync completed", "cache", cacheName, "count", count)
 
 		if err = upgrade.DisconnectSource(); err != nil {
 			return fmt.Errorf("failed to disconnect source for cache'%s': %w", cacheName, err)

--- a/pkg/infinispan/version/version.go
+++ b/pkg/infinispan/version/version.go
@@ -126,7 +126,7 @@ func (m *Manager) Log(log logr.Logger) {
 	if bytes, err := json.MarshalIndent(m.Operands, "", "  "); err != nil {
 		log.Error(err, "unable to log VersionManager content")
 	} else {
-		log.Info(fmt.Sprintf("Loaded Operand Versions:\n%s", bytes))
+		log.Info("Loaded operand versions", "operands", string(bytes))
 	}
 }
 

--- a/pkg/kubernetes/controllerutil.go
+++ b/pkg/kubernetes/controllerutil.go
@@ -39,7 +39,7 @@ func LookupResource(name, namespace string, resource, caller client.Object, clie
 					eventRec.Event(caller, corev1.EventTypeWarning, EventReasonResourceNotReady, fmt.Sprintf("%s resource '%s' not ready", reflect.TypeOf(resource).Elem().Name(), name))
 				}
 			}
-			logger.Info(fmt.Sprintf("%s resource '%s' not ready", reflect.TypeOf(resource).Elem().Name(), name))
+			logger.Info("Resource not ready", "kind", reflect.TypeOf(resource).Elem().Name(), "name", name)
 			return &reconcile.Result{RequeueAfter: consts.DefaultWaitOnCreateResource}, nil
 		}
 		return &reconcile.Result{}, err

--- a/pkg/kubernetes/k8sutil.go
+++ b/pkg/kubernetes/k8sutil.go
@@ -9,7 +9,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ForceRunModeEnv indicates if the operator should be forced to run in either local
@@ -32,8 +32,6 @@ const (
 	// which is the name of the current pod.
 	PodNameEnvVar = "POD_NAME"
 )
-
-var log = logf.Log.WithName("k8sutil")
 
 // GetWatchNamespace returns the namespace the operator should be watching for changes
 func GetWatchNamespace() (string, error) {
@@ -65,7 +63,7 @@ func getOperatorNamespace() (string, error) {
 		return "", err
 	}
 	ns := strings.TrimSpace(string(nsBytes))
-	log.V(1).Info("Found namespace", "Namespace", ns)
+	log.Log.V(1).Info("Found namespace", "namespace", ns)
 	return ns, nil
 }
 
@@ -112,14 +110,14 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 		return nil, fmt.Errorf("required env %s not set, please configure downward API", PodNameEnvVar)
 	}
 
-	log.V(1).Info("Found podname", "Pod.Name", podName)
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Found podname", "pod", podName)
 
 	pod := &corev1.Pod{}
 	key := crclient.ObjectKey{Namespace: ns, Name: podName}
 	err := client.Get(ctx, key, pod)
 	if err != nil {
-		log.Error(err, "Failed to get Pod", "Pod.Namespace", ns, "Pod.Name", podName)
-		return nil, err
+		return nil, fmt.Errorf("failed to get pod %s: %w", podName, err)
 	}
 
 	// .Get() clears the APIVersion and Kind,
@@ -127,7 +125,7 @@ func GetPod(ctx context.Context, client crclient.Client, ns string) (*corev1.Pod
 	pod.APIVersion = "v1"
 	pod.Kind = "Pod"
 
-	log.V(1).Info("Found Pod", "Pod.Namespace", ns, "Pod.Name", pod.Name)
+	logger.V(1).Info("Found Pod", "pod", pod.Name)
 
 	return pod, nil
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -197,14 +197,12 @@ func (k Kubernetes) GetKubernetesRESTConfig(masterURL, secretName, namespace str
 
 	config, err := clientcmd.BuildConfigFromFlags(masterURL, "")
 	if err != nil {
-		logger.Error(err, "unable to create REST configuration", "master URL", masterURL)
-		return nil, err
+		return nil, fmt.Errorf("unable to create REST configuration for %s: %w", masterURL, err)
 	}
 
 	secret, err := k.GetSecret(secretName, namespace, ctx)
 	if err != nil {
-		logger.Error(err, "unable to find Secret", "secret name", secretName)
-		return nil, err
+		return nil, fmt.Errorf("unable to find secret %s: %w", secretName, err)
 	}
 
 	for _, secretKey := range []string{"certificate-authority", "client-certificate", "client-key"} {
@@ -223,8 +221,7 @@ func (k Kubernetes) GetKubernetesRESTConfig(masterURL, secretName, namespace str
 func (k Kubernetes) GetOpenShiftRESTConfig(masterURL, secretName, namespace string, logger logr.Logger, ctx context.Context) (*rest.Config, error) {
 	config, err := clientcmd.BuildConfigFromFlags(masterURL, "")
 	if err != nil {
-		logger.Error(err, "unable to create REST configuration", "master URL", masterURL)
-		return nil, err
+		return nil, fmt.Errorf("unable to create REST configuration for %s: %w", masterURL, err)
 	}
 
 	// Skip-tls for accessing other OpenShift clusters
@@ -232,8 +229,7 @@ func (k Kubernetes) GetOpenShiftRESTConfig(masterURL, secretName, namespace stri
 
 	secret, err := k.GetSecret(secretName, namespace, ctx)
 	if err != nil {
-		logger.Error(err, "unable to find Secret", "secret name", secretName)
-		return nil, err
+		return nil, fmt.Errorf("unable to find secret %s: %w", secretName, err)
 	}
 
 	if token, ok := secret.Data["token"]; ok {
@@ -281,7 +277,7 @@ func (k Kubernetes) GetNodeHost(logger logr.Logger, ctx context.Context) (string
 			if nodeCondition.Type == corev1.NodeReady && nodeCondition.Status == corev1.ConditionTrue && len(nodeStatus.Addresses) > 0 {
 				for _, addressType := range []corev1.NodeAddressType{corev1.NodeExternalIP, corev1.NodeInternalIP} {
 					if host := getNodeAddress(node, addressType); host != "" {
-						logger.Info("Found ready worker node.", "Host", host)
+						logger.Info("Found ready worker node", "host", host)
 						return host, nil
 					}
 				}

--- a/pkg/reconcile/pipeline/infinispan/context/resources.go
+++ b/pkg/reconcile/pipeline/infinispan/context/resources.go
@@ -132,9 +132,10 @@ func (r resources) load(name string, obj client.Object, load func() error, opts 
 		}
 
 		if isNotFound && !config.SkipEventRec {
-			msg := fmt.Sprintf("%s resource '%s' not ready", reflect.TypeOf(obj).Elem().Name(), name)
-			r.Log().Info(msg)
-			r.EventRecorder().Event(r.infinispan, corev1.EventTypeWarning, "ResourceNotReady", msg)
+			kind := reflect.TypeOf(obj).Elem().Name()
+			r.Log().V(1).Info("Resource not ready", "kind", kind, "resource", name)
+			r.EventRecorder().Event(r.infinispan, corev1.EventTypeNormal, "ResourceNotReady",
+				fmt.Sprintf("%s resource '%s' not ready", kind, name))
 		}
 		return err
 	}

--- a/pkg/reconcile/pipeline/infinispan/handler/configure/xsite.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/configure/xsite.go
@@ -68,7 +68,7 @@ func XSite(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		xSite.MaxRelayNodes = i.Spec.Service.Sites.Local.MaxRelayNodes
 	}
 	ctx.ConfigFiles().XSite = xSite
-	ctx.Log().Info("x-site configured", "configuration", xSite)
+	ctx.Log().V(2).Info("x-site configured", "configuration", xSite)
 }
 
 func searchRemoteSites(i *ispnv1.Infinispan, ctx pipeline.Context, xSite *pipeline.XSite) error {
@@ -119,8 +119,7 @@ func appendRemoteLocation(i *ispnv1.Infinispan, ctx pipeline.Context, xSite *pip
 
 	remoteKubernetes, err := kube.NewKubernetesFromConfig(restConfig, ctx.Kubernetes().Client.Scheme())
 	if err != nil {
-		logger.Error(err, "could not connect to remote location URL", "URL", remoteLocation.URL)
-		return err
+		return fmt.Errorf("could not connect to remote site %q: %w", remoteLocation.URL, err)
 	}
 
 	remoteLocationName := remoteLocation.Name
@@ -130,54 +129,44 @@ func appendRemoteLocation(i *ispnv1.Infinispan, ctx pipeline.Context, xSite *pip
 
 	routeSupported, err := remoteKubernetes.IsGroupVersionSupported(pipeline.RouteGVK.GroupVersion().String(), pipeline.RouteGVK.Kind)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("failed to check if GVK '%s' is supported", pipeline.RouteGVK))
-		return err
+		return fmt.Errorf("failed to check if Route GVK is supported: %w", err)
 	}
 
 	if routeSupported {
 		// Note: we need to lookup the Route first because, even if Route is enabled, the service exists with "ClusterIP".
-		logger.Info("Lookup cross-site route", "Name", remoteRouteName, "Namespace", remoteNamespace)
+		logger.V(1).Info("Lookup cross-site route", "name", remoteRouteName, "namespace", remoteNamespace)
 		siteRoute := &routev1.Route{}
 		if err := remoteKubernetes.Client.Get(ctx.Ctx(), types.NamespacedName{Name: remoteRouteName, Namespace: remoteNamespace}, siteRoute); err == nil {
 			// Route found
-			logger.Info("Remote route found!", "host", siteRoute.Spec.Host)
+			logger.V(1).Info("Remote route found", "host", siteRoute.Spec.Host)
 			appendBackupSite(remoteLocationName, siteRoute.Spec.Host, 443, xSite, false)
 			return nil
 		} else if client.IgnoreNotFound(err) != nil {
-			logger.Error(err, "could not get x-site Route in remote cluster", "site route name", remoteRouteName, "site namespace", remoteNamespace)
-			return err
+			return fmt.Errorf("could not get x-site Route %s/%s in remote cluster: %w", remoteNamespace, remoteRouteName, err)
 		}
 	}
 
 	// No Route object found, try the Service
-	logger.Info("Lookup cross-site service", "Name", remoteServiceName, "Namespace", remoteNamespace)
+	logger.V(1).Info("Lookup cross-site service", "name", remoteServiceName, "namespace", remoteNamespace)
 	siteService := &corev1.Service{}
 	err = remoteKubernetes.Client.Get(ctx.Ctx(), types.NamespacedName{Name: remoteServiceName, Namespace: remoteNamespace}, siteService)
 	if err != nil {
-		logger.Error(err, "could not get x-site service in remote cluster", "site service name", remoteServiceName, "site namespace", remoteNamespace)
-		return err
+		return fmt.Errorf("could not get x-site service %s/%s in remote cluster: %w", remoteNamespace, remoteServiceName, err)
 	}
 
 	if siteService.Spec.Type == corev1.ServiceTypeClusterIP {
-		// If we reach this point, we have a remote API URL to a different cluster.
-		// ClusterIP service won't work because we will be unable to connect to the internal IP address
-		err = fmt.Errorf("ClusterIP service type not supported")
-		logger.Error(err, "could not get x-site service in remote cluster", "site service name", remoteServiceName, "site namespace", remoteNamespace)
-		return err
+		return fmt.Errorf("ClusterIP service type not supported for x-site service %s/%s in remote cluster", remoteNamespace, remoteServiceName)
 	}
 
 	host, port, err := getCrossSiteServiceHostPort(siteService, ctx, remoteKubernetes, "XSiteRemoteServiceUnsupported")
 	if err != nil {
-		logger.Error(err, "error retrieving remote x-site service information")
-		return err
+		return fmt.Errorf("error retrieving remote x-site service information: %w", err)
 	}
 	if host == "" {
-		err = fmt.Errorf("remote x-site service host not yet available")
-		logger.Error(err, "could not get x-site service in remote cluster", "site service name", remoteServiceName, "site namespace", remoteNamespace)
-		return err
+		return fmt.Errorf("remote x-site service %s/%s host not yet available", remoteNamespace, remoteServiceName)
 	}
 
-	logger.Info("remote site service", "host", host, "port", port)
+	logger.V(1).Info("Remote site service found", "host", host, "port", port)
 	appendBackupSite(remoteLocationName, host, port, xSite, false)
 
 	return nil
@@ -290,11 +279,11 @@ func TransportTLS(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		Type:     consts.GetWithDefault(string(keyStoreSecret.Data["type"]), "pkcs12"),
 	}
 
-	log.Info("Transport TLS Configured.", "Keystore", keyStoreFileName, "Secret Name", keyStoreSecret.Name)
+	log.V(1).Info("Transport TLS configured", "keystore", keyStoreFileName, "secret", keyStoreSecret.Name)
 
 	// do not attempt to load the trust store secret if not configured
 	if i.GetSiteTrustoreSecretName() == "" {
-		log.Info("Truststore not configured.")
+		log.V(1).Info("Truststore not configured")
 		return
 	}
 
@@ -313,7 +302,7 @@ func TransportTLS(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		ctx.Stop(err)
 		return
 	}
-	log.Info("Found Truststore.", "Truststore", trustStoreFileName, "Secret Name", trustStoreSecret.Name)
+	log.V(1).Info("Truststore found", "truststore", trustStoreFileName, "secret", trustStoreSecret.Name)
 	configFiles.Transport.Truststore = &pipeline.Truststore{
 		File:     trustStoreSecret.Data[trustStoreFileName],
 		Path:     fmt.Sprintf("%s/%s", consts.SiteTrustStoreRoot, trustStoreFileName),
@@ -337,8 +326,8 @@ func GossipRouterTLS(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		return
 	}
 
-	log := ctx.Log().WithName("GossipRouter")
-	log.Info("TLS Configured.", "Keystore", filename, "Secret Name", keyStoreSecret.Name)
+	log := ctx.Log().WithName("gossipRouter")
+	log.V(1).Info("TLS configured", "keystore", filename, "secret", keyStoreSecret.Name)
 
 	configFiles := ctx.ConfigFiles()
 	gossipRouter := &configFiles.XSite.GossipRouter
@@ -354,7 +343,7 @@ func GossipRouterTLS(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		// between the two to allow this to change in the future without having to update the provisioning handlers
 		gossipRouter.Truststore = configFiles.Transport.Truststore
 	} else {
-		log.Info("No TrustStore secret found")
+		log.V(1).Info("No truststore secret found")
 	}
 }
 

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/conditions.go
@@ -58,13 +58,13 @@ func OperatorStatusChecks(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		if ctx.Operand().Deprecated {
 			msg := fmt.Sprintf("Infinispan version '%s' will be removed in a subsequent Operator release. You must upgrade to a non-deprecated release before upgrading the Operator.", i.Spec.Version)
 			ctx.EventRecorder().Event(i, corev1.EventTypeWarning, "DeprecatedOperandVersion", msg)
-			ctx.Log().Error(nil, msg)
+			ctx.Log().Info(msg)
 		}
 
 		if i.Spec.Autoscale != nil {
 			errMsg := "Autoscale is no longer supported. Please remove spec.autoscale field."
 			ctx.EventRecorder().Event(i, corev1.EventTypeWarning, "AutoscaleNotSupported", errMsg)
-			ctx.Log().Error(fmt.Errorf("AutoscaleNotSupported"), errMsg)
+			ctx.Log().Info(errMsg, "reason", "autoscaleNotSupported")
 		}
 		ctx.Requeue(
 			ctx.UpdateInfinispan(func() {
@@ -91,7 +91,7 @@ func PodStatus(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			starting = append(starting, pod.GetName())
 		}
 	}
-	ctx.Log().Info("Found deployments with status ", "starting", starting, "ready", ready)
+	ctx.Log().V(1).Info("Pod status", "starting", starting, "ready", ready)
 	_ = ctx.UpdateInfinispan(func() {
 		i.Status.PodStatus = ispnv1.DeploymentStatus{
 			Starting: starting,
@@ -112,6 +112,7 @@ func AwaitWellFormedCondition(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		return
 	}
 
+	previouslyWellFormed := i.IsConditionTrue(ispnv1.ConditionWellFormed)
 	wellFormed := wellFormedCondition(i, ctx, podList)
 	if err := ctx.UpdateInfinispan(func() {
 		i.SetConditions(wellFormed)
@@ -122,9 +123,12 @@ func AwaitWellFormedCondition(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		return
 	}
 
+	if wellFormed.Status == metav1.ConditionTrue && !previouslyWellFormed {
+		ctx.Log().Info("Infinispan cluster is well-formed", "replicas", len(podList.Items))
+	}
+
 	if i.NotClusterFormed(len(podList.Items), int(i.Spec.Replicas)) {
-		ctx.Log().Info("Cluster not well-formed, retrying ...")
-		ctx.Log().Info(fmt.Sprintf("podList.Items=%d, i.Spec.Replicas=%d", len(podList.Items), int(i.Spec.Replicas)))
+		ctx.Log().V(1).Info("Cluster not well-formed, retrying", "pods", len(podList.Items), "replicas", int(i.Spec.Replicas))
 		ctx.RequeueAfter(consts.DefaultWaitClusterNotWellFormed, nil)
 	}
 }
@@ -196,11 +200,13 @@ func XSiteViewCondition(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		k8s := ctx.Kubernetes()
 		logs, err := k8s.Logs(provision.InfinispanContainer, podName, i.Namespace, false, ctx.Ctx())
 		if err != nil {
-			ctx.Log().Error(err, fmt.Sprintf("Unable to retrive logs for i pod %s", podName))
+			ctx.Log().Error(err, "Unable to retrieve logs for pod", "pod", podName)
 		}
 		if strings.Contains(logs, "ISPN000643") {
 			if err := ctx.InfinispanClientForPod(podName).Container().Xsite().PushAllState(); err != nil {
 				ctx.Log().Error(err, "Unable to push xsite state after SFS data recovery")
+			} else {
+				ctx.Log().Info("Pushed xsite state after recovery")
 			}
 		}
 	}

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/console.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/console.go
@@ -55,7 +55,7 @@ func ConsoleUrl(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					ctx.RequeueAfter(consts.DefaultWaitOnCluster, nil)
 					return
 				}
-				log.Info("LoadBalancer address not ready yet. Waiting on value in reconcile loop")
+				log.V(1).Info("LoadBalancer address not ready yet")
 				ctx.RequeueAfter(consts.DefaultWaitOnCluster, nil)
 				return
 			}
@@ -85,4 +85,7 @@ func ConsoleUrl(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			i.Status.ConsoleUrl = ptr.To(fmt.Sprintf("%s://%s/console", i.GetEndpointScheme(), exposeAddress))
 		}
 	})
+	if i.Status.ConsoleUrl != nil {
+		ctx.Log().V(1).Info("Updated console URL in status", "url", *i.Status.ConsoleUrl)
+	}
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/hotrod_upgrades.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/hotrod_upgrades.go
@@ -32,7 +32,7 @@ type HotRodRollingUpgradeRequest struct {
 var nameRegexp = regexp.MustCompile(`(.*)-([\d]+$)`)
 
 func hotRodRollingUpgradeLog(log logr.Logger) logr.Logger {
-	return log.WithName("HotRodRollingUpgrade")
+	return log.WithName("hotRodRollingUpgrade")
 }
 
 func subMapOf(f, s map[string]string) bool {
@@ -52,7 +52,7 @@ func ScheduleHotRodRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	}
 
 	requestedOperand := ctx.Operand()
-	log.Info(fmt.Sprintf("Scheduling an Upgrade to Operand %s", requestedOperand.Ref()))
+	log.Info("Scheduling upgrade to new operand", "version", requestedOperand.Ref())
 
 	err := ctx.UpdateInfinispan(func() {
 		i.Status.HotRodRollingUpgradeStatus = &ispnv1.HotRodRollingUpgradeStatus{
@@ -66,7 +66,7 @@ func ScheduleHotRodRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if err != nil {
 		log.Error(err, "unable to create initial Hot Rod status")
 	}
-	ctx.Requeue(nil)
+	ctx.Requeue(err)
 }
 
 // HotRodRollingUpgrade handles all stages of a Hot Rod Rolling upgrade. Throughout the execution we use RequeueEventually
@@ -81,7 +81,7 @@ func HotRodRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 
 	podList, err := ctx.InfinispanPods()
 	if err != nil || len(podList.Items) == 0 {
-		log.Info("No pods found")
+		log.V(1).Info("No pods found")
 		return
 	}
 
@@ -109,14 +109,14 @@ func HotRodRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if !subMapOf(ctx.DefaultLabels(), i.ObjectMeta.Labels) || !subMapOf(ctx.DefaultAnnotations(), i.Annotations) {
 		ctx.Requeue(
 			ctx.UpdateInfinispan(func() {
-				ctx.Log().Info("Updating Labels", "Labels: ", ctx.DefaultLabels())
+				ctx.Log().Info("Updating Labels", "labels", ctx.DefaultLabels())
 				i.ApplyOperatorMeta(ctx.DefaultLabels(), ctx.DefaultAnnotations())
 			}))
 		return
 	}
 
 	if err := req.handleMigration(); err != nil {
-		ctx.Log().Error(err, fmt.Sprintf("%s failed, retrying", upgradeStatus.Stage))
+		ctx.Log().Error(err, "Upgrade stage failed, retrying", "stage", string(upgradeStatus.Stage))
 		ctx.RequeueEventually(0)
 	}
 }
@@ -125,22 +125,22 @@ func (r *HotRodRollingUpgradeRequest) handleMigration() error {
 	status := r.i.Status.HotRodRollingUpgradeStatus
 	switch status.Stage {
 	case ispnv1.HotRodRollingStageStart:
-		r.log.Info(string(ispnv1.HotRodRollingStageStart))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStageStart))
 		return r.createNewStatefulSet()
 	case ispnv1.HotRodRollingStagePrepare:
-		r.log.Info(string(ispnv1.HotRodRollingStagePrepare))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStagePrepare))
 		return r.prepare()
 	case ispnv1.HotRodRollingStageRedirect:
-		r.log.Info(string(ispnv1.HotRodRollingStageRedirect))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStageRedirect))
 		return r.redirectService()
 	case ispnv1.HotRodRollingStageSync:
-		r.log.Info(string(ispnv1.HotRodRollingStageSync))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStageSync))
 		return r.syncData()
 	case ispnv1.HotRodRollingStageStatefulSetReplace:
-		r.log.Info(string(ispnv1.HotRodRollingStageStatefulSetReplace))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStageStatefulSetReplace))
 		return r.replaceStatefulSet()
 	case ispnv1.HotRodRollingStageCleanup:
-		r.log.Info(string(ispnv1.HotRodRollingStageCleanup))
+		r.log.V(2).Info("Hot Rod rolling upgrade stage", "stage", string(ispnv1.HotRodRollingStageCleanup))
 		return r.cleanup()
 	default:
 		return nil
@@ -197,6 +197,7 @@ func (r *HotRodRollingUpgradeRequest) changeSelector(serviceName string, selecto
 	if err != nil {
 		return fmt.Errorf("failed to update service: %w", err)
 	}
+	r.ctx.Log().V(1).Info("Patched service selector for upgrade")
 	return nil
 }
 
@@ -302,6 +303,7 @@ func (r *HotRodRollingUpgradeRequest) reconcileNewPingService() error {
 	if err := resources.Create(newPingService, true); err != nil {
 		return fmt.Errorf("error creating new ping service '%s' : %w", newPingServiceName, err)
 	}
+	r.ctx.Log().V(1).Info("Created target cluster resources")
 	return nil
 }
 
@@ -380,6 +382,7 @@ func (r *HotRodRollingUpgradeRequest) createNewStatefulSet() error {
 		if err = ctx.Resources().Create(targetStatefulSet, true); err != nil {
 			return fmt.Errorf("failed to create new statefulSet '%s': %w", targetStatefulSetName, err)
 		}
+		r.ctx.Log().Info("Created target StatefulSet for rolling upgrade")
 		r.ctx.RequeueEventually(constants.DefaultWaitOnCluster)
 		return nil
 	}
@@ -391,7 +394,7 @@ func (r *HotRodRollingUpgradeRequest) createNewStatefulSet() error {
 
 	for _, pod := range podList.Items {
 		if !kube.IsPodReady(pod) {
-			log.Info(fmt.Sprintf("Pod '%s' not ready", pod.Name))
+			log.Info("Pod not ready", "pod", pod.Name)
 			r.ctx.RequeueEventually(constants.DefaultWaitOnCluster)
 			return nil
 		}
@@ -399,9 +402,9 @@ func (r *HotRodRollingUpgradeRequest) createNewStatefulSet() error {
 
 	// Check if cluster is well-formed
 	wellFormed := wellFormedCondition(r.i, r.ctx, podList)
-	log.Info(fmt.Sprintf("Cluster WellFormed: %v", wellFormed))
+	log.Info("Cluster well-formed check", "wellFormed", wellFormed.Status)
 	if wellFormed.Status != metav1.ConditionTrue {
-		log.Info(fmt.Sprintf("Cluster from Statefulset '%s' not well formed", targetStatefulSet.Name))
+		log.Info("Cluster from StatefulSet not well formed", "statefulSet", targetStatefulSet.Name)
 		ctx.RequeueEventually(constants.DefaultWaitClusterNotWellFormed)
 		return nil
 	}
@@ -513,6 +516,7 @@ func (r *HotRodRollingUpgradeRequest) replaceStatefulSet() error {
 // cleanup Dispose a statefulSet from an Infinispan CRD and its dependencies
 func (r *HotRodRollingUpgradeRequest) cleanup() error {
 	ctx := r.ctx
+	r.ctx.Log().Info("Cleaning up rolling upgrade resources")
 	// Wait for cluster with new statefulSet stability
 	if !r.i.IsWellFormed() {
 		ctx.RequeueEventually(constants.DefaultWaitOnCreateResource)

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/manage.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/manage.go
@@ -22,7 +22,7 @@ func AwaitPodIps(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	}
 
 	if !kube.ArePodIPsReady(podList) {
-		ctx.Log().Info("Pod IPs are not ready yet")
+		ctx.Log().V(1).Info("Pod IPs are not ready yet")
 		ctx.RequeueAfter(consts.DefaultWaitClusterPodsNotReady,
 			ctx.UpdateInfinispan(func() {
 				i.SetCondition(ispnv1.ConditionWellFormed, metav1.ConditionUnknown, "Pods are not ready")
@@ -51,6 +51,7 @@ func RemoveFailedInitContainers(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					ctx.Requeue(err)
 					return
 				}
+				ctx.Log().Info("Deleted pod with failed init container", "pod", pod.Name)
 			}
 		}
 	}
@@ -90,6 +91,7 @@ func UpdatePodLabels(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		if err != nil {
 			return
 		}
+		ctx.Log().V(1).Info("Updated pod labels", "pod", pod.Name)
 	}
 }
 
@@ -117,6 +119,7 @@ func ConfigureLoggers(infinispan *ispnv1.Infinispan, ctx pipeline.Context) {
 					ctx.Requeue(fmt.Errorf("unable to set logger %s=%s: %w", category, string(level), err))
 					return
 				}
+				ctx.Log().V(1).Info("Set server log level")
 			}
 		}
 	}
@@ -149,7 +152,7 @@ func ClusterScaling(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	scalingDown := i.IsConditionTrue(ispnv1.ConditionScalingDown) && statefulSet.Status.ReadyReplicas > i.Spec.Replicas
 	if scalingUp || scalingDown {
 		// The StatefulSet spec has already been updated to i.spec.replicas, so we must wait for the pods to be updated
-		ctx.Log().Info("waiting for the StatefulSet to scale", string(ispnv1.ConditionScalingUp), scalingUp, string(ispnv1.ConditionScalingDown), scalingDown)
+		ctx.Log().V(1).Info("Waiting for the StatefulSet to scale", "scalingUp", scalingUp, "scalingDown", scalingDown)
 		ctx.RequeueAfter(consts.DefaultWaitClusterPodsNotReady, nil)
 		return
 	}
@@ -173,6 +176,7 @@ func ClusterScaling(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					ctx.Requeue(fmt.Errorf("unable to remove PVC '%s' for old pod: %w", pvc, err))
 					return
 				}
+				ctx.Log().Info("Deleted PVC during scale-down", "pvc", pvc)
 			}
 		}
 	} else {
@@ -194,4 +198,5 @@ func ClusterScaling(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		i.RemoveCondition(ispnv1.ConditionScalingDown)
 		i.RemoveCondition(ispnv1.ConditionScalingUp)
 	})
+	ctx.Log().V(1).Info("Updated replica status", "replicas", i.Spec.Replicas)
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/statefulset_updates.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/statefulset_updates.go
@@ -57,7 +57,7 @@ func StatefulSetRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		if memRequests.Cmp(previousMemRequests) != 0 || memLimits.Cmp(previousMemLimits) != 0 {
 			res.Requests["memory"] = memRequests
 			res.Limits["memory"] = memLimits
-			log.Info("memory changed, update i", "memLim", memLimits, "cpuReq", memRequests, "previous cpuLim", previousMemLimits, "previous cpuReq", previousMemRequests)
+			log.Info("Memory resources changed", "memoryLimit", memLimits, "memoryRequest", memRequests, "previousMemoryLimit", previousMemLimits, "previousMemoryRequest", previousMemRequests)
 			statefulSet.Spec.Template.Annotations["updateDate"] = time.Now().String()
 			updateReasons = append(updateReasons, "memory changed")
 		}
@@ -69,7 +69,7 @@ func StatefulSetRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		if cpuReq.Cmp(previousCPUReq) != 0 || cpuLim.Cmp(previousCPULim) != 0 {
 			res.Requests["cpu"] = cpuReq
 			res.Limits["cpu"] = cpuLim
-			log.Info("cpu changed, update i", "cpuLim", cpuLim, "cpuReq", cpuReq, "previous cpuLim", previousCPULim, "previous cpuReq", previousCPUReq)
+			log.Info("CPU resources changed", "cpuLimit", cpuLim, "cpuRequest", cpuReq, "previousCpuLimit", previousCPULim, "previousCpuRequest", previousCPUReq)
 			statefulSet.Spec.Template.Annotations["updateDate"] = time.Now().String()
 			updateReasons = append(updateReasons, "cpu changed")
 		}
@@ -250,9 +250,8 @@ func StatefulSetRollingUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			labelsForPod[consts.StatefulSetPodLabel] = i.GetStatefulSetName()
 			statefulSet.Spec.Template.Labels = labelsForPod
 		}
-		err := ctx.Resources().Update(statefulSet, pipeline.RetryOnErr)
-		if err != nil {
-			log.Error(err, "failed to update StatefulSet", "StatefulSet.Name", statefulSet.Name)
+		if err := ctx.Resources().Update(statefulSet, pipeline.RetryOnErr); err != nil {
+			return
 		}
 	}
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/manage/upgrades.go
@@ -129,10 +129,8 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 
 	// Initiate the GracefulShutdown if it's not already in progress
 	if i.Spec.Replicas == 0 {
-		logger.Info(".Spec.Replicas==0")
 		replicas := *statefulSet.Spec.Replicas
 		if replicas != 0 {
-			logger.Info("StatefulSet.Spec.Replicas!=0")
 			// Only send a GracefulShutdown request to the server if it hasn't succeeded already
 			if !i.IsConditionTrue(ispnv1.ConditionStopping) {
 				logger.Info("Sending GracefulShutdown request to the Infinispan cluster")
@@ -159,7 +157,7 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					if err != nil {
 						if shutdown, state := containerAlreadyShutdown(err); shutdown {
 							serverMeta.skip, serverMeta.state = true, state
-							logger.Info("At least one cache-container has already been shutdown by the Operator, resuming shutdown", "pod", pod.Name, "state", state)
+							logger.V(1).Info("At least one cache-container has already been shutdown by the Operator, resuming shutdown", "pod", pod.Name, "state", state)
 							shutdownAlreadyInitiated = true
 							// Continue processing other pods here as it's possible that one or more pods still haven't
 							// been shutdown and we need to initiate the client
@@ -238,7 +236,7 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 				for _, pod := range podList.Items {
 					serverMeta := serverMetaMap[pod.Name]
 					if serverMeta.skip {
-						logger.Info("Skipping pod whose cache-container has already been shutdown by the Operator", "pod", pod, "state", serverMeta.state)
+						logger.V(1).Info("Skipping pod whose cache-container has already been shutdown by the Operator", "pod", pod, "state", serverMeta.state)
 						continue
 					}
 					ispnClient := serverMeta.client
@@ -251,6 +249,7 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 							ctx.Requeue(fmt.Errorf("unable to disable rebalancing: %w", err))
 							return
 						}
+						ctx.Log().Info("Disabled cluster rebalancing")
 						rebalanceDisabled = true
 					}
 
@@ -258,7 +257,7 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 						ctx.Requeue(fmt.Errorf("error encountered on container shutdown: %w", err))
 						return
 					} else {
-						logger.Info("Executed Container Shutdown on pod: ", "Pod.Name", pod.Name)
+						logger.V(1).Info("Container shutdown executed", "pod", pod.Name)
 					}
 				}
 
@@ -279,6 +278,7 @@ func GracefulShutdown(i *ispnv1.Infinispan, ctx pipeline.Context) {
 				ctx.Requeue(err)
 			} else {
 				statefulSet.Spec.Replicas = ptr.To(int32(0))
+				ctx.Log().Info("Scaling StatefulSet to zero for graceful shutdown")
 				// GracefulShutdown in progress, but we must wait until the StatefulSet has scaled down before proceeding
 				ctx.Requeue(ctx.Resources().Update(statefulSet))
 			}
@@ -372,14 +372,14 @@ func EnableRebalanceAfterScaleUp(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			ctx.Requeue(err)
 			return
 		} else if len(podList.Items) != int(i.Spec.Replicas) {
-			ctx.Log().Info("Waiting on cluster pods to be provisioned", "pods", len(podList.Items), "spec.replicas", i.Spec.Replicas)
+			ctx.Log().V(1).Info("Waiting on cluster pods to be provisioned", "pods", len(podList.Items), "spec.replicas", i.Spec.Replicas)
 			ctx.RequeueAfter(consts.DefaultWaitClusterPodsNotReady, nil)
 			return
 		}
 
 		ispnClient, err := ctx.InfinispanClient()
 		if err != nil {
-			ctx.Log().Info("Waiting on at least one ready pod", "err", err)
+			ctx.Log().V(1).Info("Waiting on at least one ready pod", "reason", err.Error())
 			ctx.RequeueAfter(consts.DefaultWaitClusterPodsNotReady, nil)
 			return
 		}
@@ -388,7 +388,7 @@ func EnableRebalanceAfterScaleUp(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			ctx.Requeue(fmt.Errorf("unable to retrieve cluster information on scale up: %w", err))
 			return
 		} else if info.ClusterSize != i.Spec.Replicas {
-			ctx.Log().Info("waiting for cluster to form", "replicas", i.Spec.Replicas)
+			ctx.Log().V(1).Info("Waiting for cluster to form", "replicas", i.Spec.Replicas)
 			ctx.RequeueAfter(consts.DefaultWaitClusterPodsNotReady, nil)
 			return
 		}
@@ -409,12 +409,12 @@ func EnableRebalanceAfterScaleUp(i *ispnv1.Infinispan, ctx pipeline.Context) {
 
 func AwaitUpgrade(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if i.IsUpgradeCondition() {
-		ctx.Log().Info("IsUpgradeCondition")
 		ctx.Requeue(nil)
 	}
 }
 
 func destroyResources(i *ispnv1.Infinispan, ctx pipeline.Context) {
+	ctx.Log().Info("Destroying cluster resources")
 
 	type resource struct {
 		name string

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/config_listener.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/config_listener.go
@@ -32,8 +32,7 @@ func ConfigListener(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	} else {
 		// If env not explicitly set, use the Operator image
 		if image, err := kube.GetOperatorImage(ctx.Ctx(), ctx.Kubernetes().Client); err != nil {
-			ctx.Log().Error(err, "unable to create ConfigListener deployment")
-			ctx.Requeue(err)
+			ctx.Requeue(fmt.Errorf("unable to create ConfigListener deployment: %w", err))
 			return
 		} else {
 			configListenerImage = image
@@ -189,6 +188,7 @@ func ConfigListener(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		if err := createOrUpdate(roleBinding); err != nil {
 			return
 		}
+		ctx.Log().V(1).Info("Created ConfigListener RBAC")
 	}
 
 	operandVersions, err := ctx.Operands().Json()
@@ -288,6 +288,7 @@ func RemoveConfigListener(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			return
 		}
 	}
+	ctx.Log().Info("Removed ConfigListener resources")
 
 	// Remove any Cache CR instances owned by Infinispan as these were created by the Listener
 	cacheList := &v2alpha1.CacheList{}
@@ -319,9 +320,9 @@ func ScaleConfigListener(replicas int32, i *ispnv1.Infinispan, ctx pipeline.Cont
 	})
 
 	if err != nil {
-		ctx.Log().Error(err, "unable to scale ConfigListener Deployment")
+		return fmt.Errorf("unable to scale ConfigListener deployment: %w", err)
 	}
-	return err
+	return nil
 }
 
 func UpdateConfigListenerDeployment(i *ispnv1.Infinispan, ctx pipeline.Context, mutate func(deployment *appsv1.Deployment)) error {
@@ -339,5 +340,8 @@ func UpdateConfigListenerDeployment(i *ispnv1.Infinispan, ctx pipeline.Context, 
 		mutate(deployment)
 		return nil
 	})
+	if err == nil {
+		ctx.Log().Info("Created ConfigListener deployment")
+	}
 	return err
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/configmaps.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/configmaps.go
@@ -22,7 +22,9 @@ func InfinispanConfigMap(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		configmap.Labels = i.Labels("infinispan-configmap-configuration")
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(configmap, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(configmap, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created ConfigMap", "configMap", configmap.Name)
+	}
 }
 
 func PopulateServerConfigMap(baseConfig, adminConfig, zeroConfig, log4jConfig string, cm *corev1.ConfigMap) {

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/gossiprouter.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/gossiprouter.go
@@ -16,10 +16,11 @@ import (
 
 func GossipRouter(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	r := ctx.Resources()
-	log := ctx.Log().WithName("GossipRouter")
+	log := ctx.Log().WithName("gossipRouter")
 
 	if !i.HasSites() {
 		_ = ctx.Resources().Delete(i.GetGossipRouterDeploymentName(), &appsv1.Deployment{}, pipeline.RetryOnErr)
+		ctx.Log().V(1).Info("Ensured no GossipRouter deployment")
 		return
 	}
 
@@ -28,6 +29,7 @@ func GossipRouter(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if err := r.Delete(oldRouterDeployment, &appsv1.Deployment{}, pipeline.RetryOnErr); err != nil {
 		return
 	}
+	ctx.Log().V(1).Info("Ensured no legacy GossipRouter deployment", "deployment", oldRouterDeployment)
 
 	if !i.IsGossipRouterEnabled() {
 		if i.Spec.Replicas == 0 {
@@ -187,16 +189,14 @@ func GossipRouter(i *ispnv1.Infinispan, ctx pipeline.Context) {
 
 	result, err := r.CreateOrUpdate(router, true, mutateFn, pipeline.RetryOnErr)
 	if err != nil {
-		log.Error(err, "Failed to configure Cross-Site Deployment")
 		return
 	}
 	if result != pipeline.OperationResultNone {
-		log.Info(fmt.Sprintf("Cross-site deployment '%s' %s", router.Name, string(result)))
+		log.Info("Cross-site deployment reconciled", "deployment", router.Name, "result", string(result))
 	}
 
 	pods := &corev1.PodList{}
 	if err := r.List(i.GossipRouterPodSelectorLabels(), pods, pipeline.RetryOnErr); err != nil {
-		log.Error(err, "Failed to fetch Gossip Router pod")
 		return
 	}
 

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/provision_test.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/provision_test.go
@@ -58,10 +58,10 @@ var _ = Describe("Provision", func() {
 						EphemeralStorage: true,
 					},
 				},
-				Version: "IGNORED. Required so we can call Default()",
+				Version: "IGNORED. Required so we can call ApplyDefaults()",
 			},
 		}
-		ispn.Default()
+		ispn.ApplyDefaults()
 
 		// Assert PriorityClassName set when specified
 		ss, err := ClusterStatefulSetSpec("statefulset", ispn, ctx)
@@ -105,10 +105,10 @@ var _ = Describe("Provision", func() {
 						EphemeralStorage: true,
 					},
 				},
-				Version: "IGNORED. Required so we can call Default()",
+				Version: "IGNORED. Required so we can call ApplyDefaults()",
 			},
 		}
-		ispn.Default()
+		ispn.ApplyDefaults()
 
 		ss, err := ClusterStatefulSetSpec("statefulset", ispn, ctx)
 		Expect(err).Should(BeNil())

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/secrets.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/secrets.go
@@ -15,7 +15,9 @@ func UserAuthenticationSecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		secret.Data = map[string][]byte{consts.ServerIdentitiesFilename: ctx.ConfigFiles().UserIdentities}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created secret", "secret", secret.Name)
+	}
 }
 
 func AdminSecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -32,7 +34,9 @@ func AdminSecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created secret", "secret", secret.Name)
+	}
 }
 
 func InfinispanSecuritySecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -49,7 +53,9 @@ func InfinispanSecuritySecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(secret, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created secret", "secret", secret.Name)
+	}
 }
 
 func TruststoreSecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -69,7 +75,9 @@ func TruststoreSecret(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(secret, false, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(secret, false, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created secret", "secret", secret.Name)
+	}
 }
 
 func newSecret(i *ispnv1.Infinispan, name string) *corev1.Secret {

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/service_monitor.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/service_monitor.go
@@ -25,6 +25,7 @@ func ServiceMonitor(i *iv1.Infinispan, ctx pipeline.Context) {
 		if err := ctx.Resources().Delete(i.GetServiceMonitorName(), &monitoringv1.ServiceMonitor{}, pipeline.IgnoreNotFound, pipeline.RetryOnErr); err != nil {
 			return
 		}
+		ctx.Log().V(1).Info("Deleted ServiceMonitor")
 		return
 	}
 
@@ -100,5 +101,7 @@ func ServiceMonitor(i *iv1.Infinispan, ctx pipeline.Context) {
 
 	if _, err := ctx.Resources().CreateOrUpdate(serviceMonitor, true, mutateFn); err != nil {
 		ctx.Requeue(fmt.Errorf("unable to createOrUpdate ServiceMonitor: %w", err))
+	} else {
+		ctx.Log().V(1).Info("Created ServiceMonitor")
 	}
 }

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/services.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/services.go
@@ -35,7 +35,9 @@ func PingService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		servicePort.Port = consts.InfinispanPingPort
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created service", "service", svc.Name)
+	}
 }
 
 func ClusterService(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -68,7 +70,9 @@ func ClusterService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created service", "service", svc.Name)
+	}
 }
 
 func AdminService(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -102,7 +106,9 @@ func AdminService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	if _, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr); err == nil {
+		ctx.Log().V(1).Info("Created service", "service", svc.Name)
+	}
 }
 
 func ExternalService(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -125,6 +131,7 @@ func ExternalService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					if err := ctx.Resources().Delete(svc.Name, &svc, pipeline.RetryOnErr); err != nil {
 						return
 					}
+					ctx.Log().Info("Deleted resource on expose type change", "resource", svc.Name)
 				}
 			case pipeline.RouteGVK:
 				routeList := &routev1.RouteList{}
@@ -135,6 +142,7 @@ func ExternalService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					if err := ctx.Resources().Delete(route.Name, &route, pipeline.RetryOnErr); err != nil {
 						return
 					}
+					ctx.Log().Info("Deleted resource on expose type change", "resource", route.Name)
 				}
 			case pipeline.IngressGVK:
 				ingressList := &ingressv1.IngressList{}
@@ -145,6 +153,7 @@ func ExternalService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 					if err := ctx.Resources().Delete(route.Name, &route, pipeline.RetryOnErr); err != nil {
 						return
 					}
+					ctx.Log().Info("Deleted resource on expose type change", "resource", route.Name)
 				}
 			}
 		}
@@ -194,7 +203,15 @@ func defineExternalService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	result, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	if err == nil {
+		switch result {
+		case pipeline.OperationResultCreated:
+			ctx.Log().Info("Created external endpoint", "service", svc.Name)
+		case pipeline.OperationResultUpdated:
+			ctx.Log().V(1).Info("Updated external endpoint", "service", svc.Name)
+		}
+	}
 }
 
 func defineExternalRoute(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -216,7 +233,15 @@ func defineExternalRoute(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(route, true, mutateFn, pipeline.RetryOnErr)
+	result, err := ctx.Resources().CreateOrUpdate(route, true, mutateFn, pipeline.RetryOnErr)
+	if err == nil {
+		switch result {
+		case pipeline.OperationResultCreated:
+			ctx.Log().Info("Created external endpoint", "route", route.Name)
+		case pipeline.OperationResultUpdated:
+			ctx.Log().V(1).Info("Updated external endpoint", "route", route.Name)
+		}
+	}
 }
 
 func defineExternalIngress(i *ispnv1.Infinispan, ctx pipeline.Context) {
@@ -265,19 +290,29 @@ func defineExternalIngress(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		}
 		return nil
 	}
-	_, _ = ctx.Resources().CreateOrUpdate(ingress, true, mutateFn, pipeline.RetryOnErr)
+	result, err := ctx.Resources().CreateOrUpdate(ingress, true, mutateFn, pipeline.RetryOnErr)
+	if err == nil {
+		switch result {
+		case pipeline.OperationResultCreated:
+			ctx.Log().Info("Created external endpoint", "ingress", ingress.Name)
+		case pipeline.OperationResultUpdated:
+			ctx.Log().V(1).Info("Updated external endpoint", "ingress", ingress.Name)
+		}
+	}
 }
 
 func XSiteService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if !i.HasSites() || !i.IsGossipRouterEnabled() {
 		_ = ctx.Resources().Delete(i.GetSiteServiceName(), &corev1.Service{}, pipeline.RetryOnErr, pipeline.IgnoreNotFound)
+		ctx.Log().V(1).Info("Ensured no xsite endpoint", "service", i.GetSiteServiceName())
 		ok, err := ctx.Kubernetes().IsGroupVersionKindSupported(pipeline.RouteGVK)
 		if err != nil {
-			ctx.Log().Error(err, fmt.Sprintf("failed to check if GVK '%s' is supported", pipeline.RouteGVK))
+			ctx.Log().Error(err, "failed to check if GVK is supported", "gvk", pipeline.RouteGVK)
 			return
 		}
 		if ok {
 			_ = ctx.Resources().Delete(i.GetSiteRouteName(), &routev1.Route{}, pipeline.RetryOnErr, pipeline.IgnoreNotFound)
+			ctx.Log().V(1).Info("Ensured no xsite endpoint", "route", i.GetSiteRouteName())
 		}
 		return
 	}
@@ -330,8 +365,15 @@ func XSiteService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		return nil
 	}
 
-	if _, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr); err != nil {
+	result, err := ctx.Resources().CreateOrUpdate(svc, true, mutateFn, pipeline.RetryOnErr)
+	if err != nil {
 		return
+	}
+	switch result {
+	case pipeline.OperationResultCreated:
+		ctx.Log().Info("Created xsite endpoint", "service", svc.Name)
+	case pipeline.OperationResultUpdated:
+		ctx.Log().V(1).Info("Updated xsite endpoint", "service", svc.Name)
 	}
 
 	if exposeType == ispnv1.CrossSiteExposeTypeRoute {
@@ -353,7 +395,15 @@ func XSiteService(i *ispnv1.Infinispan, ctx pipeline.Context) {
 			}
 			return nil
 		}
-		_, _ = ctx.Resources().CreateOrUpdate(route, true, mutateFn, pipeline.RetryOnErr)
+		routeResult, routeErr := ctx.Resources().CreateOrUpdate(route, true, mutateFn, pipeline.RetryOnErr)
+		if routeErr == nil {
+			switch routeResult {
+			case pipeline.OperationResultCreated:
+				ctx.Log().Info("Created xsite endpoint", "route", route.Name)
+			case pipeline.OperationResultUpdated:
+				ctx.Log().V(1).Info("Updated xsite endpoint", "route", route.Name)
+			}
+		}
 	}
 }
 

--- a/pkg/reconcile/pipeline/infinispan/handler/provision/statefulsets.go
+++ b/pkg/reconcile/pipeline/infinispan/handler/provision/statefulsets.go
@@ -67,6 +67,7 @@ func ClusterStatefulSet(i *ispnv1.Infinispan, ctx pipeline.Context) {
 	if err := ctx.Resources().Create(statefulSet, true, pipeline.RetryOnErr); err != nil {
 		return
 	}
+	ctx.Log().Info("Created StatefulSet", "statefulSet", statefulSet.Name)
 
 	selector, err := metav1.LabelSelectorAsSelector(statefulSet.Spec.Selector)
 
@@ -79,6 +80,7 @@ func ClusterStatefulSet(i *ispnv1.Infinispan, ctx pipeline.Context) {
 		i.Status.StatefulSetName = statefulSet.Name
 		i.Status.Selector = selector.String()
 	})
+	ctx.Log().V(1).Info("Set initial replica status", "replicas", i.Spec.Replicas)
 }
 
 func ClusterStatefulSetSpec(statefulSetName string, i *ispnv1.Infinispan, ctx pipeline.Context) (*appsv1.StatefulSet, error) {

--- a/test/e2e/cache/cache_test.go
+++ b/test/e2e/cache/cache_test.go
@@ -603,6 +603,6 @@ func cacheCR(cacheName string, i *v1.Infinispan) *v2alpha1.Cache {
 			Name:        cacheName,
 		},
 	}
-	cache.Default()
+	cache.ApplyDefaults()
 	return cache
 }

--- a/test/e2e/infinispan/spec_update_test.go
+++ b/test/e2e/infinispan/spec_update_test.go
@@ -224,8 +224,8 @@ func verifyStatefulSetUpdate(ispn ispnv1.Infinispan, modifier func(*ispnv1.Infin
 
 	tutils.ExpectNoError(testKube.UpdateInfinispan(&ispn, func() {
 		modifier(&ispn)
-		// Explicitly call Default to replicate the defaulting webhook
-		ispn.Default()
+		// Explicitly call ApplyDefaults to replicate the defaulting webhook
+		ispn.ApplyDefaults()
 	}))
 
 	// Wait for a new generation to appear

--- a/test/e2e/utils/common.go
+++ b/test/e2e/utils/common.go
@@ -274,7 +274,7 @@ func DefaultSpec(t *testing.T, testKube *TestKubernetes, initializer func(*ispnv
 
 	// Apply the defaults last
 	if RunLocalOperator == "TRUE" {
-		infinispan.Default()
+		infinispan.ApplyDefaults()
 	}
 
 	return infinispan


### PR DESCRIPTION
Closes #690 

Summary

  - Refactor logging across all controllers and pipeline handlers to use log.FromContext(ctx) instead of struct-level loggers, ensuring structured context (namespace, name, controller, reconcileID) is
  automatically included
  - Replace fmt.Sprintf in log messages with structured key-value pairs using lowercase camelCase field keys
  - Apply consistent log levels: V(1) for diagnostic/lifecycle messages, V(2) for deep debugging, Info for state-changing operations only
  - Remove decorative log delimiters ("+++++ Reconciling", "----- End Reconciling")
  - Eliminate double-logging by returning wrapped errors instead of logging then returning
  - Rename struct loggers from log/Log to setupLog to clarify they are only for SetupWithManager use
  - Normalize WithName to lowercase camelCase (e.g. "cache", "gossipRouter")
  - Add logging conventions documentation to CONTRIBUTING.md

  Test plan

  - [ ] Verify operator builds cleanly (make build)
  - [ ] Run unit tests (make test)
  - [ ] Run e2e tests to confirm reconciliation behavior is unchanged
  - [ ] Deploy operator and verify logs contain structured fields with correct context (namespace, name, reconcileID)
  - [ ] Confirm no duplicate log lines appear for error paths
  - [ ] Test interactions with logging env vars